### PR TITLE
Fix UE8M0 packing: mask mantissa bits when extracting fp32 exponents

### DIFF
--- a/deep_gemm/include/deep_gemm/impls/smxx_layout.cuh
+++ b/deep_gemm/include/deep_gemm/impls/smxx_layout.cuh
@@ -7,6 +7,13 @@
 
 namespace deep_gemm {
 
+/// Pack exponent bytes from 4 fp32 bit-patterns into one uint32 (UE8M0 format).
+__device__ __forceinline__ uint32_t pack_4_fp32_exponents(
+    uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3) {
+    return ((v0 >> 23u) & 0xFFu) | (((v1 >> 23u) & 0xFFu) << 8u)
+         | (((v2 >> 23u) & 0xFFu) << 16u) | (((v3 >> 23u) & 0xFFu) << 24u);
+}
+
 template <uint32_t kNumThreads, uint32_t BLOCK_MN, uint32_t SF_K,
           uint32_t PADDED_SF_K = SF_K + (1 - (SF_K % 2))>
 CUTLASS_GLOBAL void transpose_fp32(const float* sf, float* out, const uint32_t mn) {
@@ -98,11 +105,7 @@ CUTLASS_GLOBAL void transpose_and_pack_fp32_into_ue8m0(float* sf, uint32_t* out,
         }
 
         // Pack and store
-        uint32_t packed = 0;
-        packed |= (values[0] >> 23u);
-        packed |= (values[1] >> 15u);
-        packed |= (values[2] >>  7u);
-        packed |= (values[3] <<  1u);
+        uint32_t packed = pack_4_fp32_exponents(values[0], values[1], values[2], values[3]);
         if (const auto global_mn_idx = blockIdx.x * BLOCK_MN + mn_idx; global_mn_idx < mn)
             out[sf_k_pack_idx * tma_aligned_mn + global_mn_idx] = packed;
     }
@@ -178,10 +181,10 @@ CUTLASS_GLOBAL void pack_fp32_into_ue8m0(float* sf, uint32_t* out, uint32_t* ks,
 
         // Pack and store
         uint4 packed;
-        packed.x = (values[0].x >> 23u) | (values[1].x >> 15u) | (values[2].x >> 7u) | (values[3].x << 1u);
-        packed.y = (values[0].y >> 23u) | (values[1].y >> 15u) | (values[2].y >> 7u) | (values[3].y << 1u);
-        packed.z = (values[0].z >> 23u) | (values[1].z >> 15u) | (values[2].z >> 7u) | (values[3].z << 1u);
-        packed.w = (values[0].w >> 23u) | (values[1].w >> 15u) | (values[2].w >> 7u) | (values[3].w << 1u);
+        packed.x = pack_4_fp32_exponents(values[0].x, values[1].x, values[2].x, values[3].x);
+        packed.y = pack_4_fp32_exponents(values[0].y, values[1].y, values[2].y, values[3].y);
+        packed.z = pack_4_fp32_exponents(values[0].z, values[1].z, values[2].z, values[3].z);
+        packed.w = pack_4_fp32_exponents(values[0].w, values[1].w, values[2].w, values[3].w);
         reinterpret_cast<uint4*>(out + packed_sf_k_idx * mn)[mn_idx] = packed;
     }
 }


### PR DESCRIPTION
Same fix as https://github.com/deepseek-ai/DeepGEMM/pull/337.

`transpose_and_pack_fp32_into_ue8m0` and `pack_fp32_into_ue8m0` pack 4 fp32
exponent bytes into one uint32 using shift-and-OR:

    packed |= (values[0] >> 23u);   // byte 0: OK
    packed |= (values[1] >> 15u);   // byte 1: mantissa leaks into byte 0
    packed |= (values[2] >>  7u);   // byte 2: mantissa leaks into bytes 0-1
    packed |= (values[3] <<  1u);   // byte 3: mantissa leaks into bytes 0-2

When fp32 scale factors have non-zero mantissa (not exact powers of two),
mantissa bits leak into adjacent exponent fields. For example, packing four
copies of 0.006975 (exp=0x77) produces 0x77ffffff instead of 0x77777777.

This causes NaN in `fp8_einsum` when callers pass plain float32 scales
(e.g. sglang's activation quantization for DeepSeek-V4 on Blackwell).

The torch fallback `get_mn_major_tma_aligned_packed_ue8m0_tensor_torch` is
correct (uses `>> 23` then `.to(kUInt8)` which naturally truncates), but the
CUDA kernel path doesn't truncate.

Fix: extract each exponent with `(val >> 23) & 0xFF` and shift to the correct
byte position, in a shared `pack_4_fp32_exponents` helper.

## Reproduction

```python
import torch
from deep_gemm.utils.layout import get_mn_major_tma_aligned_packed_ue8m0_tensor

# Packing bug: non-power-of-2 fp32 value gets mantissa leaked into packed result
sf = torch.full((4, 8), 0.006975, device="cuda", dtype=torch.float32)
packed = get_mn_major_tma_aligned_packed_ue8m0_tensor(sf)
assert packed[0, 0].item() == 0x77777777, f"got {hex(packed[0, 0].item())}"  # fails: 0x77ffffff

# Power-of-2 value works because mantissa is zero
sf2 = torch.full((4, 8), 0.0078125, device="cuda", dtype=torch.float32)
packed2 = get_mn_major_tma_aligned_packed_ue8m0_tensor(sf2)
assert packed2[0, 0].item() == 0x78787878  # passes
```