### PR TITLE
dynamically load the ops before execution

### DIFF
--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -44,9 +44,10 @@ def _ensure_initialized() -> None:
 
 
 def _wrap_op(name: str):
+    func = getattr(torch.ops.deep_gemm, name)
     def _fn(*args, **kwargs):
         _ensure_initialized()
-        return getattr(torch.ops.deep_gemm, name)(*args, **kwargs)
+        return func(*args, **kwargs)
     return _fn
 
 set_num_sms = _wrap_op('set_num_sms')


### PR DESCRIPTION
## Problem

When dynamically load the ops, the checker report missing operations warning.

```
Warning: Missing operations: ['set_num_sms', 'get_num_sms', 'set_tc_util', 'get_tc_util', 'fp8_gemm_nt', 'fp8_gemm_nn', 'fp8_gemm_tn', 'fp8_gemm_tt', 'm_grouped_fp8_gemm_nt_contiguous', 'm_grouped_fp8_gemm_nn_contiguous', 'm_grouped_fp8_gemm_nt_masked', 'k_grouped_fp8_gemm_tn_contiguous', 'transform_sf_into_required_layout']
```

## Solution

try to preload the ops before actually call the func.