### PR TITLE
Sm90 mega moe on sgl dev

### DIFF
--- a/csrc/apis/sm90_mega.hpp
+++ b/csrc/apis/sm90_mega.hpp
@@ -1,0 +1,204 @@
+#pragma once
+
+#include <functional>
+
+#include "mega.hpp"
+#include "../jit_kernels/impls/sm90_fp8_mega_moe.hpp"
+
+namespace deep_gemm::mega {
+
+static int get_token_alignment_for_sm90_mega_moe() {
+    return layout::kLCMCandidateBlockM;
+}
+
+static std::tuple<int64_t, std::function<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>(const torch::Tensor&)>>
+get_symm_buffer_size_for_sm90_mega_moe(
+    const int& num_ranks, const int& num_experts,
+    const int& num_max_tokens_per_rank, const int& num_topk,
+    const int& hidden, const int& intermediate_hidden,
+    const bool& use_fp8_dispatch, const std::string& activation) {
+    DG_HOST_ASSERT(num_experts % num_ranks == 0);
+    DG_HOST_ASSERT(use_fp8_dispatch);
+    DG_HOST_ASSERT(activation == "swiglu");
+
+    const auto workspace = layout::Workspace(nullptr, num_ranks, num_experts, num_max_tokens_per_rank, num_topk);
+
+    const auto fp8_token_layout = layout::Data(hidden);
+    const auto bf16_token_layout = layout::Data(hidden * 2);
+    const auto fp8_intermediate_token_layout = layout::Data(intermediate_hidden);
+    const auto fp8_sf_layout = layout::Data(hidden / 32);
+    const auto fp8_intermediate_sf_layout = layout::Data(intermediate_hidden / 16);
+    const auto input_topk_idx_layout = layout::Data(num_topk * sizeof(int64_t), false);
+    const auto input_topk_weights_layout = layout::Data(num_topk * sizeof(float), false);
+    const auto l1_topk_weights_layout = layout::Data(sizeof(float), false);
+
+    const auto input_token_buffer = layout::Buffer(
+        fp8_token_layout, 1, num_max_tokens_per_rank,
+        workspace.get_end_ptr());
+    const auto input_sf_buffer = layout::Buffer(
+        fp8_sf_layout, 1, num_max_tokens_per_rank,
+        input_token_buffer.get_end_ptr());
+    const auto input_topk_idx_buffer = layout::Buffer(
+        input_topk_idx_layout, 1, num_max_tokens_per_rank,
+        input_sf_buffer.get_end_ptr());
+    const auto input_topk_weights_buffer = layout::Buffer(
+        input_topk_weights_layout, 1, num_max_tokens_per_rank,
+        input_topk_idx_buffer.get_end_ptr());
+
+    const auto num_max_pool_tokens = static_cast<int>(workspace.num_max_pool_tokens);
+    int num_max_padded_sf_pool_tokens = 0;
+    for (int block_m: layout::kCandidateBlockM) {
+        num_max_padded_sf_pool_tokens = std::max(
+            num_max_padded_sf_pool_tokens,
+            layout::get_num_padded_sf_pool_tokens(num_max_pool_tokens, block_m)
+        );
+    }
+
+    const auto l1_token_buffer = layout::Buffer(
+        fp8_token_layout, 1, num_max_pool_tokens,
+        input_topk_weights_buffer.get_end_ptr());
+    const auto l1_sf_buffer = layout::Buffer(
+        fp8_sf_layout, 1, num_max_padded_sf_pool_tokens,
+        l1_token_buffer.get_end_ptr());
+    const auto l1_topk_weights_buffer = layout::Buffer(
+        l1_topk_weights_layout, 1, num_max_pool_tokens,
+        l1_sf_buffer.get_end_ptr());
+
+    const auto l2_token_buffer = layout::Buffer(
+        fp8_intermediate_token_layout, 1, num_max_pool_tokens,
+        l1_topk_weights_buffer.get_end_ptr());
+    const auto l2_sf_buffer = layout::Buffer(
+        fp8_intermediate_sf_layout, 1, num_max_padded_sf_pool_tokens,
+        l2_token_buffer.get_end_ptr());
+
+    const auto combine_token_buffer = layout::Buffer(
+        bf16_token_layout, num_topk, num_max_tokens_per_rank,
+        l2_sf_buffer.get_end_ptr());
+
+    DG_HOST_ASSERT(hidden % 128 == 0 and intermediate_hidden % 128 == 0);
+
+    auto slice_input_buffers = [=](const torch::Tensor& buffer) {
+        auto x = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(input_token_buffer.base)),
+            {num_max_tokens_per_rank, hidden},
+            torch::TensorOptions().dtype(torch::kFloat8_e4m3fn).device(buffer.device()));
+        auto x_sf = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(input_sf_buffer.base)),
+            {num_max_tokens_per_rank, hidden / 128},
+            torch::TensorOptions().dtype(torch::kFloat32).device(buffer.device()));
+        auto topk_idx = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(input_topk_idx_buffer.base)),
+            {num_max_tokens_per_rank, num_topk},
+            torch::TensorOptions().dtype(torch::kInt64).device(buffer.device()));
+        auto topk_weights = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(input_topk_weights_buffer.base)),
+            {num_max_tokens_per_rank, num_topk},
+            torch::TensorOptions().dtype(torch::kFloat32).device(buffer.device()));
+        auto l1_acts = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(l1_token_buffer.base)),
+            {num_max_pool_tokens, hidden},
+            torch::TensorOptions().dtype(torch::kFloat8_e4m3fn).device(buffer.device()));
+        auto l1_acts_sf = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(l1_sf_buffer.base)),
+            {num_max_padded_sf_pool_tokens, hidden / 128},
+            {1, num_max_padded_sf_pool_tokens},
+            torch::TensorOptions().dtype(torch::kFloat32).device(buffer.device()));
+        auto l2_acts = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(l2_token_buffer.base)),
+            {num_max_pool_tokens, intermediate_hidden},
+            torch::TensorOptions().dtype(torch::kFloat8_e4m3fn).device(buffer.device()));
+        auto l2_acts_sf = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(l2_sf_buffer.base)),
+            {num_max_padded_sf_pool_tokens, intermediate_hidden / 64},
+            {1, num_max_padded_sf_pool_tokens},
+            torch::TensorOptions().dtype(torch::kFloat32).device(buffer.device()));
+        return std::make_tuple(x, x_sf, topk_idx, topk_weights, l1_acts, l1_acts_sf, l2_acts, l2_acts_sf);
+    };
+    return {reinterpret_cast<int64_t>(combine_token_buffer.get_end_ptr()), slice_input_buffers};
+}
+
+static void fp8_mega_moe(
+    const torch::Tensor& y,
+    const std::tuple<torch::Tensor, torch::Tensor>& l1_weights_tuple,
+    const std::tuple<torch::Tensor, torch::Tensor>& l2_weights_tuple,
+    const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
+    const torch::Tensor& sym_buffer,
+    const std::vector<int64_t>& sym_buffer_ptrs, const int& rank_idx,
+    const int& num_max_tokens_per_rank,
+    const int& num_experts, const int& num_topk,
+    const std::tuple<int, int, int>& recipe,
+    const std::string& activation,
+    const std::optional<float>& activation_clamp_opt,
+    const bool& fast_math
+) {
+    const auto [l1_weights, l1_weights_sf] = l1_weights_tuple;
+    const auto [l2_weights, l2_weights_sf] = l2_weights_tuple;
+
+    const auto arch_major = device_runtime->get_arch_major();
+    DG_HOST_ASSERT(arch_major == 9);
+
+    const auto num_tokens = static_cast<int>(y.size(0));
+    const auto [rm, rn, rk] = recipe;
+    DG_HOST_ASSERT(rm == 128 and rn == 128 and rk == 128);
+    DG_HOST_ASSERT(activation == "swiglu");
+
+    const auto activation_clamp =
+        activation_clamp_opt.value_or(std::numeric_limits<float>::infinity());
+    DG_HOST_ASSERT(activation_clamp >= 0);
+
+    DG_HOST_ASSERT(get_major_type_ab(l1_weights) == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(get_major_type_ab(l2_weights) == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(l1_weights.scalar_type() == torch::kFloat8_e4m3fn);
+    DG_HOST_ASSERT(l2_weights.scalar_type() == torch::kFloat8_e4m3fn);
+    const auto [num_experts_per_rank, intermediate_hidden_2, hidden] = get_shape<3>(l1_weights);
+    const auto [num_experts_per_rank_, hidden_, intermediate_hidden] = get_shape<3>(l2_weights);
+    DG_HOST_ASSERT(num_tokens <= num_max_tokens_per_rank);
+    DG_HOST_ASSERT(num_experts_per_rank == num_experts_per_rank_);
+    DG_HOST_ASSERT(hidden == hidden_);
+    DG_HOST_ASSERT(intermediate_hidden_2 == 2 * intermediate_hidden);
+    DG_HOST_ASSERT(l1_weights.is_contiguous() and l2_weights.is_contiguous());
+    DG_HOST_ASSERT(hidden % 128 == 0 and intermediate_hidden % 128 == 0);
+    DG_HOST_ASSERT(intermediate_hidden / 64 <= 64);
+
+    constexpr int kGranMN = 128, kGranK = 128;
+    check_sf_layout(l1_weights_sf, intermediate_hidden * 2, hidden, kGranMN, kGranK,
+                    num_experts_per_rank, false, true, torch::kFloat);
+    check_sf_layout(l2_weights_sf, hidden, intermediate_hidden, kGranMN, kGranK,
+                    num_experts_per_rank, false, true, torch::kFloat);
+
+    if (cumulative_local_expert_recv_stats.has_value()) {
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->scalar_type() == torch::kInt);
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->numel() == num_experts_per_rank);
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->is_contiguous());
+    }
+
+    const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
+    const auto num_experts_ = num_experts_per_rank * num_ranks;
+    const auto [num_required_bytes, slice] = get_symm_buffer_size_for_sm90_mega_moe(
+        num_ranks, num_experts,
+        num_max_tokens_per_rank, num_topk,
+        hidden, intermediate_hidden,
+        true, activation);
+    DG_HOST_ASSERT(sym_buffer.nbytes() >= static_cast<size_t>(num_required_bytes));
+    DG_HOST_ASSERT(num_experts == num_experts_);
+
+    const auto [x, x_sf, topk_idx, topk_weights, l1_acts, l1_acts_sf, l2_acts, l2_acts_sf] = slice(sym_buffer);
+
+    sm90_fp8_mega_moe(y,
+                     l1_acts, l1_acts_sf,
+                     l2_acts, l2_acts_sf,
+                     l1_weights, l2_weights,
+                     l1_weights_sf, l2_weights_sf,
+                     cumulative_local_expert_recv_stats,
+                     sym_buffer_ptrs,
+                     rank_idx, num_max_tokens_per_rank,
+                     num_experts_per_rank,
+                     num_tokens, num_topk,
+                     hidden, intermediate_hidden,
+                     activation_clamp, fast_math);
+
+    if (get_env<int>("DG_COMM_KERNEL_DEBUG"))
+        sym_buffer.zero_();
+}
+
+} // namespace deep_gemm::mega

--- a/csrc/jit_kernels/heuristics/sm90_mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/sm90_mega_moe.hpp
@@ -1,0 +1,191 @@
+#pragma once
+
+#include "mega_moe.hpp"
+
+namespace deep_gemm {
+
+// ============================================================================
+// SM90 (Hopper) MegaMoE configuration
+// ----------------------------------------------------------------------------
+// SM90 differs from SM100 in:
+//   - No tensor memory (TMEM): WGMMA accumulators live in registers.
+//   - No FP4: weights are FP8 e4m3 with per-128 channel float scales.
+//   - No 2-CTA cluster MMA: TMA multicast cluster=2 may still be used.
+//   - Activation SF is float, not UE8M0 int: L1 input uses per-128 K and the
+//     fused L1 epilogue writes L2 activation SF at per-64 K granularity.
+// The kernel implementation is in `deep_gemm/impls/sm90_fp8_mega_moe.cuh`.
+// ============================================================================
+
+struct MegaMoESM90Config {
+    int block_m, block_n, block_k;
+    int cluster_size;
+    int num_max_pool_tokens;
+    int num_padded_sf_pool_tokens;
+    int swizzle_acts_mode, swizzle_weights_mode;
+    int num_experts_per_wave;
+    int num_stages, smem_size;
+    int num_dispatch_threads, num_non_epilogue_threads, num_epilogue_threads;
+
+    friend std::ostream& operator << (std::ostream& os, const MegaMoESM90Config& config) {
+        os << "MegaMoESM90Config("
+           << "block_m=" << config.block_m << ", block_n=" << config.block_n << ", block_k=" << config.block_k
+           << ", cluster_size=" << config.cluster_size
+           << ", num_max_pool_tokens=" << config.num_max_pool_tokens
+           << ", num_padded_sf_pool_tokens=" << config.num_padded_sf_pool_tokens
+           << ", swizzle_acts_mode=" << config.swizzle_acts_mode << ", swizzle_weights_mode=" << config.swizzle_weights_mode
+           << ", num_experts_per_wave=" << config.num_experts_per_wave
+           << ", num_stages=" << config.num_stages << ", smem_size=" << config.smem_size
+           << ", num_dispatch_threads=" << config.num_dispatch_threads
+           << ", num_non_epilogue_threads=" << config.num_non_epilogue_threads
+           << ", num_epilogue_threads=" << config.num_epilogue_threads << ")";
+        return os;
+    }
+};
+
+static std::tuple<int, int> get_block_config_for_mega_moe_sm90(
+    const int& num_ranks, const int& num_experts,
+    const int& num_max_tokens_per_rank, const int& num_topk,
+    const int& num_tokens) {
+    const float expected_tokens_per_expert =
+        static_cast<float>(num_tokens) * num_ranks * num_topk / num_experts;
+    const bool auto_split_mn = expected_tokens_per_expert >= 64.0f;
+    if (auto_split_mn)
+        return {128, 512};
+
+    const int block_m = 64;
+    const int num_epilogue_warpgroups = 2;
+
+    DG_HOST_ASSERT(std::any_of(
+        layout::kCandidateBlockM, layout::kCandidateBlockM + layout::kNumCandidateBlockMs,
+        [=](const auto& candidate) { return candidate == block_m; })
+    );
+    return {block_m, num_epilogue_warpgroups * 128};
+}
+
+static int get_num_experts_per_wave_for_mega_moe_sm90(
+    const int& num_experts_per_rank, const int& num_tokens, const int& num_topk,
+    const int& intermediate_hidden, const int& block_m, const int& block_n, const int& num_sms) {
+    const float expected_tokens_per_expert =
+        static_cast<float>(num_tokens) * num_topk / num_experts_per_rank;
+    if (expected_tokens_per_expert < 1.0f or expected_tokens_per_expert > 4.0f)
+        return num_experts_per_rank;
+
+    if (block_m == 64 and intermediate_hidden >= 3072) {
+        const int num_n_blocks_per_expert = (2 * intermediate_hidden) / block_n;
+        const int single_wave_blocks =
+            num_experts_per_rank * num_n_blocks_per_expert;
+        if (single_wave_blocks >= 4 * num_sms)
+            return num_experts_per_rank;
+    }
+    return get_num_experts_per_wave_for_mega_moe(
+        num_experts_per_rank, num_tokens, num_topk,
+        intermediate_hidden, block_m, block_n, num_sms);
+}
+
+static std::pair<int, int> get_pipeline_config_for_mega_moe_sm90(
+    const int& smem_capacity,
+    const int& num_experts, const int& hidden,
+    const int& block_m, const int& block_n, const int& block_k,
+    const int& num_dispatch_warps, const int& num_epilogue_warps) {
+    constexpr int kSmemAlignment = 1024;
+
+    const int smem_expert_count_size = align(
+        num_experts * static_cast<int>(sizeof(uint32_t)), kSmemAlignment);
+    const int smem_send_buffers_size = align(
+        static_cast<int>(layout::Buffer(layout::Data(hidden), num_dispatch_warps, 1).get_num_bytes()),
+        kSmemAlignment);
+    const int smem_dispatch_size = smem_expert_count_size + smem_send_buffers_size;
+
+    const int smem_cd_l1 = block_m * (block_n / 2);
+    const int smem_cd_l2 = block_m * block_n * static_cast<int>(sizeof(nv_bfloat16));
+    const int smem_cd = align(std::max(smem_cd_l1, smem_cd_l2), kSmemAlignment);
+
+    const int smem_sfa_per_stage = align(2 * block_m * static_cast<int>(sizeof(float)), 128);
+    const int smem_sfb_per_stage = 0;
+    const int smem_per_stage = block_m * block_k + block_n * block_k +
+                               smem_sfa_per_stage + smem_sfb_per_stage;
+
+    const int smem_barriers_fixed = (num_dispatch_warps + 2 * num_epilogue_warps) * 8;
+    const int smem_barriers_per_stage = 2 * 8;
+    const int smem_fixed = smem_dispatch_size + smem_cd + smem_barriers_fixed;
+
+    const int num_stages = (smem_capacity - smem_fixed) /
+                           (smem_per_stage + smem_barriers_per_stage);
+    DG_HOST_ASSERT(num_stages >= 2);
+    const int smem_size = smem_fixed + num_stages * (smem_per_stage + smem_barriers_per_stage);
+    DG_HOST_ASSERT(smem_size <= smem_capacity);
+    return {num_stages, smem_size};
+}
+
+static MegaMoESM90Config get_mega_moe_config_sm90(
+    const int& num_ranks, const int& num_experts, const int& num_experts_per_rank,
+    const int& num_max_tokens_per_rank, const int& num_tokens, const int& num_topk,
+    const int& hidden, const int& intermediate_hidden,
+    const int& num_padded_sf_pool_tokens) {
+    const auto [block_m, num_epilogue_threads] = get_block_config_for_mega_moe_sm90(
+        num_ranks, num_experts, num_max_tokens_per_rank, num_topk, num_tokens);
+    const float expected_tokens_per_expert =
+        static_cast<float>(num_tokens) * num_ranks * num_topk / num_experts;
+    const bool auto_split_mn = expected_tokens_per_expert >= 64.0f;
+    const bool decode_split_n_path =
+        block_m == 64 and num_epilogue_threads == 256;
+    const bool decode_use_block_n_256 =
+        decode_split_n_path and intermediate_hidden >= 3072 and
+        expected_tokens_per_expert >= 0.25f and
+        (2 * intermediate_hidden) % 256 == 0;
+    const int block_n = auto_split_mn ? 256
+                                      : (decode_use_block_n_256 ? 256 : 128);
+    const int block_k = 128;
+    const int cluster_size = 1;
+    const int num_max_pool_tokens = layout::get_num_max_pool_tokens(
+        num_ranks, num_max_tokens_per_rank, num_topk, num_experts_per_rank);
+    const int swizzle_acts_mode = 128;
+    const int swizzle_weights_mode = 128;
+
+    const int num_sms = device_runtime->get_num_sms();
+    const int num_experts_per_wave = get_num_experts_per_wave_for_mega_moe_sm90(
+        num_experts_per_rank, num_tokens, num_topk,
+        intermediate_hidden, block_m, block_n, num_sms);
+
+    const bool reduce_decode_threads = num_epilogue_threads == 128;
+    const bool decode_split_n =
+        block_m == 64 and num_epilogue_threads == 256;
+    const bool shrink_non_epilogue = reduce_decode_threads or decode_split_n;
+    const int num_dispatch_threads =
+        (num_epilogue_threads == 512 or shrink_non_epilogue) ? 64 : 128;
+    const bool split_sfa_loader_warp = false;
+    const int num_non_epilogue_threads =
+        split_sfa_loader_warp ? 128 :
+            ((num_epilogue_threads == 512 or shrink_non_epilogue) ? 64 : 128);
+    DG_HOST_ASSERT((num_dispatch_threads + num_non_epilogue_threads) % 128 == 0);
+
+    const auto [num_stages, smem_size] = get_pipeline_config_for_mega_moe_sm90(
+        SM90ArchSpec::smem_capacity,
+        num_experts, hidden,
+        block_m, block_n, block_k,
+        num_dispatch_threads / 32, num_epilogue_threads / 32);
+
+    const auto config = MegaMoESM90Config {
+        block_m, block_n, block_k,
+        cluster_size,
+        num_max_pool_tokens, num_padded_sf_pool_tokens,
+        swizzle_acts_mode, swizzle_weights_mode,
+        num_experts_per_wave,
+        num_stages, smem_size,
+        num_dispatch_threads, num_non_epilogue_threads, num_epilogue_threads
+    };
+
+    if (get_env<int>("DG_JIT_DEBUG") or get_env<int>("DG_PRINT_CONFIGS")) {
+        const auto key = fmt::format(
+            "MegaMoESM90Config(num_ranks={}, num_experts={}, hidden={}, intermediate_hidden={}, num_max_tokens_per_rank={}, num_tokens={}, num_topk={})",
+            num_ranks, num_experts, hidden, intermediate_hidden, num_max_tokens_per_rank, num_tokens, num_topk);
+        static std::unordered_set<std::string> printed;
+        if (printed.count(key) == 0) {
+            std::cout << key << ": " << config << std::endl;
+            printed.insert(key);
+        }
+    }
+    return config;
+}
+
+} // namespace deep_gemm

--- a/csrc/jit_kernels/impls/sm90_fp8_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm90_fp8_mega_moe.hpp
@@ -1,0 +1,305 @@
+#pragma once
+
+#include <torch/python.h>
+#include "../../jit/compiler.hpp"
+#include "../../jit/kernel_runtime.hpp"
+#include "../../utils/exception.hpp"
+#include "../../utils/format.hpp"
+#include "runtime_utils.hpp"
+
+#include <deep_gemm/layout/mega_moe.cuh>
+#include <deep_gemm/layout/sym_buffer.cuh>
+
+#include "../heuristics/sm90_mega_moe.hpp"
+
+namespace deep_gemm {
+
+// ============================================================================
+// SM90 (Hopper) FP8 MegaMoE host runtime
+// ----------------------------------------------------------------------------
+// This is the SM90 counterpart of `SM100FP8FP4MegaMoERuntime`. The kernel
+// itself lives in `deep_gemm/impls/sm90_fp8_mega_moe.cuh`.
+//
+// Differences from SM100 path:
+//   * Activations and weights are both FP8 (e4m3); no FP4.
+//   * Activation/weight scale factors (SF) are float, not UE8M0 int + per-32
+//     UTCCP layout. L1 activation SF and weight SF are per-128 K; the fused L1
+//     epilogue writes L2 activation SF at per-64 K granularity.
+//   * No tensor memory: WGMMA accumulators are register-resident.
+//   * Cluster size is at most 2 (TMA multicast on A); no 2-CTA UMMA.
+// ============================================================================
+
+class SM90FP8MegaMoERuntime final : public LaunchRuntime<SM90FP8MegaMoERuntime> {
+public:
+    struct Args {
+        // Templated arguments
+        int num_max_tokens_per_rank;
+        int hidden, intermediate_hidden;
+        int num_experts, num_topk;
+        int num_ranks;
+        float activation_clamp;
+        bool fast_math;
+        int epilogue_registers;
+        bool reuse_accum_as_final;
+        bool l2_arrival_counter;
+        bool l2_epilogue_requires_full_sync;
+        bool split_phase_hot_path;
+        MegaMoESM90Config config;
+
+        // Runtime arguments
+        void* y;
+        int* cumulative_local_expert_recv_stats;
+        int num_tokens;
+        layout::SymBuffer<> sym_buffer_ptrs;
+
+        // Tensormaps for activations and weights. Weight scale factors use
+        // block (128, 128) quantization and are loaded by the math warpgroup
+        // directly from global memory (no TMA descriptor required).
+        CUtensorMap tensor_map_l1_acts;
+        CUtensorMap tensor_map_l1_acts_sf;
+        CUtensorMap tensor_map_l1_weights;
+        const float* l1_weights_sf;
+        CUtensorMap tensor_map_l1_output;
+        CUtensorMap tensor_map_l2_acts;
+        CUtensorMap tensor_map_l2_acts_sf;
+        CUtensorMap tensor_map_l2_weights;
+        const float* l2_weights_sf;
+
+        // Launch configs
+        LaunchArgs launch_args;
+    };
+
+    static std::string generate_impl(const Args& args) {
+        return fmt::format(R"(
+#include <deep_gemm/impls/sm90_fp8_mega_moe.cuh>
+
+using namespace deep_gemm;
+
+static void __instantiate_kernel() {{
+    auto ptr = reinterpret_cast<void*>(&sm90_fp8_mega_moe_impl<
+        {},
+        {}, {},
+        {}, {},
+        {},
+        {}, {}, {},
+        {},
+        {},
+        {},
+        {}, {}, {},
+        {}, {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {}
+    >);
+}};
+)",
+    args.num_max_tokens_per_rank,
+    args.hidden, args.intermediate_hidden,
+    args.num_experts, args.num_topk,
+    args.config.num_experts_per_wave,
+    args.config.block_m, args.config.block_n, args.config.block_k,
+    args.config.num_max_pool_tokens,
+    args.config.num_padded_sf_pool_tokens,
+    args.config.num_stages,
+    args.config.num_dispatch_threads, args.config.num_non_epilogue_threads, args.config.num_epilogue_threads,
+    args.launch_args.grid_dim.first, args.num_ranks,
+    to_string(args.activation_clamp),
+    args.fast_math ? "true" : "false",
+    args.epilogue_registers,
+    args.reuse_accum_as_final ? "true" : "false",
+    args.l2_arrival_counter ? "true" : "false",
+    args.l2_epilogue_requires_full_sync ? "true" : "false",
+    args.split_phase_hot_path ? "true" : "false");
+    }
+
+    static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
+        DG_CUDA_UNIFIED_CHECK(launch_kernel(kernel, config,
+            args.y,
+            args.cumulative_local_expert_recv_stats,
+            args.num_tokens,
+            args.sym_buffer_ptrs,
+            args.tensor_map_l1_acts,
+            args.tensor_map_l1_acts_sf,
+            args.tensor_map_l1_weights,
+            args.l1_weights_sf,
+            args.tensor_map_l1_output,
+            args.tensor_map_l2_acts,
+            args.tensor_map_l2_acts_sf,
+            args.tensor_map_l2_weights,
+            args.l2_weights_sf
+        ));
+    }
+};
+
+static void sm90_fp8_mega_moe(
+    const torch::Tensor& y,
+    const torch::Tensor& l1_acts, const torch::Tensor& l1_acts_sf,
+    const torch::Tensor& l2_acts, const torch::Tensor& l2_acts_sf,
+    const torch::Tensor& l1_weights, const torch::Tensor& l2_weights,
+    const torch::Tensor& l1_weights_sf, const torch::Tensor& l2_weights_sf,
+    const std::optional<torch::Tensor> cumulative_local_expert_recv_stats,
+    const std::vector<int64_t>& sym_buffer_ptrs,
+    const int& rank_idx, const int& num_max_tokens_per_rank,
+    const int& num_experts_per_rank,
+    const int& num_tokens, const int& num_topk,
+    const int& hidden, const int& intermediate_hidden,
+    const float& activation_clamp,
+    const bool& fast_math
+) {
+    const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
+    const auto num_experts = num_experts_per_rank * num_ranks;
+    const auto num_padded_sf_pool_tokens = static_cast<int>(l1_acts_sf.size(0));
+
+    // Heuristics
+    const auto config = get_mega_moe_config_sm90(
+        num_ranks, num_experts, num_experts_per_rank,
+        num_max_tokens_per_rank, num_tokens, num_topk,
+        hidden, intermediate_hidden, num_padded_sf_pool_tokens);
+    const int default_epilogue_registers =
+        config.num_epilogue_threads == 512 ? 112 : 0;
+    const int epilogue_registers = default_epilogue_registers;
+    if (epilogue_registers > 0) {
+        const int dispatch_registers =
+            config.num_epilogue_threads == 512 ? 32 : 48;
+        const int non_epilogue_registers =
+            config.num_epilogue_threads == 512 ? 24 : 40;
+        DG_HOST_ASSERT(dispatch_registers * config.num_dispatch_threads +
+                       non_epilogue_registers * config.num_non_epilogue_threads +
+                       epilogue_registers * config.num_epilogue_threads <= 64512);
+    }
+    const bool reuse_accum_as_final = config.block_m == 128;
+    const bool default_split_mn_barrier_opt =
+        config.block_m == 128 and config.block_n == 256 and
+        config.num_epilogue_threads == 512;
+    const bool split_phase_hot_path =
+        config.block_m == 128 and config.block_n == 256 and hidden >= 7168;
+    const bool decode_split_n_path =
+        config.block_m == 64 and config.num_epilogue_threads == 256;
+    const bool decode_split_n_bn256 =
+        decode_split_n_path and config.block_n == 256;
+    const bool decode_l2_counter =
+        decode_split_n_bn256 and num_tokens >= 4 and num_tokens <= 128;
+    const bool l2_arrival_counter =
+        default_split_mn_barrier_opt or decode_l2_counter;
+    const bool l2_epilogue_requires_full_sync =
+        not l2_arrival_counter;
+
+    // Tensormap construction
+    // Acts/weights: standard 2D TMA descriptors (FP8 K-major).
+    // Activation SF: per-128 channel float for L1, per-64 for L2 (MN-major, no swizzle).
+    // Weight SF: block (128, 128) raw float pointer (no TMA descriptor).
+    constexpr int kGranK = 128;
+    constexpr int kL2ActsSFGranK = 64;
+    const auto tensor_map_l1_acts = make_tma_2d_desc(l1_acts,
+                                                     hidden, config.num_max_pool_tokens,
+                                                     config.block_k, config.block_m,
+                                                     static_cast<int>(l1_acts.stride(-2)),
+                                                     config.swizzle_acts_mode);
+    const auto tensor_map_l1_acts_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l1_acts_sf,
+                                                        config.num_padded_sf_pool_tokens, hidden,
+                                                        config.block_m, kGranK,
+                                                        1, 0);
+    const int weight_tma_block_n = config.block_n > 256 ? 256 : config.block_n;
+    const auto tensor_map_l1_weights = make_tma_2d_desc(l1_weights,
+                                                        hidden, num_experts_per_rank * intermediate_hidden * 2,
+                                                        config.block_k, weight_tma_block_n,
+                                                        static_cast<int>(l1_weights.stride(-2)),
+                                                        config.swizzle_weights_mode);
+    // L1 output (post-SwiGLU FP8): N is halved. The correctness path stages
+    // this tile in plain row-major SMEM before the TMA store. Later L2 TMA
+    // loads may still swizzle from this row-major global buffer into their own
+    // SMEM tile.
+    // The usual TMA store is issued per warpgroup, each writing a `WG_BLOCK_M`
+    // row tile from its own SMEM offset. The m64n128 2-WG split-N decode path is
+    // different: both warpgroups stage one joint 64-column L1-output tile and a
+    // single warpgroup issues the combined store, so the descriptor must cover
+    // the full block_m x (block_n / 2) tile.
+    const int num_epilogue_warpgroups_h = config.num_epilogue_threads / 128;
+    const bool split_n_warpgroups =
+        config.block_m == 64 and num_epilogue_warpgroups_h > 1 and
+        config.block_n % num_epilogue_warpgroups_h == 0 and
+        (config.block_n / num_epilogue_warpgroups_h == 64 or
+         config.block_n / num_epilogue_warpgroups_h == 128);
+    const bool split_mn_warpgroups =
+        config.block_m == 128 and config.block_n == 256 and num_epilogue_warpgroups_h == 4;
+    const int wg_split_m = split_n_warpgroups ? 1 :
+        (split_mn_warpgroups ? 2 : num_epilogue_warpgroups_h);
+    const int wg_split_n = split_n_warpgroups ? num_epilogue_warpgroups_h :
+        (split_mn_warpgroups ? 2 : 1);
+    DG_HOST_ASSERT(wg_split_m * wg_split_n == num_epilogue_warpgroups_h);
+    const int wg_block_m = config.block_m / wg_split_m;
+    const int wg_block_n = config.block_n / wg_split_n;
+    const int wg_l1_out_block_n = wg_block_n / 2;
+    const bool split_n_shares_sf =
+        split_n_warpgroups and wg_l1_out_block_n < kL2ActsSFGranK;
+    const int l1_output_swizzle_mode = 0;
+    const int l1_output_box_n =
+        split_n_shares_sf ? config.block_n / 2 : wg_l1_out_block_n;
+    const int l1_output_box_m =
+        split_n_shares_sf ? config.block_m : wg_block_m;
+    const auto tensor_map_l1_output = make_tma_2d_desc(l2_acts,
+                                                       intermediate_hidden, config.num_max_pool_tokens,
+                                                       l1_output_box_n, l1_output_box_m,
+                                                       static_cast<int>(l2_acts.stride(-2)),
+                                                       l1_output_swizzle_mode);
+    const auto tensor_map_l2_acts = make_tma_2d_desc(l2_acts,
+                                                     intermediate_hidden, config.num_max_pool_tokens,
+                                                     config.block_k, config.block_m,
+                                                     static_cast<int>(l2_acts.stride(-2)),
+                                                     config.swizzle_acts_mode);
+    const auto tensor_map_l2_acts_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l2_acts_sf,
+                                                        config.num_padded_sf_pool_tokens, intermediate_hidden,
+                                                        config.block_m, kL2ActsSFGranK,
+                                                        1, 0);
+    const auto tensor_map_l2_weights = make_tma_2d_desc(l2_weights,
+                                                        intermediate_hidden, num_experts_per_rank * hidden,
+                                                        config.block_k, weight_tma_block_n,
+                                                        static_cast<int>(l2_weights.stride(-2)),
+                                                        config.swizzle_weights_mode);
+
+    // Stats can be optional
+    int* cumulative_local_expert_recv_stats_ptr = nullptr;
+    if (cumulative_local_expert_recv_stats.has_value())
+        cumulative_local_expert_recv_stats_ptr = cumulative_local_expert_recv_stats->data_ptr<int>();
+
+    // Launch
+    const auto num_sms = device_runtime->get_num_sms();
+    const SM90FP8MegaMoERuntime::Args args = {
+        .num_max_tokens_per_rank = num_max_tokens_per_rank,
+        .hidden = hidden, .intermediate_hidden = intermediate_hidden,
+        .num_experts = num_experts, .num_topk = num_topk,
+        .num_ranks = num_ranks,
+        .activation_clamp = activation_clamp,
+        .fast_math = fast_math,
+        .epilogue_registers = epilogue_registers,
+        .reuse_accum_as_final = reuse_accum_as_final,
+        .l2_arrival_counter = l2_arrival_counter,
+        .l2_epilogue_requires_full_sync = l2_epilogue_requires_full_sync,
+        .split_phase_hot_path = split_phase_hot_path,
+        .config = config,
+        .y = y.data_ptr(),
+        .cumulative_local_expert_recv_stats = cumulative_local_expert_recv_stats_ptr,
+        .num_tokens = num_tokens,
+        .sym_buffer_ptrs = layout::SymBuffer<>(sym_buffer_ptrs, rank_idx),
+        .tensor_map_l1_acts = tensor_map_l1_acts,
+        .tensor_map_l1_acts_sf = tensor_map_l1_acts_sf,
+        .tensor_map_l1_weights = tensor_map_l1_weights,
+        .l1_weights_sf = l1_weights_sf.data_ptr<float>(),
+        .tensor_map_l1_output = tensor_map_l1_output,
+        .tensor_map_l2_acts = tensor_map_l2_acts,
+        .tensor_map_l2_acts_sf = tensor_map_l2_acts_sf,
+        .tensor_map_l2_weights = tensor_map_l2_weights,
+        .l2_weights_sf = l2_weights_sf.data_ptr<float>(),
+        .launch_args = LaunchArgs(num_sms, config.num_dispatch_threads + config.num_non_epilogue_threads + config.num_epilogue_threads,
+                                  config.smem_size, config.cluster_size)
+    };
+    const auto code = SM90FP8MegaMoERuntime::generate(args);
+    const auto runtime = compiler->build("sm90_fp8_mega_moe", code);
+    SM90FP8MegaMoERuntime::launch(runtime, args);
+}
+
+} // namespace deep_gemm

--- a/csrc/tvm_ffi_api.cpp
+++ b/csrc/tvm_ffi_api.cpp
@@ -18,6 +18,7 @@
 #include "apis/gemm.hpp"
 #include "apis/layout.hpp"
 #include "apis/mega.hpp"
+#include "apis/sm90_mega.hpp"
 #include "utils/torch_compat.hpp"
 
 
@@ -584,6 +585,37 @@ dg_get_symm_buffer_size_for_mega_moe(int64_t num_ranks, int64_t num_experts, int
         num_bytes, slice_input_buffers);
 }
 
+Tuple<int64_t, TypedFunction<Tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor>(TensorView)>>
+dg_get_symm_buffer_size_for_sm90_mega_moe(int64_t num_ranks, int64_t num_experts, int64_t num_max_tokens_per_rank, int64_t num_topk, int64_t hidden,
+                                         int64_t intermediate_hidden, bool use_fp8_dispatch, std::string activation) {
+    auto [num_bytes, fn] = mega::get_symm_buffer_size_for_sm90_mega_moe(
+        static_cast<int>(num_ranks),
+        static_cast<int>(num_experts),
+        static_cast<int>(num_max_tokens_per_rank),
+        static_cast<int>(num_topk),
+        static_cast<int>(hidden),
+        static_cast<int>(intermediate_hidden),
+        use_fp8_dispatch,
+        activation
+    );
+
+    auto slice_input_buffers = [=](TensorView buffer) {
+        auto [x, x_sf, topk_idx, topk_weights, l1_acts, l1_acts_sf, l2_acts, l2_acts_sf] =  fn(convert_to_torch_tensor(buffer));
+        return Tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor>(
+            Tensor::FromDLPack(at::toDLPack(x.view(at::kChar))),
+            Tensor::FromDLPack(at::toDLPack(x_sf)),
+            Tensor::FromDLPack(at::toDLPack(topk_idx)),
+            Tensor::FromDLPack(at::toDLPack(topk_weights)),
+            Tensor::FromDLPack(at::toDLPack(l1_acts.view(at::kChar))),
+            Tensor::FromDLPack(at::toDLPack(l1_acts_sf)),
+            Tensor::FromDLPack(at::toDLPack(l2_acts.view(at::kChar))),
+            Tensor::FromDLPack(at::toDLPack(l2_acts_sf))
+        );
+    };
+    return Tuple<int64_t, TypedFunction<Tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor>(TensorView)>>(
+        num_bytes, slice_input_buffers);
+}
+
 void dg_fp8_fp4_mega_moe(TensorView y, TensorView l1_weights, TensorView l1_weights_sf, TensorView l2_weights, TensorView l2_weights_sf,
                         Optional<TensorView> cumulative_local_expert_recv_stats, TensorView sym_buffer, Array<int64_t> sym_buffer_ptrs,
                         int64_t rank_idx, int64_t num_max_tokens_per_rank, int64_t num_experts, int64_t num_topk,
@@ -600,6 +632,32 @@ void dg_fp8_fp4_mega_moe(TensorView y, TensorView l1_weights, TensorView l1_weig
     auto recipe_val = std::make_tuple(static_cast<int>(recipe_a), static_cast<int>(recipe_b), static_cast<int>(recipe_c));
 
     mega::fp8_fp4_mega_moe(
+        convert_to_torch_tensor(y),
+        std::make_pair(convert_to_torch_tensor(l1_weights), convert_to_torch_tensor(l1_weights_sf)),
+        std::make_pair(convert_to_torch_tensor(l2_weights), convert_to_torch_tensor(l2_weights_sf)),
+        c_val, convert_to_torch_tensor(sym_buffer), sym_buffer_ptrs_val, static_cast<int>(rank_idx),
+        static_cast<int>(num_max_tokens_per_rank), static_cast<int>(num_experts),
+        static_cast<int>(num_topk), recipe_val, activation, act_clamp_opt_val, fast_math
+    );
+}
+
+
+void dg_fp8_mega_moe(TensorView y, TensorView l1_weights, TensorView l1_weights_sf, TensorView l2_weights, TensorView l2_weights_sf,
+                    Optional<TensorView> cumulative_local_expert_recv_stats, TensorView sym_buffer, Array<int64_t> sym_buffer_ptrs,
+                    int64_t rank_idx, int64_t num_max_tokens_per_rank, int64_t num_experts, int64_t num_topk,
+                    Tuple<int64_t, int64_t, int64_t> recipe, std::string activation, Optional<double> activation_clamp_opt, bool fast_math) {
+    auto c_val = cumulative_local_expert_recv_stats.has_value()? std::optional<torch::Tensor>(convert_to_torch_tensor(cumulative_local_expert_recv_stats.value())) : std::nullopt;
+    auto act_clamp_opt_val = activation_clamp_opt.has_value()? std::optional<float>(static_cast<float>(activation_clamp_opt.value())) : std::nullopt;
+    std::vector<int64_t> sym_buffer_ptrs_val;
+    sym_buffer_ptrs_val.reserve(sym_buffer_ptrs.size());
+
+    for (Array<int64_t>::iterator it = sym_buffer_ptrs.begin(); it != sym_buffer_ptrs.end(); ++it) {
+        sym_buffer_ptrs_val.push_back(*it);
+    }
+    auto [recipe_a, recipe_b, recipe_c] = recipe;
+    auto recipe_val = std::make_tuple(static_cast<int>(recipe_a), static_cast<int>(recipe_b), static_cast<int>(recipe_c));
+
+    mega::fp8_mega_moe(
         convert_to_torch_tensor(y),
         std::make_pair(convert_to_torch_tensor(l1_weights), convert_to_torch_tensor(l1_weights_sf)),
         std::make_pair(convert_to_torch_tensor(l2_weights), convert_to_torch_tensor(l2_weights_sf)),
@@ -631,7 +689,9 @@ void dg_mega_moe_pre_dispatch(
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_token_alignment_for_mega_moe, dg_get_token_alignment_for_mega_moe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_symm_buffer_size_for_mega_moe, dg_get_symm_buffer_size_for_mega_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_symm_buffer_size_for_sm90_mega_moe, dg_get_symm_buffer_size_for_sm90_mega_moe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fp8_fp4_mega_moe, dg_fp8_fp4_mega_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fp8_mega_moe, dg_fp8_mega_moe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(mega_moe_pre_dispatch, dg_mega_moe_pre_dispatch);
 
 

--- a/deep_gemm/include/deep_gemm/comm/barrier.cuh
+++ b/deep_gemm/include/deep_gemm/comm/barrier.cuh
@@ -67,9 +67,14 @@ CUTLASS_DEVICE void nvlink_barrier(const layout::Workspace& workspace,
             const auto start_clock = clock64();
             while (ptx::ld_acq_sys(signal_ptr) != target) {
                 if (clock64() - start_clock >= kNumTimeoutCycles) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900) && (__CUDA_ARCH__ < 1000) && \
+        !(defined(DG_NVLINK_BARRIER_VERBOSE_TIMEOUT) && DG_NVLINK_BARRIER_VERBOSE_TIMEOUT)
+                    DG_TRAP_ONLY_DEVICE_ASSERT(false);
+#else
                     printf("DeepGEMM NVLink barrier timeout (180s): rank=%d, counter=%d, signal=%d, target=%d, phase=%d, sign=%d, tag=%d\n",
                            sym_buffer.rank_idx, *counter_ptr, ptx::ld_acq_sys(signal_ptr), target, signal_phase, signal_sign, kTag);
                     DG_DEVICE_ASSERT(false and "NVLink barrier timeout");
+#endif
                 }
             }
         }

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_mega_moe.cuh
@@ -65,6 +65,43 @@ __forceinline__ __device__ void sm90_fp8_mega_moe_get_e4m3_sf_and_sf_inv(
     sf.y = math::fast_pow2(exp_y), sf_inv.y = math::fast_pow2(-exp_y);
 }
 
+template <uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,
+          uint32_t L1_SHAPE_N, uint32_t L1_SHAPE_K,
+          uint32_t L2_SHAPE_N, uint32_t L2_SHAPE_K,
+          uint32_t kNumExpertsPerRank,
+          uint32_t kNumExpertsPerWave,
+          uint32_t kNumSMs, uint32_t kNumRanks,
+          uint32_t kNumExpertsPerLane,
+          uint32_t kNumL1BlockNs, uint32_t kNumL2BlockNs,
+          uint32_t kNumL1BlockKs, uint32_t kNumL2BlockKs,
+          typename L1Func, typename L2Func>
+CUTLASS_DEVICE void sm90_fp8_mega_moe_for_each_block_split(
+    sched::MegaMoEScheduler<BLOCK_M, BLOCK_N, BLOCK_K,
+                            L1_SHAPE_N, L1_SHAPE_K,
+                            L2_SHAPE_N, L2_SHAPE_K,
+                            kNumExpertsPerRank,
+                            kNumExpertsPerWave,
+                            kNumSMs, kNumRanks,
+                            kNumExpertsPerLane,
+                            kNumL1BlockNs, kNumL2BlockNs,
+                            kNumL1BlockKs, kNumL2BlockKs>& scheduler,
+    L1Func&& l1_func, L2Func&& l2_func) {
+    scheduler.fetch_expert_recv_count();
+    scheduler.set_expert_idx(0);
+
+    while (true) {
+        CUTE_TIE_DECL(scheduler.get_next_block(), block_phase, current_local_expert_idx, m_block_idx, n_block_idx);
+        if (block_phase == sched::BlockPhase::None)
+            break;
+
+        if (block_phase == sched::BlockPhase::Linear1) {
+            l1_func(current_local_expert_idx, kNumL1BlockKs, m_block_idx, n_block_idx);
+        } else {
+            l2_func(current_local_expert_idx, kNumL2BlockKs, m_block_idx, n_block_idx);
+        }
+    }
+}
+
 // ============================================================================
 // SM90 (Hopper) FP8 MegaMoE — full implementation
 // ----------------------------------------------------------------------------
@@ -762,20 +799,22 @@ sm90_fp8_mega_moe_impl(void* y,
         };
 
         if constexpr (kSplitPhaseHotPath) {
-            scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
-                                         const uint32_t& local_expert_idx,
-                                         const uint32_t& num_k_blocks,
-                                         const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
-                if (block_phase == sched::BlockPhase::Linear1) {
+            sm90_fp8_mega_moe_for_each_block_split(
+                scheduler,
+                [&](const uint32_t& local_expert_idx,
+                    const uint32_t& num_k_blocks,
+                    const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
                     process_a_sfa_block(
                         std::integral_constant<sched::BlockPhase, sched::BlockPhase::Linear1>{},
                         local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
-                } else {
+                },
+                [&](const uint32_t& local_expert_idx,
+                    const uint32_t& num_k_blocks,
+                    const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
                     process_a_sfa_block(
                         std::integral_constant<sched::BlockPhase, sched::BlockPhase::Linear2>{},
                         local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
-                }
-            });
+                });
         } else {
             scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
                                          const uint32_t& local_expert_idx,
@@ -1731,20 +1770,22 @@ sm90_fp8_mega_moe_impl(void* y,
         };
 
         if constexpr (kSplitPhaseHotPath) {
-            scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
-                                         const uint32_t& local_expert_idx,
-                                         const uint32_t& num_k_blocks,
-                                         const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
-                if (block_phase == sched::BlockPhase::Linear1) {
+            sm90_fp8_mega_moe_for_each_block_split(
+                scheduler,
+                [&](const uint32_t& local_expert_idx,
+                    const uint32_t& num_k_blocks,
+                    const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
                     process_math_block(
                         std::integral_constant<sched::BlockPhase, sched::BlockPhase::Linear1>{},
                         local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
-                } else {
+                },
+                [&](const uint32_t& local_expert_idx,
+                    const uint32_t& num_k_blocks,
+                    const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
                     process_math_block(
                         std::integral_constant<sched::BlockPhase, sched::BlockPhase::Linear2>{},
                         local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
-                }
-            });
+                });
         } else {
             scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
                                          const uint32_t& local_expert_idx,

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_mega_moe.cuh
@@ -1,0 +1,1894 @@
+#pragma once
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-attributes"
+
+#include <cstdint>
+#include <type_traits>
+#include <cutlass/arch/barrier.h>
+#include <cutlass/arch/reg_reconfig.h>
+
+#include <cute/arch/cluster_sm90.hpp>
+#include <cute/arch/copy_sm90_tma.hpp>
+
+#include <deep_gemm/common/math.cuh>
+#include <deep_gemm/common/tma_copy.cuh>
+#include <deep_gemm/common/utils.cuh>
+#include <deep_gemm/comm/barrier.cuh>
+#include <deep_gemm/layout/sym_buffer.cuh>
+#include <deep_gemm/layout/mega_moe.cuh>
+#include <deep_gemm/mma/sm90.cuh>
+#include <deep_gemm/scheduler/mega_moe.cuh>
+#include <deep_gemm/ptx/ld_st.cuh>
+#include <deep_gemm/ptx/tma.cuh>
+#include <deep_gemm/ptx/utils.cuh>
+#include <deep_gemm/ptx/wgmma.cuh>
+#define __CLION_IDE__
+
+namespace deep_gemm {
+
+template <float kActivationClamp>
+__forceinline__ __device__ float sm90_fp8_mega_moe_clamp_gate(float x) {
+    if constexpr (kActivationClamp != cute::numeric_limits<float>::infinity())
+        x = cute::min(x, kActivationClamp);
+    return x;
+}
+
+template <float kActivationClamp>
+__forceinline__ __device__ float sm90_fp8_mega_moe_clamp_up(float x) {
+    if constexpr (kActivationClamp != cute::numeric_limits<float>::infinity())
+        x = cute::min(cute::max(x, -kActivationClamp), kActivationClamp);
+    return x;
+}
+
+template <bool kFastMath>
+__forceinline__ __device__ float sm90_fp8_mega_moe_silu(float x) {
+    const float e = kFastMath ? __expf(-x) : expf(-x);
+    const float sig = kFastMath ? math::fast_rcp(1.0f + e) : 1.0f / (1.0f + e);
+    return x * sig;
+}
+
+template <bool kFastMath, float kActivationClamp>
+__forceinline__ __device__ float sm90_fp8_mega_moe_swiglu(float g, float u) {
+    g = sm90_fp8_mega_moe_clamp_gate<kActivationClamp>(g);
+    u = sm90_fp8_mega_moe_clamp_up<kActivationClamp>(u);
+    return sm90_fp8_mega_moe_silu<kFastMath>(g) * u;
+}
+
+__forceinline__ __device__ void sm90_fp8_mega_moe_get_e4m3_sf_and_sf_inv(
+    const float2& amax, float2& sf, float2& sf_inv) {
+    constexpr float kScale = 1.0f / 448.0f;
+    const auto scaled = make_float2(__fmul_rn(amax.x, kScale), __fmul_rn(amax.y, kScale));
+    const auto exp_x = math::fast_log2_ceil(scaled.x);
+    const auto exp_y = math::fast_log2_ceil(scaled.y);
+    sf.x = math::fast_pow2(exp_x), sf_inv.x = math::fast_pow2(-exp_x);
+    sf.y = math::fast_pow2(exp_y), sf_inv.y = math::fast_pow2(-exp_y);
+}
+
+// ============================================================================
+// SM90 (Hopper) FP8 MegaMoE — full implementation
+// ----------------------------------------------------------------------------
+// Pipeline (cluster=1, no TMA multicast):
+//   * Dispatch warps: pull tokens (FP8) and SF (per-128 channel float) from
+//     remote ranks via NVLink into the local L1 pool.
+//   * GEMM TMA-load warps (1 for A+SFA, 1 for B+SFB) feed the pipeline stages.
+//   * Math warpgroups (totalling kNumEpilogueThreads) consume each
+//     stage with WGMMA, accumulate into registers, then run the epilogue:
+//       - L1 (Linear1): SwiGLU with gate/up granularity-8 interleaved layout,
+//         per-row amax over each output-SF group, FP8 e4m3 quantize, STSM into
+//         SMEM, TMA store to local L1 output buffer.
+//         The per-row SF is written as a *float* into the L2-acts SF buffer at
+//         per-64 K granularity (one SF per L1 N block), so each block is fully
+//         self-contained and no cross-CTA amax synchronisation is needed.
+//       - L2 (Linear2): BF16 cast of the GEMM output, STSM into SMEM, then
+//         NVLink scatter to remote combine buffers.
+//   * After all GEMM blocks, the math warps run the COMBINE step (top-k
+//     reduction in BF16) — ported verbatim from the SM100 kernel.
+// ============================================================================
+
+template <
+    uint32_t kNumMaxTokensPerRank,
+    uint32_t kHidden, uint32_t kIntermediateHidden,
+    uint32_t kNumExperts, uint32_t kNumTopk,
+    uint32_t kNumExpertsPerWave,
+    uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,
+    uint32_t kNumMaxPoolTokens,
+    uint32_t kNumPaddedSFPoolTokens,
+    uint32_t kNumStages,
+    uint32_t kNumDispatchThreads, uint32_t kNumNonEpilogueThreads,
+    uint32_t kNumEpilogueThreads,
+    uint32_t kNumSMs, uint32_t kNumRanks,
+    float kActivationClamp,
+    bool kFastMath,
+    uint32_t kEpilogueRegisterBudget,
+    bool kReuseAccumAsFinal,
+    bool kL2ArrivalCounter,
+    bool kL2EpilogueRequiresFullSync,
+    bool kSplitPhaseHotPath,
+    uint32_t L1_SHAPE_N = kIntermediateHidden * 2,
+    uint32_t L1_SHAPE_K = kHidden,
+    uint32_t L2_SHAPE_N = kHidden,
+    uint32_t L2_SHAPE_K = kIntermediateHidden,
+    uint32_t kNumDispatchWarps = kNumDispatchThreads / 32,
+    uint32_t kNumMMANonEpilogueWarps = kNumNonEpilogueThreads / 32,
+    uint32_t kNumEpilogueWarps = kNumEpilogueThreads / 32,
+    uint32_t kNumEpilogueWarpgroups = kNumEpilogueWarps / 4,
+    uint32_t kNumThreads = kNumDispatchThreads + kNumNonEpilogueThreads + kNumEpilogueThreads,
+    uint32_t kNumTokensPerWarp = 32 / kNumTopk,
+    uint32_t kNumExpertsPerRank = kNumExperts / kNumRanks
+>
+CUTLASS_GLOBAL __launch_bounds__(kNumThreads, 1) void
+sm90_fp8_mega_moe_impl(void* y,
+                       int* cumulative_local_expert_recv_stats,
+                       const uint32_t num_tokens,
+                       const __grid_constant__ layout::SymBuffer<kNumRanks> sym_buffer,
+                       const __grid_constant__ cute::TmaDescriptor tensor_map_l1_acts,
+                       const __grid_constant__ cute::TmaDescriptor tensor_map_l1_acts_sf,
+                       const __grid_constant__ cute::TmaDescriptor tensor_map_l1_weights,
+                       const float* __restrict__ l1_weights_sf,
+                       const __grid_constant__ cute::TmaDescriptor tensor_map_l1_output,
+                       const __grid_constant__ cute::TmaDescriptor tensor_map_l2_acts,
+                       const __grid_constant__ cute::TmaDescriptor tensor_map_l2_acts_sf,
+                       const __grid_constant__ cute::TmaDescriptor tensor_map_l2_weights,
+                       const float* __restrict__ l2_weights_sf) {
+#if (defined(__CUDA_ARCH__) and (__CUDA_ARCH__ >= 900) and (__CUDA_ARCH__ < 1000)) or defined(__CLION_IDE__)
+    using Barrier = cutlass::arch::ClusterTransactionBarrier;
+
+    // =====================================================================
+    // Template checks
+    // =====================================================================
+    DG_STATIC_ASSERT(kNumDispatchThreads >= 64 and kNumDispatchThreads % 64 == 0,
+                     "Invalid number of dispatch threads");
+    DG_STATIC_ASSERT(kNumNonEpilogueThreads == 64 or kNumNonEpilogueThreads == 128,
+                     "Invalid number of GEMM TMA warps");
+    DG_STATIC_ASSERT((kNumDispatchThreads + kNumNonEpilogueThreads) % 128 == 0,
+                     "Math warpgroup start must be 128-thread aligned");
+    DG_STATIC_ASSERT(kNumEpilogueThreads % 128 == 0, "Invalid number of math/epilogue threads");
+    DG_STATIC_ASSERT(kNumExperts % kNumRanks == 0, "Invalid number of experts or ranks");
+    DG_STATIC_ASSERT(BLOCK_M % 64 == 0, "BLOCK_M must be a multiple of WGMMA::M (64)");
+    DG_STATIC_ASSERT(BLOCK_N == 128 or BLOCK_N == 256 or BLOCK_N == 512,
+                     "SM90 MegaMoE supports CTA BLOCK_N=128/256/512");
+    DG_STATIC_ASSERT(BLOCK_K == 128, "BLOCK_K is fixed to 128 (per-128 SF)");
+
+    // =====================================================================
+    // Thread / warp identification
+    // =====================================================================
+    const uint32_t sm_idx     = blockIdx.x;
+    const uint32_t thread_idx = threadIdx.x;
+    const uint32_t warp_idx   = cutlass::canonical_warp_idx_sync();
+    const uint32_t lane_idx   = ptx::get_lane_idx();
+
+    // Prefetch all TMA descriptors at the very beginning
+    if (warp_idx == 0 and cute::elect_one_sync()) {
+        cute::prefetch_tma_descriptor(&tensor_map_l1_acts);
+        cute::prefetch_tma_descriptor(&tensor_map_l1_acts_sf);
+        cute::prefetch_tma_descriptor(&tensor_map_l1_weights);
+        cute::prefetch_tma_descriptor(&tensor_map_l1_output);
+        cute::prefetch_tma_descriptor(&tensor_map_l2_acts);
+        cute::prefetch_tma_descriptor(&tensor_map_l2_acts_sf);
+        cute::prefetch_tma_descriptor(&tensor_map_l2_weights);
+    }
+
+    // =====================================================================
+    // Workspaces and symmetric buffer slicing (mirror SM100 layout, except SF
+    // for L2 activations uses per-64 K granularity)
+    // =====================================================================
+    const auto workspace = layout::Workspace(
+        sym_buffer.get_base_ptr(), kNumRanks, kNumExperts, kNumMaxTokensPerRank, kNumTopk);
+
+    constexpr auto fp8_token_layout              = layout::Data(kHidden);
+    constexpr auto bf16_token_layout             = layout::Data(kHidden * sizeof(nv_bfloat16));
+    constexpr auto fp8_intermediate_token_layout = layout::Data(kIntermediateHidden);
+    // Per-128 K float SF: 4 bytes per per-128 group => `kHidden / 32` bytes/token (same as SM100 packing)
+    constexpr auto fp8_sf_layout                 = layout::Data(kHidden / 32);
+    // Per-64 K float SF (SM90 only): 4 bytes per per-64 group => `kIntermediateHidden / 16` bytes/token
+    constexpr auto fp8_intermediate_sf_layout    = layout::Data(kIntermediateHidden / 16);
+    constexpr auto input_topk_idx_layout         = layout::Data(kNumTopk * sizeof(int64_t), false);
+    constexpr auto input_topk_weights_layout     = layout::Data(kNumTopk * sizeof(float), false);
+    constexpr auto l1_topk_weights_layout        = layout::Data(sizeof(float), false);
+
+    // Registered input area
+    const auto input_token_buffer        = layout::Buffer(fp8_token_layout, 1, kNumMaxTokensPerRank, workspace.get_end_ptr());
+    const auto input_sf_buffer           = layout::Buffer(fp8_sf_layout, 1, kNumMaxTokensPerRank, input_token_buffer.get_end_ptr());
+    const auto input_topk_idx_buffer     = layout::Buffer(input_topk_idx_layout, 1, kNumMaxTokensPerRank, input_sf_buffer.get_end_ptr());
+    const auto input_topk_weights_buffer = layout::Buffer(input_topk_weights_layout, 1, kNumMaxTokensPerRank, input_topk_idx_buffer.get_end_ptr());
+
+    // L1 input area
+    const auto l1_token_buffer        = layout::Buffer(fp8_token_layout, 1, kNumMaxPoolTokens, input_topk_weights_buffer.get_end_ptr());
+    const auto l1_sf_buffer           = layout::Buffer(fp8_sf_layout, 1, kNumPaddedSFPoolTokens, l1_token_buffer.get_end_ptr());
+    const auto l1_topk_weights_buffer = layout::Buffer(l1_topk_weights_layout, 1, kNumMaxPoolTokens, l1_sf_buffer.get_end_ptr());
+
+    // L2 input area
+    const auto l2_token_buffer = layout::Buffer(fp8_intermediate_token_layout, 1, kNumMaxPoolTokens, l1_topk_weights_buffer.get_end_ptr());
+    const auto l2_sf_buffer    = layout::Buffer(fp8_intermediate_sf_layout, 1, kNumPaddedSFPoolTokens, l2_token_buffer.get_end_ptr());
+
+    // Combine input area
+    const auto combine_token_buffer = layout::Buffer(bf16_token_layout, kNumTopk, kNumMaxTokensPerRank, l2_sf_buffer.get_end_ptr());
+
+    // =====================================================================
+    // GEMM data types and shape constants
+    // =====================================================================
+    using a_dtype_t = cutlass::float_e4m3_t;
+    using b_dtype_t = cutlass::float_e4m3_t;
+    constexpr bool kSplitNWarpgroups =
+        BLOCK_M == 64 and kNumEpilogueWarpgroups > 1 and
+        BLOCK_N % kNumEpilogueWarpgroups == 0 and
+        ((BLOCK_N / kNumEpilogueWarpgroups == 64) or (BLOCK_N / kNumEpilogueWarpgroups == 128));
+    constexpr bool kSplitMNWarpgroups =
+        BLOCK_M == 128 and BLOCK_N == 256 and kNumEpilogueWarpgroups == 4;
+    constexpr uint32_t kWarpgroupSplitM = kSplitNWarpgroups ? 1 :
+        (kSplitMNWarpgroups ? 2 : kNumEpilogueWarpgroups);
+    constexpr uint32_t kWarpgroupSplitN = kSplitNWarpgroups ? kNumEpilogueWarpgroups :
+        (kSplitMNWarpgroups ? 2 : 1);
+    constexpr uint32_t WG_BLOCK_M = BLOCK_M / kWarpgroupSplitM;
+    constexpr uint32_t WG_BLOCK_N = BLOCK_N / kWarpgroupSplitN;
+    constexpr uint32_t kNumCombineWarps = kNumEpilogueWarps;
+    using L1WGMMA   = typename mma::sm90::FP8MMASelector<WG_BLOCK_N>::type;  // M=64, N=WG_BLOCK_N, K=32
+    using L2WGMMA   = typename mma::sm90::FP8MMASelector<WG_BLOCK_N>::type;
+    constexpr uint32_t kL1OutputArrivalParts = 1;
+    static_assert(L1WGMMA::M == 64 and L1WGMMA::N == WG_BLOCK_N and L1WGMMA::K == 32,
+                  "Unexpected WGMMA shape");
+    DG_STATIC_ASSERT(kWarpgroupSplitM * kWarpgroupSplitN == kNumEpilogueWarpgroups,
+                     "Invalid warpgroup split");
+    DG_STATIC_ASSERT(WG_BLOCK_M == L1WGMMA::M,
+                     "Each warpgroup must run exactly one WGMMA-M tile");
+    DG_STATIC_ASSERT(kNumCombineWarps <= kNumEpilogueWarps,
+                     "Combine warp count must fit in epilogue warps");
+
+    // Cluster=1 -> no multicast, A/B are loaded full-sized
+    constexpr uint32_t LOAD_BLOCK_M    = BLOCK_M;
+    constexpr uint32_t LOAD_BLOCK_N    = BLOCK_N;
+    constexpr uint32_t L1_OUT_BLOCK_N  = BLOCK_N / 2;  // post-SwiGLU
+    constexpr uint32_t WG_L1_OUT_BLOCK_N = WG_BLOCK_N / 2;
+    // When WG_L1_OUT_BLOCK_N < 64 the two N-split warpgroups jointly own a
+    // single per-64 L2-acts SF group, so they must publish ONE shared SF slot
+    // (k_sf_idx == n_block_idx) instead of one per warpgroup. The amax that
+    // feeds that shared SF must be reduced across both warpgroups.
+    constexpr bool kSplitNSharesSF = kSplitNWarpgroups and (WG_L1_OUT_BLOCK_N < 64);
+    constexpr uint32_t kSwizzleAMode   = BLOCK_K * sizeof(a_dtype_t);   // 128
+    constexpr uint32_t kSwizzleBMode   = BLOCK_K * sizeof(b_dtype_t);   // 128
+    constexpr uint32_t kSwizzleCDMode  = 128;
+    constexpr uint32_t kGranK          = 128;          // L1 acts SF, weights SF
+    constexpr uint32_t kL2ActsSFGranK  = 64;           // L2 acts SF (per-64 K, SM90 only)
+
+    // =====================================================================
+    // Shared memory layout
+    // =====================================================================
+    constexpr uint32_t kSharedMemoryAlignment = 1024;
+    extern __shared__ __align__(kSharedMemoryAlignment) uint8_t smem_buffer[];
+
+    constexpr uint32_t SMEM_EXPERT_COUNT_SIZE =
+        math::constexpr_align<uint32_t>(kNumExperts * sizeof(uint32_t), kSharedMemoryAlignment);
+    constexpr uint32_t SMEM_SEND_BUFFER_SIZE =
+        math::constexpr_align(fp8_token_layout.get_num_bytes() * kNumDispatchWarps, kSharedMemoryAlignment);
+    constexpr uint32_t SMEM_A_SIZE_PER_STAGE = LOAD_BLOCK_M * BLOCK_K * sizeof(a_dtype_t);
+    constexpr uint32_t SMEM_B_SIZE_PER_STAGE = LOAD_BLOCK_N * BLOCK_K * sizeof(b_dtype_t);
+    // SFA per-stage must be sized for the larger of L1 (BLOCK_M floats) and L2 (2*BLOCK_M floats per-64).
+    constexpr uint32_t SMEM_SFA_SIZE_PER_STAGE =
+        math::constexpr_align<uint32_t>(2 * BLOCK_M * sizeof(float), 128u);
+    // Block (128, 128) weight SF is loaded directly from global by the math
+    // warpgroup, so no SMEM is needed.
+    constexpr uint32_t SMEM_SFB_SIZE_PER_STAGE = 0;
+
+    // CD output: max of L1 FP8 (BLOCK_M * (BLOCK_N/2) * 1 byte) and
+    // L2 BF16 (BLOCK_M * BLOCK_N * 2 bytes). Split-M warpgroups own disjoint
+    // row slices; shared-SF split-N warpgroups stage disjoint column slices
+    // into one CTA tile.
+    constexpr uint32_t SMEM_CD_L1_SIZE = BLOCK_M * L1_OUT_BLOCK_N * sizeof(cutlass::float_e4m3_t);
+    constexpr uint32_t SMEM_CD_L2_SIZE = BLOCK_M * BLOCK_N * sizeof(nv_bfloat16);
+    constexpr uint32_t SMEM_CD_SIZE    = math::constexpr_align(
+        SMEM_CD_L1_SIZE > SMEM_CD_L2_SIZE ? SMEM_CD_L1_SIZE : SMEM_CD_L2_SIZE, kSharedMemoryAlignment);
+
+    constexpr uint32_t SMEM_BEFORE_BARRIER_SIZE =
+        SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE + SMEM_CD_SIZE +
+        kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE);
+
+    // SMEM pointers
+    auto smem_expert_count = reinterpret_cast<uint32_t*>(smem_buffer);
+    const auto smem_send_buffers = layout::Buffer(
+        fp8_token_layout, kNumDispatchWarps, 1,
+        math::advance_ptr(smem_buffer, SMEM_EXPERT_COUNT_SIZE));
+
+    auto smem_gemm_base = math::advance_ptr(
+        smem_buffer, SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE);
+
+    // CD output is shared by L1 (FP8) and L2 (BF16); reinterpret-cast as needed.
+    auto smem_cd_l1 = reinterpret_cast<cutlass::float_e4m3_t*>(smem_gemm_base);
+    auto smem_cd_l2 = reinterpret_cast<nv_bfloat16*>(smem_gemm_base);
+
+    auto smem_a = utils::PatternVisitor([=](const uint32_t& i) {
+        return math::advance_ptr<a_dtype_t>(smem_gemm_base, SMEM_CD_SIZE + i * SMEM_A_SIZE_PER_STAGE);
+    });
+    auto smem_b = utils::PatternVisitor([=](const uint32_t& i) {
+        return math::advance_ptr<b_dtype_t>(smem_gemm_base, SMEM_CD_SIZE + kNumStages * SMEM_A_SIZE_PER_STAGE + i * SMEM_B_SIZE_PER_STAGE);
+    });
+    auto sf_start_ptr = math::advance_ptr<uint8_t>(smem_gemm_base,
+        SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE));
+    auto smem_sfa = utils::PatternVisitor([=](const uint32_t& i) {
+        return reinterpret_cast<float*>(sf_start_ptr + i * SMEM_SFA_SIZE_PER_STAGE);
+    });
+
+    // Barriers live after SF (SFB is loaded directly from global, no SMEM)
+    auto barrier_start_ptr = reinterpret_cast<Barrier*>(
+        sf_start_ptr + kNumStages * SMEM_SFA_SIZE_PER_STAGE);
+    auto dispatch_barriers = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + i; });
+    auto full_barriers     = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + kNumDispatchWarps + i; });
+    auto empty_barriers    = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + kNumDispatchWarps + kNumStages + i; });
+    auto combine_barriers  = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + kNumDispatchWarps + kNumStages * 2 + i; });
+
+    // =====================================================================
+    // Initialization
+    // =====================================================================
+    if (warp_idx == 0) {
+        // Clean expert-count shared memory
+        #pragma unroll
+        for (uint32_t i = lane_idx; i < kNumExperts; i += 32)
+            ptx::st_shared(smem_expert_count + i, 0u);
+    } else if (warp_idx == 1) {
+        // Init dispatch m-barriers
+        #pragma unroll
+        for (uint32_t i = lane_idx; i < kNumDispatchWarps; i += 32)
+            dispatch_barriers[i]->init(1);
+        cutlass::arch::fence_barrier_init();
+    } else if (warp_idx == 2) {
+        // Init GEMM full/empty barriers and combine barriers
+        if (cute::elect_one_sync()) {
+            #pragma unroll
+            for (uint32_t i = 0; i < kNumStages; ++ i) {
+                // Two producer warps (A+SFA loader, B+SFB loader) each call
+                // `arrive_and_expect_tx` per stage, so init count must be 2.
+                full_barriers[i]->init(2);
+                // Each math warp arrives once per stage release.
+                empty_barriers[i]->init(kNumEpilogueWarps);
+            }
+            #pragma unroll
+            for (uint32_t i = 0; i < kNumCombineWarps * 2; ++ i)
+                combine_barriers[i]->init(1);
+        }
+        cutlass::arch::fence_barrier_init();
+    }
+    __syncthreads();
+
+    // =====================================================================
+    // Scheduler (cluster=1)
+    // =====================================================================
+    auto scheduler = sched::MegaMoEScheduler<
+        BLOCK_M, BLOCK_N, BLOCK_K,
+        L1_SHAPE_N, L1_SHAPE_K,
+        L2_SHAPE_N, L2_SHAPE_K,
+        kNumExpertsPerRank, kNumExpertsPerWave,
+        kNumSMs, kNumRanks>(workspace);
+
+    // Pipeline state shared by TMA loaders and math warpgroups
+    uint32_t stage_idx = 0, phase = 0;
+    auto advance_pipeline = [&](uint32_t& k_block_idx) {
+        ++ k_block_idx;
+        stage_idx = stage_idx == kNumStages - 1 ? 0 : stage_idx + 1;
+        phase ^= stage_idx == 0;
+    };
+
+    // Intra-SM barrier indices (mirroring SM100)
+    constexpr uint32_t kDispatchBarrierIdx              = 0;
+    constexpr uint32_t kDispatchWithEpilogueBarrierIdx  = 1;
+    constexpr uint32_t kEpilogueFullBarrierIdx          = 2;
+    constexpr uint32_t kEpilogueWGBarrierStartIdx       = 3;
+
+    // Cross-rank NVLink barrier tags
+    constexpr uint32_t kBeforeDispatchPullBarrierTag    = 1;
+    constexpr uint32_t kBeforeCombineReduceBarrierTag   = 2;
+    constexpr uint32_t kAfterWorkspaceCleanBarrierTag   = 3;
+
+    // Register reconfiguration counts (chosen to fit in 64512 reg budget).
+    // For the 256-epilogue-thread split-N decode path:
+    //   64*48 + 64*40 + 256*168 = 48640 <= 64512.
+    // For the 512-epilogue-thread split-MN path, trim dispatch and loader roles
+    // so launch bounds still leave enough WGMMA registers.
+    // Reduced-thread decode (kNumThreads<=256) raises the launch-bounds
+    // register ceiling to 65536/256=256; grant the epilogue warpgroup the full
+    // 256 so the accumulator double-buffer fits without spilling.
+    //   64*48 + 64*40 + 128*256 = 38400 <= 64512.
+    constexpr uint32_t kNumEpilogueRegisters    =
+        kEpilogueRegisterBudget == 0 ?
+            (kNumEpilogueThreads == 512 ? 112 :
+                (kNumEpilogueThreads == 256 ? 168 :
+                    (kNumThreads <= 256u ? 256 : 208))) :
+            kEpilogueRegisterBudget;
+    // The 512-epilogue-thread path has only 3584 registers of headroom at
+    // epilogue=112.  Raising epilogue to 120 is not viable without changing
+    // the role topology: dispatch=24 stalls the split-MN path, while
+    // non-epilogue=16 is below ptxas' setmaxnreg.dec legal minimum.
+    constexpr uint32_t kNumDispatchRegisters =
+        kNumEpilogueThreads == 512 ? 32 : 48;
+    constexpr uint32_t kNumNonEpilogueRegisters =
+        kNumEpilogueThreads == 512 ? 24 : 40;
+    DG_STATIC_ASSERT(kNumDispatchRegisters * kNumDispatchThreads +
+                     kNumNonEpilogueRegisters * kNumNonEpilogueThreads +
+                     kNumEpilogueRegisters * kNumEpilogueThreads <= 64512,
+                     "Too many registers");
+
+    constexpr uint32_t kDispatchGridSyncIndex = 0;
+    constexpr uint32_t kEpilogueGridSyncIndex = 1;
+
+    // =====================================================================
+    // ROLE 1: DISPATCH WARPS
+    //   Mirrors SM100 dispatch with two changes:
+    //     * SF is per-128 channel float (no UTCCP transpose). We store the
+    //       remote per-token SF directly into the local L1 SF buffer in
+    //       MN-major layout: `local_sf[k_chunk * num_padded_sf_pool_tokens + token_idx]`.
+    //     * The "token_idx_in_expert" → SF token index is now the simple
+    //       per-block linear mapping (no 4×32 transpose).
+    // =====================================================================
+    if (warp_idx < kNumDispatchWarps) {
+        cutlass::arch::warpgroup_reg_dealloc<kNumDispatchRegisters>();
+
+        DG_STATIC_ASSERT(kNumTopk <= 32, "Invalid number of topk");
+        constexpr uint32_t kNumActivateLanes = kNumTokensPerWarp * kNumTopk;
+        const auto read_topk_idx = [&](const auto& process) {
+            #pragma unroll
+            for (uint32_t i = (sm_idx * kNumDispatchWarps + warp_idx) * kNumTokensPerWarp;
+                 i < num_tokens;
+                 i += kNumSMs * kNumDispatchWarps * kNumTokensPerWarp) {
+                int expert_idx = -1;
+                if (i + (lane_idx / kNumTopk) < num_tokens and lane_idx < kNumActivateLanes) {
+                    expert_idx = static_cast<int>(
+                        __ldg(input_topk_idx_buffer.get_base_ptr<int64_t>() + i * kNumTopk + lane_idx));
+                    if (expert_idx >= 0)
+                        process(i * kNumTopk + lane_idx, expert_idx);
+                }
+                __syncwarp();
+            }
+        };
+
+        // Count tokens per expert
+        read_topk_idx([&](const uint32_t& token_topk_idx, const int& expert_idx) {
+            atomicAdd_block(smem_expert_count + expert_idx, 1);
+        });
+        ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
+
+        // Stake out per-expert SM offsets via global atomic
+        #pragma unroll
+        for (uint32_t i = thread_idx; i < kNumExperts; i += kNumDispatchThreads) {
+            const uint64_t send_value = (1ull << 32) | static_cast<uint64_t>(smem_expert_count[i]);
+            smem_expert_count[i] = static_cast<uint32_t>(
+                ptx::atomic_add(workspace.get_expert_send_count_ptr(i), send_value));
+        }
+        ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
+
+        // Write source token-topk indices to remote ranks
+        read_topk_idx([&](const uint32_t& token_topk_idx, const int& expert_idx) {
+            const auto dst_rank_idx = expert_idx / kNumExpertsPerRank;
+            const auto dst_slot_idx = atomicAdd_block(smem_expert_count + expert_idx, 1);
+            const auto dst_ptr = workspace.get_src_token_topk_idx_ptr(
+                expert_idx % kNumExpertsPerRank, sym_buffer.rank_idx, dst_slot_idx);
+            *sym_buffer.map(dst_ptr, dst_rank_idx) = token_topk_idx;
+        });
+
+        comm::grid_sync<kNumSMs, kDispatchGridSyncIndex>(
+            workspace, sm_idx, thread_idx,
+            [=]() { ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx); }
+        );
+
+        if (sm_idx == 0) {
+            #pragma unroll
+            for (uint32_t i = thread_idx; i < kNumExperts; i += kNumDispatchThreads) {
+                const auto dst_rank_idx = i / kNumExpertsPerRank;
+                const auto dst_local_expert_idx = i % kNumExpertsPerRank;
+                const auto expert_status = *workspace.get_expert_send_count_ptr(i);
+                *sym_buffer.map(
+                    workspace.get_expert_recv_count_ptr(sym_buffer.rank_idx, dst_local_expert_idx),
+                    dst_rank_idx) = expert_status & 0xffffffff;
+                ptx::atomic_add_sys(
+                    sym_buffer.map(workspace.get_expert_recv_count_sum_ptr(dst_local_expert_idx), dst_rank_idx),
+                    expert_status);
+            }
+        }
+        ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
+
+        comm::nvlink_barrier<kNumRanks, kNumSMs, kNumDispatchThreads,
+                             kDispatchGridSyncIndex, kBeforeDispatchPullBarrierTag>(
+            workspace, sym_buffer, sm_idx, thread_idx,
+            [=]() { ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx); },
+            false, true);
+
+        // Sync with epilogue warps before pulling tokens.
+        ptx::sync_unaligned(kNumDispatchThreads + kNumEpilogueThreads, kDispatchWithEpilogueBarrierIdx);
+
+        // Token / SF pull loop
+        uint32_t pull_mbarrier_phase = 0;
+        const auto pull_buffer = smem_send_buffers.get_rank_buffer(warp_idx).get_data_buffer(0);
+        const auto pull_mbarrier = dispatch_barriers[warp_idx];
+
+        scheduler.fetch_expert_recv_count();
+
+        constexpr uint32_t kNumRanksPerLane = math::constexpr_ceil_div(kNumRanks, 32u);
+        int      current_expert_idx = -1;
+        uint32_t stored_rank_count[kNumRanksPerLane] = {};
+        uint32_t expert_start_idx = 0, expert_end_idx = 0;
+        uint32_t expert_pool_block_offset = 0;
+
+        constexpr uint32_t kNumGlobalWarps = kNumSMs * kNumDispatchWarps;
+        for (uint32_t token_idx = sm_idx * kNumDispatchWarps + warp_idx; ; token_idx += kNumGlobalWarps) {
+                int old_expert_idx = current_expert_idx;
+                while (token_idx >= expert_end_idx) {
+                    if (++ current_expert_idx >= kNumExpertsPerRank)
+                        break;
+                    expert_pool_block_offset += math::ceil_div(expert_end_idx - expert_start_idx, BLOCK_M);
+                    expert_start_idx = expert_end_idx;
+                    expert_end_idx += scheduler.get_num_tokens(current_expert_idx);
+                }
+                if (current_expert_idx >= kNumExpertsPerRank)
+                    break;
+
+                if (old_expert_idx != current_expert_idx) {
+                    old_expert_idx = current_expert_idx;
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumRanksPerLane; ++ i) {
+                        const uint32_t j = i * 32 + lane_idx;
+                        stored_rank_count[i] = j < kNumRanks ?
+                            static_cast<uint32_t>(*workspace.get_expert_recv_count_ptr(j, current_expert_idx)) : 0;
+                    }
+                }
+
+                // Round-robin rank selection (identical to SM100)
+                uint32_t current_rank_in_expert_idx;
+                uint32_t remaining[kNumRanksPerLane];
+                #pragma unroll
+                for (uint32_t i = 0; i < kNumRanksPerLane; ++ i)
+                    remaining[i] = stored_rank_count[i];
+                uint32_t offset = 0;
+                uint32_t token_idx_in_expert = token_idx - expert_start_idx;
+                uint32_t slot_idx = token_idx_in_expert;
+                uint32_t token_idx_in_rank;
+                while (true) {
+                    uint32_t num_actives_in_lane = 0;
+                    uint32_t min_in_lane = 0xffffffff;
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumRanksPerLane; ++ i) {
+                        num_actives_in_lane += remaining[i] > 0;
+                        if (remaining[i] > 0)
+                            min_in_lane = cute::min(min_in_lane, remaining[i]);
+                    }
+                    const uint32_t num_active_ranks = __reduce_add_sync(0xffffffff, num_actives_in_lane);
+                    const uint32_t length = __reduce_min_sync(0xffffffff, min_in_lane);
+
+                    const uint32_t num_round_tokens = length * num_active_ranks;
+                    if (slot_idx < num_round_tokens) {
+                        const uint32_t slot_idx_in_round = slot_idx % num_active_ranks;
+                        uint32_t num_seen_ranks = 0;
+                        current_rank_in_expert_idx = 0;
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kNumRanksPerLane; ++ i) {
+                            const uint32_t mask = __ballot_sync(0xffffffff, remaining[i] > 0);
+                            const uint32_t num_active_lanes = __popc(mask);
+                            if (slot_idx_in_round >= num_seen_ranks and slot_idx_in_round < num_seen_ranks + num_active_lanes)
+                                current_rank_in_expert_idx = i * 32 + __fns(mask, 0, slot_idx_in_round - num_seen_ranks + 1);
+                            num_seen_ranks += num_active_lanes;
+                        }
+                        token_idx_in_rank = offset + (slot_idx / num_active_ranks);
+                        break;
+                    }
+                    slot_idx -= num_round_tokens;
+                    offset += length;
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumRanksPerLane; ++ i)
+                        remaining[i] -= cute::min(remaining[i], length);
+                }
+
+                const uint32_t src_token_topk_idx = *workspace.get_src_token_topk_idx_ptr(
+                    current_expert_idx, current_rank_in_expert_idx, token_idx_in_rank);
+                const uint32_t src_token_idx = src_token_topk_idx / kNumTopk;
+                const uint32_t src_topk_idx  = src_token_topk_idx % kNumTopk;
+
+                const uint32_t pool_token_idx = expert_pool_block_offset * BLOCK_M + token_idx_in_expert;
+
+                // Pull token data. Overlap a remote TMA load with SF copy and
+                // then use TMA store to materialize the local L1 input.
+                if (cute::elect_one_sync()) {
+                    ptx::tma_load_1d(
+                        pull_buffer.get_base_ptr(),
+                        sym_buffer.map(input_token_buffer.get_data_buffer(src_token_idx).get_base_ptr(),
+                                       current_rank_in_expert_idx),
+                        pull_mbarrier, kHidden);
+                }
+                __syncwarp();
+
+                // Copy SF: per-128 K floats, written linearly (no UTCCP transpose).
+                constexpr uint32_t kNumSFFloats = kHidden / 128;
+                DG_STATIC_ASSERT(kNumSFFloats > 0 and kHidden % 128 == 0, "Invalid SF");
+                const auto remote_sf_ptr = sym_buffer.map(
+                    input_sf_buffer.get_data_buffer(src_token_idx).get_base_ptr<float>(),
+                    current_rank_in_expert_idx);
+                const auto local_sf_ptr  = l1_sf_buffer.get_base_ptr<float>();
+                const uint32_t sf_pool_token_idx = expert_pool_block_offset * BLOCK_M + token_idx_in_expert;
+                #pragma unroll
+                for (uint32_t i = 0; i < math::constexpr_ceil_div(kNumSFFloats, 32u); ++ i) {
+                    const uint32_t j = i * 32 + lane_idx;
+                    if (j < kNumSFFloats)
+                        local_sf_ptr[j * kNumPaddedSFPoolTokens + sf_pool_token_idx] = remote_sf_ptr[j];
+                }
+                __syncwarp();
+
+                if (cute::elect_one_sync()) {
+                    const auto weight = *sym_buffer.map(
+                        input_topk_weights_buffer.get_base_ptr<float>() + src_token_topk_idx,
+                        current_rank_in_expert_idx);
+                    *l1_topk_weights_buffer.get_data_buffer(pool_token_idx).get_base_ptr<float>() = weight;
+                }
+                __syncwarp();
+
+                if (cute::elect_one_sync()) {
+                    ptx::mbarrier_arrive_and_set_tx(pull_mbarrier, kHidden);
+                    ptx::mbarrier_wait_and_flip_phase(pull_mbarrier, pull_mbarrier_phase);
+
+                    ptx::tma_store_1d(
+                        l1_token_buffer.get_data_buffer(pool_token_idx).get_base_ptr(),
+                        pull_buffer.get_base_ptr(), pull_buffer.get_num_bytes());
+
+                    *workspace.get_token_src_metadata_ptr(pool_token_idx) =
+                        {current_rank_in_expert_idx, src_token_idx, src_topk_idx};
+
+                    cute::tma_store_arrive();
+                    ptx::tma_store_wait<0>();
+                    ptx::red_add_rel(
+                        workspace.get_l1_arrival_count_ptr(expert_pool_block_offset + token_idx_in_expert / BLOCK_M), 1);
+                }
+                __syncwarp();
+            }
+
+        // Cleanup workspace, overlapping with combine.
+        ptx::sync_unaligned(kNumDispatchThreads + kNumEpilogueThreads, kDispatchWithEpilogueBarrierIdx);
+
+        DG_STATIC_ASSERT(kNumSMs > 1, "Invalid SM count");
+        if (sm_idx == 0) {
+            #pragma unroll
+            for (uint32_t i = thread_idx; i < kNumExperts; i += kNumDispatchThreads)
+                *workspace.get_expert_send_count_ptr(i) = 0;
+        } else {
+            for (uint32_t i = sm_idx - 1; i < kNumExpertsPerRank; i += kNumSMs - 1) {
+                const auto num_recv_tokens = static_cast<uint32_t>(
+                    *workspace.get_expert_recv_count_sum_ptr(i));
+                const auto num_recv_m_blocks = math::ceil_div(num_recv_tokens, BLOCK_M);
+
+                expert_pool_block_offset = scheduler.get_pool_block_offset(i);
+
+                ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
+
+                DG_STATIC_ASSERT(kNumDispatchWarps >= 2, "Not enough dispatch warps");
+                if (warp_idx == 0) {
+                    *workspace.get_expert_recv_count_sum_ptr(i) = 0;
+                } else if (warp_idx == 1) {
+                    if (cute::elect_one_sync() and cumulative_local_expert_recv_stats != nullptr)
+                        ptx::red_add(cumulative_local_expert_recv_stats + i, static_cast<int>(num_recv_tokens));
+                    __syncwarp();
+                }
+
+                for (uint32_t j = thread_idx; j < kNumRanks; j += kNumDispatchThreads)
+                    *workspace.get_expert_recv_count_ptr(j, i) = 0;
+                __syncwarp();
+
+                for (uint32_t j = thread_idx; j < num_recv_m_blocks; j += kNumDispatchThreads) {
+                    *workspace.get_l1_arrival_count_ptr(expert_pool_block_offset + j) = 0;
+                    *workspace.get_l2_arrival_mask_ptr(expert_pool_block_offset + j) = 0;
+                }
+                __syncwarp();
+            }
+        }
+
+        comm::nvlink_barrier<kNumRanks, kNumSMs, kNumDispatchThreads,
+                             kDispatchGridSyncIndex, kAfterWorkspaceCleanBarrierTag>(
+            workspace, sym_buffer, sm_idx, thread_idx,
+            [=]() { ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx); },
+            true, false);
+
+    // =====================================================================
+    // ROLE 2: GEMM TMA LOAD warps (load A+SFA, B+SFB)
+    //   Warps inside `kNumNonEpilogueThreads`: warp 0 loads A + SFA,
+    //   warp 1 loads B.
+    // =====================================================================
+    } else if (warp_idx == kNumDispatchWarps) {
+        cutlass::arch::warpgroup_reg_dealloc<kNumNonEpilogueRegisters>();
+
+        auto process_a_sfa_block = [&](const auto& block_phase,
+                                       const uint32_t& local_expert_idx,
+                                       const uint32_t& num_k_blocks,
+                                       const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
+            const auto tensor_map_a_ptr = block_phase == sched::BlockPhase::Linear2
+                ? &tensor_map_l2_acts : &tensor_map_l1_acts;
+            const auto tensor_map_sfa_ptr = block_phase == sched::BlockPhase::Linear2
+                ? &tensor_map_l2_acts_sf : &tensor_map_l1_acts_sf;
+
+            const uint32_t pool_block_idx = scheduler.get_current_pool_block_offset() + m_block_idx;
+
+            // Wait for the pool to be ready
+            if (block_phase == sched::BlockPhase::Linear1) {
+                const auto ptr = workspace.get_l1_arrival_count_ptr(pool_block_idx);
+                const auto expected = scheduler.template get_valid_m<false>();
+                while (ptx::ld_acq(ptr) != expected);
+            } else {
+                constexpr uint32_t kNumL1BlockNs = L1_SHAPE_N / BLOCK_N;
+                if constexpr (kL2ArrivalCounter) {
+                    const auto ptr = reinterpret_cast<const uint32_t*>(
+                        workspace.get_l2_arrival_mask_ptr(pool_block_idx));
+                    const uint32_t active_m_wgs = math::ceil_div(
+                        scheduler.template get_valid_m<false>(), WG_BLOCK_M);
+                    const uint32_t expected =
+                        kNumL1BlockNs * active_m_wgs * kWarpgroupSplitN * kL1OutputArrivalParts;
+                    while (ptx::ld_acq(ptr) != expected);
+                } else {
+                    const auto ptr = workspace.get_l2_arrival_mask_ptr(pool_block_idx);
+                    // Each L1 N block sets one bit; total bits = L1_SHAPE_N / BLOCK_N.
+                    const uint64_t expected = (kNumL1BlockNs >= 64)
+                        ? ~0ull : ((1ull << kNumL1BlockNs) - 1ull);
+                    while (ptx::ld_acq_gpu(ptr) != expected);
+                }
+            }
+            for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
+                empty_barriers[stage_idx]->wait(phase ^ 1);
+
+                if (cute::elect_one_sync()) {
+                    const uint32_t m_idx = pool_block_idx * BLOCK_M;
+                    const uint32_t k_idx = k_block_idx * BLOCK_K;
+
+                    // TMA load A
+                    tma::copy<BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(
+                        tensor_map_a_ptr, full_barriers[stage_idx], smem_a[stage_idx],
+                        k_idx, m_idx, 1);
+
+                    // TMA load SFA
+                    if (block_phase == sched::BlockPhase::Linear1) {
+                        // L1 SFA per-128: load (BLOCK_M, 1) at K=k_block_idx
+                        tma::copy<BLOCK_M, 1, 0, float>(
+                            tensor_map_sfa_ptr, full_barriers[stage_idx], smem_sfa[stage_idx],
+                            m_idx, k_block_idx, 1);
+                        full_barriers[stage_idx]->arrive_and_expect_tx(
+                            SMEM_A_SIZE_PER_STAGE + BLOCK_M * sizeof(float));
+                    } else {
+                        // L2 SFA per-64: descriptor box is (block_mn, 1) (see make_tma_sf_desc),
+                        // so we must issue two single-group TMAs and place them at smem offsets
+                        // 0 and BLOCK_M to match math's load offsets (`+ 0 * BLOCK_M` / `+ 1 * BLOCK_M`).
+                        tma::copy<BLOCK_M, 1, 0, float>(
+                            tensor_map_sfa_ptr, full_barriers[stage_idx], smem_sfa[stage_idx],
+                            m_idx, k_block_idx * 2, 1);
+                        tma::copy<BLOCK_M, 1, 0, float>(
+                            tensor_map_sfa_ptr, full_barriers[stage_idx],
+                            smem_sfa[stage_idx] + BLOCK_M,
+                            m_idx, k_block_idx * 2 + 1, 1);
+                        full_barriers[stage_idx]->arrive_and_expect_tx(
+                            SMEM_A_SIZE_PER_STAGE + 2 * BLOCK_M * sizeof(float));
+                    }
+                }
+                __syncwarp();
+            }
+        };
+
+        if constexpr (kSplitPhaseHotPath) {
+            scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
+                                         const uint32_t& local_expert_idx,
+                                         const uint32_t& num_k_blocks,
+                                         const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
+                if (block_phase == sched::BlockPhase::Linear1) {
+                    process_a_sfa_block(
+                        std::integral_constant<sched::BlockPhase, sched::BlockPhase::Linear1>{},
+                        local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
+                } else {
+                    process_a_sfa_block(
+                        std::integral_constant<sched::BlockPhase, sched::BlockPhase::Linear2>{},
+                        local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
+                }
+            });
+        } else {
+            scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
+                                         const uint32_t& local_expert_idx,
+                                         const uint32_t& num_k_blocks,
+                                         const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
+                process_a_sfa_block(block_phase, local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
+            });
+        }
+
+    } else if (warp_idx == kNumDispatchWarps + 1) {
+        cutlass::arch::warpgroup_reg_dealloc<kNumNonEpilogueRegisters>();
+
+        scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
+                                     const uint32_t& local_expert_idx,
+                                     const uint32_t& num_k_blocks,
+                                     const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
+            const auto tensor_map_b_ptr =
+                block_phase == sched::BlockPhase::Linear2 ? &tensor_map_l2_weights : &tensor_map_l1_weights;
+
+            const uint32_t shape_n = block_phase == sched::BlockPhase::Linear2 ? L2_SHAPE_N : L1_SHAPE_N;
+
+            for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
+                empty_barriers[stage_idx]->wait(phase ^ 1);
+
+                if (cute::elect_one_sync()) {
+                    const uint32_t n_idx = local_expert_idx * shape_n + n_block_idx * BLOCK_N;
+                    const uint32_t k_idx = k_block_idx * BLOCK_K;
+
+                    // TMA load B (weight SF is now loaded directly by math warps from global)
+                    if constexpr (LOAD_BLOCK_N <= 256) {
+                        tma::copy<BLOCK_K, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(
+                            tensor_map_b_ptr, full_barriers[stage_idx], smem_b[stage_idx],
+                            k_idx, n_idx, 1);
+                    } else {
+                        DG_STATIC_ASSERT(LOAD_BLOCK_N % 256 == 0,
+                                         "Large B tiles are loaded as 256-column TMA slices");
+                        #pragma unroll
+                        for (uint32_t b_slice_idx = 0; b_slice_idx < LOAD_BLOCK_N / 256; ++ b_slice_idx) {
+                            tma::copy<BLOCK_K, 256, kSwizzleBMode, b_dtype_t>(
+                                tensor_map_b_ptr, full_barriers[stage_idx],
+                                smem_b[stage_idx] + b_slice_idx * 256 * BLOCK_K,
+                                k_idx, n_idx + b_slice_idx * 256, 1);
+                        }
+                    }
+
+                    full_barriers[stage_idx]->arrive_and_expect_tx(SMEM_B_SIZE_PER_STAGE);
+                }
+                __syncwarp();
+            }
+        });
+
+    } else if (warp_idx < kNumDispatchWarps + kNumMMANonEpilogueWarps) {
+        // Idle non-epilogue warps (kNumDispatchWarps+2, +3). They must still
+        // participate in the warpgroup-collective `setmaxnreg.dec.sync.aligned`
+        // so that the math warpgroup's `warpgroup_reg_alloc` can succeed.
+        cutlass::arch::warpgroup_reg_dealloc<kNumNonEpilogueRegisters>();
+
+    } else if (warp_idx >= kNumDispatchWarps + kNumMMANonEpilogueWarps) {
+    // =====================================================================
+    // ROLE 3: MATH WARPGROUPS (WGMMA + epilogue + combine)
+    // =====================================================================
+        cutlass::arch::warpgroup_reg_alloc<kNumEpilogueRegisters>();
+
+        const uint32_t epilogue_warp_idx  = warp_idx - (kNumDispatchWarps + kNumMMANonEpilogueWarps);
+        const uint32_t epilogue_wg_idx    = epilogue_warp_idx / 4;
+        const uint32_t epilogue_thread_idx = epilogue_warp_idx * 32 + lane_idx;
+        const uint32_t warp_idx_in_wg     = epilogue_warp_idx % 4;
+
+        // WGMMA-output register layout helpers
+        const uint32_t row_idx = lane_idx / 4;
+        const uint32_t col_idx = lane_idx % 4;
+        const uint32_t r_0 = warp_idx_in_wg * 16 + row_idx;
+        const uint32_t r_1 = r_0 + 8;
+
+        // When the two N-split warpgroups share a single per-64 SF group they
+        // also stage into ONE shared row-major L1-output tile (stride
+        // L1_OUT_BLOCK_N), each writing its own WG_L1_OUT_BLOCK_N-column half,
+        // so a single combined TMA store matches the host descriptor box.
+        constexpr uint32_t WG_SMEM_CD_L1_STRIDE_N =
+            kSplitNSharesSF ? L1_OUT_BLOCK_N : WG_L1_OUT_BLOCK_N;
+        constexpr uint32_t WG_SMEM_CD_L2_STRIDE_N = WG_BLOCK_N;
+
+        // Sync with dispatch in the full communication path.
+        ptx::sync_unaligned(kNumDispatchThreads + kNumEpilogueThreads, kDispatchWithEpilogueBarrierIdx);
+
+        auto process_math_block = [&](const auto& block_phase,
+                                      const uint32_t& local_expert_idx,
+                                      const uint32_t& num_k_blocks,
+                                      const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
+            const uint32_t valid_m = scheduler.template get_valid_m<false>();
+            const uint32_t pool_block_idx = scheduler.get_current_pool_block_offset() + m_block_idx;
+            const uint32_t m_idx = pool_block_idx * BLOCK_M;
+            const uint32_t n_idx = n_block_idx * BLOCK_N;
+            const uint32_t epilogue_wg_m_idx = epilogue_wg_idx / kWarpgroupSplitN;
+            const uint32_t epilogue_wg_n_idx = epilogue_wg_idx - epilogue_wg_m_idx * kWarpgroupSplitN;
+            const uint32_t wg_n_offset = epilogue_wg_n_idx * WG_BLOCK_N;
+            const uint32_t wg_l1_out_n_offset = epilogue_wg_n_idx * WG_L1_OUT_BLOCK_N;
+            const uint32_t row_base = epilogue_wg_m_idx * WG_BLOCK_M;
+            const uint32_t row_offset_r0 = row_base + r_0;
+            const uint32_t row_offset_r1 = row_base + r_1;
+            const uint32_t sf_n_block_idx = kSplitNSharesSF ? n_block_idx
+                : (n_block_idx * kWarpgroupSplitN + epilogue_wg_n_idx);
+            const uint32_t smem_a_wg_offset = epilogue_wg_m_idx * WG_BLOCK_M * BLOCK_K;
+            const uint32_t smem_b_wg_offset = epilogue_wg_n_idx * WG_BLOCK_N * BLOCK_K;
+            // In the shared-tile case the WG stages into the joint L1-output tile
+            // at its own column offset (row stride L1_OUT_BLOCK_N); otherwise each
+            // WG owns a disjoint contiguous WG_BLOCK_M x WG_L1_OUT_BLOCK_N slice.
+            const uint32_t smem_cd_l1_wg_offset = kSplitNSharesSF ? wg_l1_out_n_offset
+                : (epilogue_wg_idx * WG_BLOCK_M * WG_L1_OUT_BLOCK_N);
+            const uint32_t smem_cd_l2_wg_offset = epilogue_wg_idx * WG_BLOCK_M * WG_BLOCK_N;
+            const bool valid_r0 = row_offset_r0 < valid_m;
+            const bool valid_r1 = row_offset_r1 < valid_m;
+
+            // ---------------- GEMM ----------------
+            using WGMMA = L1WGMMA;
+            constexpr uint32_t kAccumPerThread = WGMMA::kNumAccum;
+            float final_accum[kAccumPerThread] = {};
+
+            if constexpr (kReuseAccumAsFinal) {
+                auto prescale_l1_final = [&](const float& scale_a_0, const float& scale_a_1,
+                                             const float& gate_sf, const float& up_sf) {
+                    const float inv_s0_gate = kFastMath ? math::fast_rcp(scale_a_0 * gate_sf) : 1.0f / (scale_a_0 * gate_sf);
+                    const float inv_s1_gate = kFastMath ? math::fast_rcp(scale_a_1 * gate_sf) : 1.0f / (scale_a_1 * gate_sf);
+                    const float inv_s0_up = kFastMath ? math::fast_rcp(scale_a_0 * up_sf) : 1.0f / (scale_a_0 * up_sf);
+                    const float inv_s1_up = kFastMath ? math::fast_rcp(scale_a_1 * up_sf) : 1.0f / (scale_a_1 * up_sf);
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                        const float inv_s0 = (i & 1u) ? inv_s0_up : inv_s0_gate;
+                        const float inv_s1 = (i & 1u) ? inv_s1_up : inv_s1_gate;
+                        final_accum[i*4+0] *= inv_s0;
+                        final_accum[i*4+1] *= inv_s0;
+                        final_accum[i*4+2] *= inv_s1;
+                        final_accum[i*4+3] *= inv_s1;
+                    }
+                };
+                auto postscale_l1_final = [&](const float& scale_a_0, const float& scale_a_1,
+                                              const float& gate_sf, const float& up_sf) {
+                    const float s0_gate = scale_a_0 * gate_sf;
+                    const float s1_gate = scale_a_1 * gate_sf;
+                    const float s0_up = scale_a_0 * up_sf;
+                    const float s1_up = scale_a_1 * up_sf;
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                        const float s0 = (i & 1u) ? s0_up : s0_gate;
+                        const float s1 = (i & 1u) ? s1_up : s1_gate;
+                        final_accum[i*4+0] *= s0;
+                        final_accum[i*4+1] *= s0;
+                        final_accum[i*4+2] *= s1;
+                        final_accum[i*4+3] *= s1;
+                    }
+                };
+                auto prescale_l2_final = [&](const float& scale_a_0, const float& scale_a_1,
+                                             const float& l2_sf) {
+                    const float inv_s0 = kFastMath ? math::fast_rcp(scale_a_0 * l2_sf) : 1.0f / (scale_a_0 * l2_sf);
+                    const float inv_s1 = kFastMath ? math::fast_rcp(scale_a_1 * l2_sf) : 1.0f / (scale_a_1 * l2_sf);
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                        final_accum[i*4+0] *= inv_s0;
+                        final_accum[i*4+1] *= inv_s0;
+                        final_accum[i*4+2] *= inv_s1;
+                        final_accum[i*4+3] *= inv_s1;
+                    }
+                };
+                auto postscale_l2_final = [&](const float& scale_a_0, const float& scale_a_1,
+                                              const float& l2_sf) {
+                    const float s0 = scale_a_0 * l2_sf;
+                    const float s1 = scale_a_1 * l2_sf;
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                        final_accum[i*4+0] *= s0;
+                        final_accum[i*4+1] *= s0;
+                        final_accum[i*4+2] *= s1;
+                        final_accum[i*4+3] *= s1;
+                    }
+                };
+                auto rescale_l1_final = [&](const float& prev_scale_a_0, const float& prev_scale_a_1,
+                                            const float& prev_gate_sf, const float& prev_up_sf,
+                                            const float& scale_a_0, const float& scale_a_1,
+                                            const float& gate_sf, const float& up_sf) {
+                    const float r0_gate = (prev_scale_a_0 * prev_gate_sf) *
+                        (kFastMath ? math::fast_rcp(scale_a_0 * gate_sf) : 1.0f / (scale_a_0 * gate_sf));
+                    const float r1_gate = (prev_scale_a_1 * prev_gate_sf) *
+                        (kFastMath ? math::fast_rcp(scale_a_1 * gate_sf) : 1.0f / (scale_a_1 * gate_sf));
+                    const float r0_up = (prev_scale_a_0 * prev_up_sf) *
+                        (kFastMath ? math::fast_rcp(scale_a_0 * up_sf) : 1.0f / (scale_a_0 * up_sf));
+                    const float r1_up = (prev_scale_a_1 * prev_up_sf) *
+                        (kFastMath ? math::fast_rcp(scale_a_1 * up_sf) : 1.0f / (scale_a_1 * up_sf));
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                        const float r0 = (i & 1u) ? r0_up : r0_gate;
+                        const float r1 = (i & 1u) ? r1_up : r1_gate;
+                        final_accum[i*4+0] *= r0;
+                        final_accum[i*4+1] *= r0;
+                        final_accum[i*4+2] *= r1;
+                        final_accum[i*4+3] *= r1;
+                    }
+                };
+                auto rescale_l2_final = [&](const float& prev_scale_a_0, const float& prev_scale_a_1,
+                                            const float& prev_l2_sf,
+                                            const float& scale_a_0, const float& scale_a_1,
+                                            const float& l2_sf) {
+                    const float r0 = (prev_scale_a_0 * prev_l2_sf) *
+                        (kFastMath ? math::fast_rcp(scale_a_0 * l2_sf) : 1.0f / (scale_a_0 * l2_sf));
+                    const float r1 = (prev_scale_a_1 * prev_l2_sf) *
+                        (kFastMath ? math::fast_rcp(scale_a_1 * l2_sf) : 1.0f / (scale_a_1 * l2_sf));
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                        final_accum[i*4+0] *= r0;
+                        final_accum[i*4+1] *= r0;
+                        final_accum[i*4+2] *= r1;
+                        final_accum[i*4+3] *= r1;
+                    }
+                };
+                auto rescale_l2_act_final = [&](const float& prev_scale_a_0, const float& prev_scale_a_1,
+                                                const float& scale_a_0, const float& scale_a_1) {
+                    const float r0 = prev_scale_a_0 * (kFastMath ? math::fast_rcp(scale_a_0) : 1.0f / scale_a_0);
+                    const float r1 = prev_scale_a_1 * (kFastMath ? math::fast_rcp(scale_a_1) : 1.0f / scale_a_1);
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                        final_accum[i*4+0] *= r0;
+                        final_accum[i*4+1] *= r0;
+                        final_accum[i*4+2] *= r1;
+                        final_accum[i*4+3] *= r1;
+                    }
+                };
+
+                if constexpr (kHidden >= 7168) {
+                    float prev_scale_a_0 = 1.0f, prev_scale_a_1 = 1.0f;
+                    float prev_gate_sf = 1.0f, prev_up_sf = 1.0f, prev_l2_sf = 1.0f;
+                    for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
+                        full_barriers[stage_idx]->wait(phase);
+
+                        float scale_a_0_lo, scale_a_1_lo;
+                        float scale_a_0_hi, scale_a_1_hi;
+                        if (block_phase == sched::BlockPhase::Linear1) {
+                            scale_a_0_lo = ptx::ld_shared(smem_sfa[stage_idx] + row_offset_r0);
+                            scale_a_1_lo = ptx::ld_shared(smem_sfa[stage_idx] + row_offset_r1);
+                        } else {
+                            scale_a_0_lo = ptx::ld_shared(smem_sfa[stage_idx] + 0 * BLOCK_M + row_offset_r0);
+                            scale_a_1_lo = ptx::ld_shared(smem_sfa[stage_idx] + 0 * BLOCK_M + row_offset_r1);
+                            scale_a_0_hi = ptx::ld_shared(smem_sfa[stage_idx] + 1 * BLOCK_M + row_offset_r0);
+                            scale_a_1_hi = ptx::ld_shared(smem_sfa[stage_idx] + 1 * BLOCK_M + row_offset_r1);
+                        }
+
+                        constexpr uint32_t kL1SFKBlocks   = kHidden / 128;
+                        constexpr uint32_t kL2SFKBlocks   = kIntermediateHidden / 128;
+                        constexpr uint32_t kL1SFGateBlks  = kIntermediateHidden / 128;
+                        constexpr uint32_t kL1SFPerExpert = (kIntermediateHidden * 2 / 128) * kL1SFKBlocks;
+                        constexpr uint32_t kL2SFPerExpert = (kHidden / 128) * kL2SFKBlocks;
+                        float gate_sf = 0.0f, up_sf = 0.0f, l2_sf = 0.0f;
+                        if (block_phase == sched::BlockPhase::Linear1) {
+                            const uint32_t gate_n = sf_n_block_idx / 2u;
+                            const uint32_t up_n   = kL1SFGateBlks + gate_n;
+                            const float* base = l1_weights_sf + local_expert_idx * kL1SFPerExpert + k_block_idx;
+                            gate_sf = __ldg(base + gate_n * kL1SFKBlocks);
+                            up_sf   = __ldg(base + up_n   * kL1SFKBlocks);
+                        } else {
+                            l2_sf = __ldg(l2_weights_sf + local_expert_idx * kL2SFPerExpert
+                                                        + sf_n_block_idx * kL2SFKBlocks + k_block_idx);
+                        }
+
+                        if (block_phase == sched::BlockPhase::Linear1) {
+                            if (k_block_idx != 0)
+                                rescale_l1_final(prev_scale_a_0, prev_scale_a_1,
+                                                 prev_gate_sf, prev_up_sf,
+                                                 scale_a_0_lo, scale_a_1_lo,
+                                                 gate_sf, up_sf);
+
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_arrive();
+                            #pragma unroll
+                            for (uint32_t k = 0; k < BLOCK_K / WGMMA::K; ++ k) {
+                                auto desc_a = mma::sm90::make_smem_desc(
+                                    smem_a[stage_idx] + smem_a_wg_offset + k * WGMMA::K, 1);
+                                auto desc_b = mma::sm90::make_smem_desc(
+                                    smem_b[stage_idx] + smem_b_wg_offset + k * WGMMA::K, 1);
+                                WGMMA::wgmma(desc_a, desc_b, final_accum, true);
+                            }
+                            ptx::warpgroup_commit_batch();
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_wait<0>();
+
+                            if (lane_idx == 0)
+                                empty_barriers[stage_idx]->arrive();
+
+                            prev_scale_a_0 = scale_a_0_lo;
+                            prev_scale_a_1 = scale_a_1_lo;
+                            prev_gate_sf = gate_sf;
+                            prev_up_sf = up_sf;
+                        } else {
+                            if (k_block_idx != 0)
+                                rescale_l2_final(prev_scale_a_0, prev_scale_a_1, prev_l2_sf,
+                                                 scale_a_0_lo, scale_a_1_lo, l2_sf);
+
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_arrive();
+                            #pragma unroll
+                            for (uint32_t k = 0; k < (BLOCK_K / 2) / WGMMA::K; ++ k) {
+                                auto desc_a = mma::sm90::make_smem_desc(
+                                    smem_a[stage_idx] + smem_a_wg_offset + k * WGMMA::K, 1);
+                                auto desc_b = mma::sm90::make_smem_desc(
+                                    smem_b[stage_idx] + smem_b_wg_offset + k * WGMMA::K, 1);
+                                WGMMA::wgmma(desc_a, desc_b, final_accum, true);
+                            }
+                            ptx::warpgroup_commit_batch();
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_wait<0>();
+
+                            rescale_l2_act_final(scale_a_0_lo, scale_a_1_lo,
+                                                 scale_a_0_hi, scale_a_1_hi);
+
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_arrive();
+                            #pragma unroll
+                            for (uint32_t k = 0; k < (BLOCK_K / 2) / WGMMA::K; ++ k) {
+                                const uint32_t k_off = (BLOCK_K / 2) + k * WGMMA::K;
+                                auto desc_a = mma::sm90::make_smem_desc(
+                                    smem_a[stage_idx] + smem_a_wg_offset + k_off, 1);
+                                auto desc_b = mma::sm90::make_smem_desc(
+                                    smem_b[stage_idx] + smem_b_wg_offset + k_off, 1);
+                                WGMMA::wgmma(desc_a, desc_b, final_accum, true);
+                            }
+                            ptx::warpgroup_commit_batch();
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_wait<0>();
+
+                            if (lane_idx == 0)
+                                empty_barriers[stage_idx]->arrive();
+
+                            prev_scale_a_0 = scale_a_0_hi;
+                            prev_scale_a_1 = scale_a_1_hi;
+                            prev_l2_sf = l2_sf;
+                        }
+                    }
+
+                    if (num_k_blocks != 0) {
+                        if (block_phase == sched::BlockPhase::Linear1) {
+                            postscale_l1_final(prev_scale_a_0, prev_scale_a_1,
+                                               prev_gate_sf, prev_up_sf);
+                        } else {
+                            postscale_l2_final(prev_scale_a_0, prev_scale_a_1, prev_l2_sf);
+                        }
+                    }
+                } else {
+                    for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
+                        full_barriers[stage_idx]->wait(phase);
+
+                        float scale_a_0_lo, scale_a_1_lo;
+                        float scale_a_0_hi, scale_a_1_hi;
+                        if (block_phase == sched::BlockPhase::Linear1) {
+                            scale_a_0_lo = ptx::ld_shared(smem_sfa[stage_idx] + row_offset_r0);
+                            scale_a_1_lo = ptx::ld_shared(smem_sfa[stage_idx] + row_offset_r1);
+                        } else {
+                            scale_a_0_lo = ptx::ld_shared(smem_sfa[stage_idx] + 0 * BLOCK_M + row_offset_r0);
+                            scale_a_1_lo = ptx::ld_shared(smem_sfa[stage_idx] + 0 * BLOCK_M + row_offset_r1);
+                            scale_a_0_hi = ptx::ld_shared(smem_sfa[stage_idx] + 1 * BLOCK_M + row_offset_r0);
+                            scale_a_1_hi = ptx::ld_shared(smem_sfa[stage_idx] + 1 * BLOCK_M + row_offset_r1);
+                        }
+
+                        constexpr uint32_t kL1SFKBlocks   = kHidden / 128;
+                        constexpr uint32_t kL2SFKBlocks   = kIntermediateHidden / 128;
+                        constexpr uint32_t kL1SFGateBlks  = kIntermediateHidden / 128;
+                        constexpr uint32_t kL1SFPerExpert = (kIntermediateHidden * 2 / 128) * kL1SFKBlocks;
+                        constexpr uint32_t kL2SFPerExpert = (kHidden / 128) * kL2SFKBlocks;
+                        float gate_sf = 0.0f, up_sf = 0.0f, l2_sf = 0.0f;
+                        if (block_phase == sched::BlockPhase::Linear1) {
+                            const uint32_t gate_n = sf_n_block_idx / 2u;
+                            const uint32_t up_n   = kL1SFGateBlks + gate_n;
+                            const float* base = l1_weights_sf + local_expert_idx * kL1SFPerExpert + k_block_idx;
+                            gate_sf = __ldg(base + gate_n * kL1SFKBlocks);
+                            up_sf   = __ldg(base + up_n   * kL1SFKBlocks);
+                        } else {
+                            l2_sf = __ldg(l2_weights_sf + local_expert_idx * kL2SFPerExpert
+                                                        + sf_n_block_idx * kL2SFKBlocks + k_block_idx);
+                        }
+
+                        if (block_phase == sched::BlockPhase::Linear1) {
+                            if (k_block_idx != 0)
+                                prescale_l1_final(scale_a_0_lo, scale_a_1_lo, gate_sf, up_sf);
+
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_arrive();
+                            #pragma unroll
+                            for (uint32_t k = 0; k < BLOCK_K / WGMMA::K; ++ k) {
+                                auto desc_a = mma::sm90::make_smem_desc(
+                                    smem_a[stage_idx] + smem_a_wg_offset + k * WGMMA::K, 1);
+                                auto desc_b = mma::sm90::make_smem_desc(
+                                    smem_b[stage_idx] + smem_b_wg_offset + k * WGMMA::K, 1);
+                                WGMMA::wgmma(desc_a, desc_b, final_accum, true);
+                            }
+                            ptx::warpgroup_commit_batch();
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_wait<0>();
+
+                            if (lane_idx == 0)
+                                empty_barriers[stage_idx]->arrive();
+
+                            postscale_l1_final(scale_a_0_lo, scale_a_1_lo, gate_sf, up_sf);
+                        } else {
+                            if (k_block_idx != 0)
+                                prescale_l2_final(scale_a_0_lo, scale_a_1_lo, l2_sf);
+
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_arrive();
+                            #pragma unroll
+                            for (uint32_t k = 0; k < (BLOCK_K / 2) / WGMMA::K; ++ k) {
+                                auto desc_a = mma::sm90::make_smem_desc(
+                                    smem_a[stage_idx] + smem_a_wg_offset + k * WGMMA::K, 1);
+                                auto desc_b = mma::sm90::make_smem_desc(
+                                    smem_b[stage_idx] + smem_b_wg_offset + k * WGMMA::K, 1);
+                                WGMMA::wgmma(desc_a, desc_b, final_accum, true);
+                            }
+                            ptx::warpgroup_commit_batch();
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_wait<0>();
+
+                            postscale_l2_final(scale_a_0_lo, scale_a_1_lo, l2_sf);
+                            prescale_l2_final(scale_a_0_hi, scale_a_1_hi, l2_sf);
+
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_arrive();
+                            #pragma unroll
+                            for (uint32_t k = 0; k < (BLOCK_K / 2) / WGMMA::K; ++ k) {
+                                const uint32_t k_off = (BLOCK_K / 2) + k * WGMMA::K;
+                                auto desc_a = mma::sm90::make_smem_desc(
+                                    smem_a[stage_idx] + smem_a_wg_offset + k_off, 1);
+                                auto desc_b = mma::sm90::make_smem_desc(
+                                    smem_b[stage_idx] + smem_b_wg_offset + k_off, 1);
+                                WGMMA::wgmma(desc_a, desc_b, final_accum, true);
+                            }
+                            ptx::warpgroup_commit_batch();
+                            #pragma unroll
+                            for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(final_accum[i]);
+                            ptx::warpgroup_wait<0>();
+
+                            if (lane_idx == 0)
+                                empty_barriers[stage_idx]->arrive();
+
+                            postscale_l2_final(scale_a_0_hi, scale_a_1_hi, l2_sf);
+                        }
+                    }
+                }
+            } else {
+                float accum[kAccumPerThread];
+
+                for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
+                    full_barriers[stage_idx]->wait(phase);
+
+                    // Read SF (must precede warpgroup_arrive)
+                    float scale_a_0_lo, scale_a_1_lo;
+                    float scale_a_0_hi, scale_a_1_hi;  // Only used in L2 (per-64 K)
+                    if (block_phase == sched::BlockPhase::Linear1) {
+                        scale_a_0_lo = ptx::ld_shared(smem_sfa[stage_idx] + row_offset_r0);
+                        scale_a_1_lo = ptx::ld_shared(smem_sfa[stage_idx] + row_offset_r1);
+                    } else {
+                        // L2: SFA layout is (K=2, M=BLOCK_M) MN-major; first half SF at offset 0, second at BLOCK_M
+                        scale_a_0_lo = ptx::ld_shared(smem_sfa[stage_idx] + 0 * BLOCK_M + row_offset_r0);
+                        scale_a_1_lo = ptx::ld_shared(smem_sfa[stage_idx] + 0 * BLOCK_M + row_offset_r1);
+                        scale_a_0_hi = ptx::ld_shared(smem_sfa[stage_idx] + 1 * BLOCK_M + row_offset_r0);
+                        scale_a_1_hi = ptx::ld_shared(smem_sfa[stage_idx] + 1 * BLOCK_M + row_offset_r1);
+                    }
+
+                    // ----- Block (128, 128) weight SF (loaded directly from global) -----
+                    // L1 weight SF shape: (E, 2*IH/128, H/128) MN-major. The N axis is
+                    // [gate(IH/128), up(IH/128)]; with the gate/up gran-8 interleave on
+                    // the FP8 weight, each logical 128-wide N tile covers 64 rows of gate
+                    // plus 64 rows of up taken from the same original 128-row block, so:
+                    //     gate_sf_n = sf_n_block_idx / 2
+                    //     up_sf_n   = (IH/128) + sf_n_block_idx / 2
+                    //
+                    // L2 weight SF shape: (E, H/128, IH/128) MN-major. One scalar per
+                    // logical 128x128 weight-SF tile, broadcast across the matching
+                    // WGMMA accumulators.
+                    //
+                    // Load the weight scale after the barrier from all WG threads.
+                    // This keeps scale loads close to their WGMMA use and lets the
+                    // read-only cache coalesce the same-address accesses.
+                    constexpr uint32_t kL1SFKBlocks   = kHidden / 128;
+                    constexpr uint32_t kL2SFKBlocks   = kIntermediateHidden / 128;
+                    constexpr uint32_t kL1SFGateBlks  = kIntermediateHidden / 128;
+                    constexpr uint32_t kL1SFPerExpert = (kIntermediateHidden * 2 / 128) * kL1SFKBlocks;
+                    constexpr uint32_t kL2SFPerExpert = (kHidden / 128) * kL2SFKBlocks;
+                    float gate_sf = 0.0f, up_sf = 0.0f, l2_sf = 0.0f;
+                    if (block_phase == sched::BlockPhase::Linear1) {
+                        const uint32_t gate_n = sf_n_block_idx / 2u;
+                        const uint32_t up_n   = kL1SFGateBlks + gate_n;
+                        const float* base = l1_weights_sf + local_expert_idx * kL1SFPerExpert + k_block_idx;
+                        gate_sf = __ldg(base + gate_n * kL1SFKBlocks);
+                        up_sf   = __ldg(base + up_n   * kL1SFKBlocks);
+                    } else {
+                        l2_sf = __ldg(l2_weights_sf + local_expert_idx * kL2SFPerExpert
+                                                    + sf_n_block_idx * kL2SFKBlocks + k_block_idx);
+                    }
+
+                    if (block_phase == sched::BlockPhase::Linear1) {
+                        // Single per-128 K-block WGMMA group
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(accum[i]);
+                        ptx::warpgroup_arrive();
+                        #pragma unroll
+                        for (uint32_t k = 0; k < BLOCK_K / WGMMA::K; ++ k) {
+                            auto desc_a = mma::sm90::make_smem_desc(
+                                smem_a[stage_idx] + smem_a_wg_offset + k * WGMMA::K, 1);
+                            auto desc_b = mma::sm90::make_smem_desc(
+                                smem_b[stage_idx] + smem_b_wg_offset + k * WGMMA::K, 1);
+                            WGMMA::wgmma(desc_a, desc_b, accum, k);
+                        }
+                        ptx::warpgroup_commit_batch();
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(accum[i]);
+                        ptx::warpgroup_wait<0>();
+
+                        if (lane_idx == 0)
+                            empty_barriers[stage_idx]->arrive();
+
+                        // L1: gate/up alternate at gran=8 along N; each `i` block of 8
+                        // cols belongs entirely to one of {gate, up}, so .x and .y
+                        // share the same scalar.
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                            const float sb = (i & 1u) ? up_sf : gate_sf;
+                            final_accum[i*4+0] += scale_a_0_lo * sb * accum[i*4+0];
+                            final_accum[i*4+1] += scale_a_0_lo * sb * accum[i*4+1];
+                            final_accum[i*4+2] += scale_a_1_lo * sb * accum[i*4+2];
+                            final_accum[i*4+3] += scale_a_1_lo * sb * accum[i*4+3];
+                        }
+                    } else {
+                        // L2: split BLOCK_K=128 into two halves (per-64 SFA), each 2 WGMMAs.
+                        // First half: K=0..63, SFA = scale_a_*_lo
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(accum[i]);
+                        ptx::warpgroup_arrive();
+                        #pragma unroll
+                        for (uint32_t k = 0; k < (BLOCK_K / 2) / WGMMA::K; ++ k) {
+                            auto desc_a = mma::sm90::make_smem_desc(
+                                smem_a[stage_idx] + smem_a_wg_offset + k * WGMMA::K, 1);
+                            auto desc_b = mma::sm90::make_smem_desc(
+                                smem_b[stage_idx] + smem_b_wg_offset + k * WGMMA::K, 1);
+                            WGMMA::wgmma(desc_a, desc_b, accum, k);
+                        }
+                        ptx::warpgroup_commit_batch();
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(accum[i]);
+                        ptx::warpgroup_wait<0>();
+
+                        // L2 first half: single scalar `l2_sf` broadcast across N.
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                            final_accum[i*4+0] += scale_a_0_lo * l2_sf * accum[i*4+0];
+                            final_accum[i*4+1] += scale_a_0_lo * l2_sf * accum[i*4+1];
+                            final_accum[i*4+2] += scale_a_1_lo * l2_sf * accum[i*4+2];
+                            final_accum[i*4+3] += scale_a_1_lo * l2_sf * accum[i*4+3];
+                        }
+
+                        // Second half: K=64..127, SFA = scale_a_*_hi
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(accum[i]);
+                        ptx::warpgroup_arrive();
+                        #pragma unroll
+                        for (uint32_t k = 0; k < (BLOCK_K / 2) / WGMMA::K; ++ k) {
+                            const uint32_t k_off = (BLOCK_K / 2) + k * WGMMA::K;
+                            auto desc_a = mma::sm90::make_smem_desc(
+                                smem_a[stage_idx] + smem_a_wg_offset + k_off, 1);
+                            auto desc_b = mma::sm90::make_smem_desc(
+                                smem_b[stage_idx] + smem_b_wg_offset + k_off, 1);
+                            WGMMA::wgmma(desc_a, desc_b, accum, k);
+                        }
+                        ptx::warpgroup_commit_batch();
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread; ++ i) ptx::warpgroup_fence_operand(accum[i]);
+                        ptx::warpgroup_wait<0>();
+
+                        if (lane_idx == 0)
+                            empty_barriers[stage_idx]->arrive();
+
+                        // L2 second half: same broadcast scalar `l2_sf`.
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kAccumPerThread / 4; ++ i) {
+                            final_accum[i*4+0] += scale_a_0_hi * l2_sf * accum[i*4+0];
+                            final_accum[i*4+1] += scale_a_0_hi * l2_sf * accum[i*4+1];
+                            final_accum[i*4+2] += scale_a_1_hi * l2_sf * accum[i*4+2];
+                            final_accum[i*4+3] += scale_a_1_hi * l2_sf * accum[i*4+3];
+                        }
+                    }
+                }
+            }
+
+            // Skip epilogue when block is past valid M (still must release via empty)
+            if (row_base >= valid_m) {
+                if (block_phase == sched::BlockPhase::Linear1) {
+                    if constexpr (not kL2ArrivalCounter)
+                        ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                } else {
+                    if constexpr (kL2EpilogueRequiresFullSync)
+                        ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                }
+                return;
+            }
+
+            if (block_phase == sched::BlockPhase::Linear1) {
+
+                // ---------------- L1 EPILOGUE: activation + FP8 quantize + TMA store ----------------
+                // Layout in `final_accum`:
+                //   kAccumPerThread/4 chunks, each chunk = 4 floats per thread =
+                //   (r0c0, r0c1, r1c0, r1c1).
+                //   Gate and up chunks alternate; pair `p` uses chunks 2p and 2p+1.
+                //
+                // For each pair we produce 4 post-SwiGLU floats per thread, mapped to
+                // output cols (p*8 + col_idx*2 + {0,1}) for both r0 and r1.
+
+                constexpr uint32_t kNumPairs = kAccumPerThread / 8;
+                float sf_r0, sf_inv_r0;
+                float sf_r1, sf_inv_r1;
+
+                float swiglu_r0[kNumPairs][2];
+                float swiglu_r1[kNumPairs][2];
+                float amax_r0 = 0.0f, amax_r1 = 0.0f;
+
+                auto clamp_gate = [](float& x) {
+                    if constexpr (kActivationClamp != cute::numeric_limits<float>::infinity())
+                        x = cute::min(x, kActivationClamp);
+                };
+                auto clamp_up = [](float& x) {
+                    if constexpr (kActivationClamp != cute::numeric_limits<float>::infinity())
+                        x = cute::min(cute::max(x, -kActivationClamp), kActivationClamp);
+                };
+                auto silu = [](float x) -> float {
+                    const float e = kFastMath ? __expf(-x) : expf(-x);
+                    const float sig = kFastMath ? math::fast_rcp(1.0f + e) : 1.0f / (1.0f + e);
+                    return x * sig;
+                };
+
+                #pragma unroll
+                for (uint32_t p = 0; p < kNumPairs; ++ p) {
+                    const uint32_t gate = 2 * p, up = 2 * p + 1;
+
+                    float g_r0_c0 = final_accum[gate*4 + 0];
+                    float g_r0_c1 = final_accum[gate*4 + 1];
+                    float g_r1_c0 = final_accum[gate*4 + 2];
+                    float g_r1_c1 = final_accum[gate*4 + 3];
+                    float u_r0_c0 = final_accum[up*4   + 0];
+                    float u_r0_c1 = final_accum[up*4   + 1];
+                    float u_r1_c0 = final_accum[up*4   + 2];
+                    float u_r1_c1 = final_accum[up*4   + 3];
+                    clamp_gate(g_r0_c0);
+                    clamp_gate(g_r0_c1);
+                    clamp_gate(g_r1_c0);
+                    clamp_gate(g_r1_c1);
+                    clamp_up(u_r0_c0);
+                    clamp_up(u_r0_c1);
+                    clamp_up(u_r1_c0);
+                    clamp_up(u_r1_c1);
+
+                    if (valid_r0) {
+                        swiglu_r0[p][0] = silu(g_r0_c0) * u_r0_c0;
+                        swiglu_r0[p][1] = silu(g_r0_c1) * u_r0_c1;
+                        amax_r0 = cute::max(amax_r0, cute::max(cute::abs(swiglu_r0[p][0]), cute::abs(swiglu_r0[p][1])));
+                    } else {
+                        swiglu_r0[p][0] = 0.0f;
+                        swiglu_r0[p][1] = 0.0f;
+                    }
+                    if (valid_r1) {
+                        swiglu_r1[p][0] = silu(g_r1_c0) * u_r1_c0;
+                        swiglu_r1[p][1] = silu(g_r1_c1) * u_r1_c1;
+                        amax_r1 = cute::max(amax_r1, cute::max(cute::abs(swiglu_r1[p][0]), cute::abs(swiglu_r1[p][1])));
+                    } else {
+                        swiglu_r1[p][0] = 0.0f;
+                        swiglu_r1[p][1] = 0.0f;
+                    }
+                }
+
+                // Apply token weight: SwiGLU * topk_weight (single load per row)
+                const float weight_r0 = valid_r0 ? *l1_topk_weights_buffer
+                    .get_data_buffer(m_idx + row_offset_r0)
+                    .get_base_ptr<float>() : 0.0f;
+                const float weight_r1 = valid_r1 ? *l1_topk_weights_buffer
+                    .get_data_buffer(m_idx + row_offset_r1)
+                    .get_base_ptr<float>() : 0.0f;
+                #pragma unroll
+                for (uint32_t p = 0; p < kNumPairs; ++ p) {
+                    swiglu_r0[p][0] *= weight_r0;
+                    swiglu_r0[p][1] *= weight_r0;
+                    swiglu_r1[p][0] *= weight_r1;
+                    swiglu_r1[p][1] *= weight_r1;
+                }
+
+                amax_r0 *= cute::abs(weight_r0);
+                amax_r1 *= cute::abs(weight_r1);
+
+                // Reduce amax across the 4 col-lanes that share the same row. In the
+                // SM90 WGMMA output layout, lanes with the same `lane_idx >> 2` and
+                // different `lane_idx & 3` partition the WG-owned output columns for
+                // the same r_0/r_1, so this is an INTRA-group reduction
+                // (`warp_reduce<4, false>`). Using `<4, true>` would instead merge
+                // amax across 8 different rows -- giving wrong per-row SF.
+                amax_r0 = math::warp_reduce<4, false>(amax_r0, math::ReduceMax<float>());
+                amax_r1 = math::warp_reduce<4, false>(amax_r1, math::ReduceMax<float>());
+
+                // Phase 2: cross-WG amax. When two N-split warpgroups share one
+                // per-64 SF group, each WG so far only saw its own
+                // WG_L1_OUT_BLOCK_N columns; the true per-row amax spans both
+                // halves. Reduce across both warpgroups through a small smem
+                // scratch (carved from the upper, currently-unused half of the
+                // CD staging region) so BOTH WGs quantize with the SAME SF.
+                if constexpr (kSplitNSharesSF) {
+                    float* amax_scratch = reinterpret_cast<float*>(
+                        reinterpret_cast<uint8_t*>(smem_cd_l1) + SMEM_CD_SIZE / 2);
+                    #pragma unroll
+                    for (uint32_t i = epilogue_thread_idx; i < BLOCK_M; i += kNumEpilogueThreads)
+                        amax_scratch[i] = 0.0f;
+                    ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                    if (col_idx == 0) {
+                        atomicMax(reinterpret_cast<unsigned int*>(&amax_scratch[r_0]), __float_as_uint(amax_r0));
+                        atomicMax(reinterpret_cast<unsigned int*>(&amax_scratch[r_1]), __float_as_uint(amax_r1));
+                    }
+                    ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                    amax_r0 = amax_scratch[r_0];
+                    amax_r1 = amax_scratch[r_1];
+                    ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                }
+
+                // Compute SF and inverse SF for each row
+                float2 amax_pair = {amax_r0, amax_r1};
+                float2 sf_pair, sf_inv_pair;
+                sm90_fp8_mega_moe_get_e4m3_sf_and_sf_inv(amax_pair, sf_pair, sf_inv_pair);
+                sf_r0 = sf_pair.x; sf_inv_r0 = sf_inv_pair.x;
+                sf_r1 = sf_pair.y; sf_inv_r1 = sf_inv_pair.y;
+
+                // Quantize and write to the shared-memory staging tile.
+                auto* smem_cd_l1_wg = smem_cd_l1 + smem_cd_l1_wg_offset;
+                DG_STATIC_ASSERT(kNumPairs % 2 == 0, "L1 staging stores two 8-byte chunks at once");
+                #pragma unroll
+                for (uint32_t p_base = 0; p_base < kNumPairs; p_base += 2) {
+                    uint16_t r0_bits[2], r1_bits[2];
+                    #pragma unroll
+                    for (uint32_t q = 0; q < 2; ++ q) {
+                        const uint32_t p = p_base + q;
+                        const float v00 = swiglu_r0[p][0] * sf_inv_r0;
+                        const float v01 = swiglu_r0[p][1] * sf_inv_r0;
+                        const float v10 = swiglu_r1[p][0] * sf_inv_r1;
+                        const float v11 = swiglu_r1[p][1] * sf_inv_r1;
+
+                        const __nv_fp8x2_e4m3 r0_pair(make_float2(v00, v01));
+                        const __nv_fp8x2_e4m3 r1_pair(make_float2(v10, v11));
+                        r0_bits[q] = valid_r0 ? r0_pair.__x : 0u;
+                        r1_bits[q] = valid_r1 ? r1_pair.__x : 0u;
+                    }
+
+                    #pragma unroll
+                    for (uint32_t q = 0; q < 2; ++ q) {
+                        const uint32_t p = p_base + q;
+                        const uint32_t col = p * 8 + col_idx * 2;
+                        auto* p0 = reinterpret_cast<uint16_t*>(
+                            smem_cd_l1_wg + r_0 * WG_SMEM_CD_L1_STRIDE_N + col);
+                        auto* p1 = reinterpret_cast<uint16_t*>(
+                            smem_cd_l1_wg + r_1 * WG_SMEM_CD_L1_STRIDE_N + col);
+                        if (valid_r0)
+                            *p0 = r0_bits[q];
+                        if (valid_r1)
+                            *p1 = r1_bits[q];
+                    }
+                }
+
+                // Write SF as float at `[token, n_block_idx]` in L2 acts SF buffer (per-64 layout).
+                // Each row is contributed by lanes col_idx in {0..3}; only col_idx == 0 writes.
+                // In the shared-SF split both warpgroups own the same per-64 group and rows, so
+                // only the first N-split warpgroup publishes the SF slot to avoid a write race.
+                if (col_idx == 0 and (not kSplitNSharesSF or epilogue_wg_n_idx == 0)) {
+                    auto sf_base_ptr = l2_sf_buffer.get_base_ptr<float>();
+                    // SF buffer is (kNumPaddedSFPoolTokens x kIntermediateHidden/64), MN-major:
+                    //   addr[k_idx * num_padded_sf_pool_tokens + token_idx]
+                    const uint32_t token_r0 = pool_block_idx * BLOCK_M + row_offset_r0;
+                    const uint32_t token_r1 = pool_block_idx * BLOCK_M + row_offset_r1;
+                    const uint32_t k_sf_idx = sf_n_block_idx;  // one per-64 post-SwiGLU group
+                    if (valid_r0)
+                        sf_base_ptr[k_sf_idx * kNumPaddedSFPoolTokens + token_r0] = sf_r0;
+                    if (valid_r1)
+                        sf_base_ptr[k_sf_idx * kNumPaddedSFPoolTokens + token_r1] = sf_r1;
+                }
+
+                // Sync the warpgroup before TMA store. In the shared-tile split
+                // both N-split warpgroups must finish writing their halves of the
+                // joint L1-output tile, so sync across all epilogue threads.
+                if constexpr (kSplitNSharesSF)
+                    ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                else
+                    ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                // Issue TMA store of the entire tile. Padding rows beyond
+                // `valid_m` are written with stale/garbage FP8 to the L1-output
+                // pool buffer, but they are never consumed downstream: the L2
+                // GEMM tile loads them, but its NVLink-scatter epilogue is
+                // gated by `m_idx_in_block >= valid_m`, and stale SF in the
+                // padding rows can produce NaN accumulators that simply stay
+                // in registers (only valid rows are converted to BF16 and
+                // STSM'd into smem). Using TMA for partial tiles is a large
+                // win for low-batch / decode where every tile is partial.
+                if constexpr (kSplitNSharesSF) {
+                    // One combined store of the joint L1_OUT_BLOCK_N tile, issued
+                    // by the first N-split warpgroup once both halves are staged.
+                    if (epilogue_wg_n_idx == 0 and warp_idx_in_wg == 0 and cute::elect_one_sync()) {
+                        const uint32_t out_n_idx = n_block_idx * L1_OUT_BLOCK_N;
+                        cute::tma_store_fence();
+                        cute::SM90_TMA_STORE_2D::copy(
+                            &tensor_map_l1_output,
+                            smem_cd_l1,
+                            out_n_idx,
+                            m_idx + row_base);
+                        cute::tma_store_arrive();
+                    }
+                } else {
+                    if (warp_idx_in_wg == 0 and cute::elect_one_sync()) {
+                        const uint32_t out_n_idx = n_block_idx * L1_OUT_BLOCK_N + wg_l1_out_n_offset;
+                        cute::tma_store_fence();
+                        cute::SM90_TMA_STORE_2D::copy(
+                            &tensor_map_l1_output,
+                            smem_cd_l1 + smem_cd_l1_wg_offset,
+                            out_n_idx,
+                            m_idx + row_base);
+                        cute::tma_store_arrive();
+                    }
+                }
+                __syncwarp();
+                ptx::tma_store_wait<0>();
+
+                // Notify L2 that this L1 output (and SF) is ready. Counter mode lets
+                // independent WG tiles publish arrivals without the CTA-wide barrier
+                // needed before the single bit-mask update.
+                if constexpr (kL2ArrivalCounter) {
+                    if constexpr (kSplitNSharesSF) {
+                        // The combined tile counts for both N-split warpgroups; the
+                        // storing warpgroup publishes all kWarpgroupSplitN arrivals
+                        // after its TMA store has drained.
+                        if (epilogue_wg_n_idx == 0 and warp_idx_in_wg == 0 and cute::elect_one_sync()) {
+                            ptx::red_add_rel(
+                                reinterpret_cast<uint32_t*>(workspace.get_l2_arrival_mask_ptr(pool_block_idx)),
+                                kWarpgroupSplitN);
+                        }
+                    } else if (warp_idx_in_wg == 0 and cute::elect_one_sync()) {
+                        ptx::red_add_rel(
+                            reinterpret_cast<uint32_t*>(workspace.get_l2_arrival_mask_ptr(pool_block_idx)), 1);
+                    }
+                } else {
+                    ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                    if (epilogue_warp_idx == 0 and cute::elect_one_sync()) {
+                        ptx::red_or_rel_gpu(
+                            workspace.get_l2_arrival_mask_ptr(pool_block_idx),
+                            1ull << n_block_idx);
+                    }
+                }
+                __syncwarp();
+                // In the shared-tile split only the first warpgroup issues and
+                // drains the combined TMA store; gate the other warpgroup so it
+                // cannot overwrite the joint smem tile in the next block until
+                // that store has drained.
+                if constexpr (kSplitNSharesSF)
+                    ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+            } else {
+                // ---------------- L2 EPILOGUE: BF16 cast + NVLink scatter ----------------
+                constexpr uint32_t kNumRowsPerWarp = WG_BLOCK_M / 8;
+
+                const uint32_t row_in_warp_block = lane_idx / 16;  // 0 or 1
+                const uint32_t lane_in_row = lane_idx % 16;
+                const uint32_t cols_per_lane = WG_BLOCK_N / 16;
+
+                // STSM into smem_cd_l2 (BF16). Reuse SM100 column-swizzle layout.
+                #pragma unroll
+                for (uint32_t i = 0; i < kAccumPerThread / 8; ++ i) {
+                    // Each i consumes 8 floats (one 16x256b chunk in SM100 terms).
+                    // For SM90 WGMMA layout, 8 floats per i correspond to 2 chunks of 4 floats:
+                    //   final_accum[i*8 + (0..3)] = chunk 2i: (r0c0, r0c1, r1c0, r1c1)
+                    //   final_accum[i*8 + (4..7)] = chunk 2i+1: same shape
+                    const uint32_t chunk_lo = 2 * i, chunk_hi = 2 * i + 1;
+
+                    auto write_pair = [&](uint32_t row, uint32_t col, uint32_t packed) {
+                        auto smem_ptr = smem_cd_l2
+                            + smem_cd_l2_wg_offset
+                            + row * WG_BLOCK_N
+                            + col;
+                        // BF16 STS: 2 bf16 elements
+                        *reinterpret_cast<uint32_t*>(smem_ptr) = packed;
+                    };
+                    if (valid_r0) {
+                        const uint32_t r0_lo = math::cast_into_bf16_and_pack(
+                            final_accum[chunk_lo*4 + 0], final_accum[chunk_lo*4 + 1]);
+                        const uint32_t r0_hi = math::cast_into_bf16_and_pack(
+                            final_accum[chunk_hi*4 + 0], final_accum[chunk_hi*4 + 1]);
+                        write_pair(r_0, chunk_lo * 8 + col_idx * 2, r0_lo);
+                        write_pair(r_0, chunk_hi * 8 + col_idx * 2, r0_hi);
+                    }
+                    if (valid_r1) {
+                        const uint32_t r1_lo = math::cast_into_bf16_and_pack(
+                            final_accum[chunk_lo*4 + 2], final_accum[chunk_lo*4 + 3]);
+                        const uint32_t r1_hi = math::cast_into_bf16_and_pack(
+                            final_accum[chunk_hi*4 + 2], final_accum[chunk_hi*4 + 3]);
+                        write_pair(r_1, chunk_lo * 8 + col_idx * 2, r1_lo);
+                        write_pair(r_1, chunk_hi * 8 + col_idx * 2, r1_hi);
+                    }
+                }
+
+                // Each warp writes and then scatters only its own 16-row
+                // slice, so a warp-level fence is enough before reading
+                // back from shared memory.
+                __syncwarp();
+
+                // Scatter to remote ranks via NVLink (one row per warp-pair)
+                // Each warpgroup-warp covers 8 unique rows x 2 (r_0 + r_1 doubled by warps)
+                // Lane group of 16 within a warp -> 1 row.
+                // Each lane copies `cols_per_lane` BF16 (= cols_per_lane*2 bytes) as one
+                // vector. WG_BLOCK_N=128 -> 8 BF16 = uint4; WG_BLOCK_N=64 -> 4 BF16 = uint2.
+                using ScatterVec = std::conditional_t<(WG_BLOCK_N <= 64), uint2, uint4>;
+                DG_STATIC_ASSERT(cols_per_lane * sizeof(nv_bfloat16) == sizeof(ScatterVec),
+                                 "Scatter vector width must match cols_per_lane");
+                #pragma unroll
+                for (uint32_t j = 0; j < kNumRowsPerWarp; ++ j) {
+                    const uint32_t row_in_wg = warp_idx_in_wg * 16 + j * 2 + row_in_warp_block;
+                    const uint32_t m_idx_in_block = row_base + row_in_wg;
+                    if (m_idx_in_block >= valid_m) break;
+
+                    // Read cols_per_lane BF16 (= one ScatterVec) from smem
+                    auto smem_ptr = smem_cd_l2
+                        + smem_cd_l2_wg_offset
+                        + row_in_wg * WG_BLOCK_N
+                        + lane_in_row * cols_per_lane;
+                    const auto packed = *reinterpret_cast<ScatterVec*>(smem_ptr);
+
+                    const auto src_metadata = *workspace.get_token_src_metadata_ptr(m_idx + m_idx_in_block);
+                    const uint32_t dst_rank_idx = src_metadata.rank_idx;
+                    const uint32_t dst_token_idx = src_metadata.token_idx;
+                    const uint32_t dst_topk_idx = src_metadata.topk_idx;
+                    const auto dst_token = combine_token_buffer.get_rank_buffer(dst_topk_idx)
+                                           .get_data_buffer(dst_token_idx);
+                    auto dst_ptr = math::advance_ptr<ScatterVec>(
+                        dst_token.get_base_ptr(),
+                        (n_idx + wg_n_offset) * sizeof(nv_bfloat16) + lane_in_row * sizeof(ScatterVec));
+                    *sym_buffer.map(dst_ptr, dst_rank_idx) = packed;
+                }
+
+                if constexpr (kL2EpilogueRequiresFullSync)
+                    ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+            }
+        };
+
+        if constexpr (kSplitPhaseHotPath) {
+            scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
+                                         const uint32_t& local_expert_idx,
+                                         const uint32_t& num_k_blocks,
+                                         const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
+                if (block_phase == sched::BlockPhase::Linear1) {
+                    process_math_block(
+                        std::integral_constant<sched::BlockPhase, sched::BlockPhase::Linear1>{},
+                        local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
+                } else {
+                    process_math_block(
+                        std::integral_constant<sched::BlockPhase, sched::BlockPhase::Linear2>{},
+                        local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
+                }
+            });
+        } else {
+            scheduler.for_each_block([&](const sched::BlockPhase& block_phase,
+                                         const uint32_t& local_expert_idx,
+                                         const uint32_t& num_k_blocks,
+                                         const uint32_t& m_block_idx, const uint32_t& n_block_idx) {
+                process_math_block(block_phase, local_expert_idx, num_k_blocks, m_block_idx, n_block_idx);
+            });
+        }
+
+        // ---------------- COMBINE ----------------
+        // NVLink barrier first: signals remote ranks that this rank's GEMM
+        // outputs (NVLink scatter targets) are fully written.
+        comm::nvlink_barrier<kNumRanks, kNumSMs, kNumEpilogueThreads,
+                             kEpilogueGridSyncIndex, kBeforeCombineReduceBarrierTag>(
+            workspace, sym_buffer, sm_idx, epilogue_thread_idx,
+            [&]() { ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx); }
+        );
+
+        // Sync with dispatch (paired with dispatch's pre-cleanup sync) so that
+        // dispatch may now safely clean workspace state.
+        ptx::sync_unaligned(kNumDispatchThreads + kNumEpilogueThreads, kDispatchWithEpilogueBarrierIdx);
+
+        if (epilogue_warp_idx >= kNumCombineWarps)
+            return;
+
+        constexpr uint32_t kNumHiddenBytes = kHidden * sizeof(nv_bfloat16);
+        constexpr uint32_t kNumElemsPerUint4 = sizeof(uint4) / sizeof(nv_bfloat162);
+
+        constexpr uint32_t kNumChunkSlots = 3;
+        constexpr uint32_t kNumMaxRegistersForBuffer = 128;
+        constexpr uint32_t kDefaultNumChunks =
+            (kNumChunkSlots * kNumCombineWarps * kNumHiddenBytes <= SMEM_BEFORE_BARRIER_SIZE
+             and kHidden <= 32 * kNumMaxRegistersForBuffer) ? 1 : 2;
+        // Flash-style hidden=7168 is 7 * 1024. Splitting combine into 7 chunks
+        // keeps each lane's BF16 reduce accumulator much smaller without
+        // violating the 32-lane uint4 mapping.
+        constexpr uint32_t kSplitMNNumChunks = (kHidden % 7 == 0) ? 7 : (kHidden >= 1024 ? 4 : 1);
+        constexpr uint32_t kNumChunks = kSplitMNWarpgroups ? kSplitMNNumChunks : kDefaultNumChunks;
+        constexpr uint32_t kNumChunkBytes = kNumHiddenBytes / kNumChunks;
+        constexpr uint32_t kNumChunkUint4 = kNumChunkBytes / sizeof(uint4);
+        constexpr uint32_t kNumUint4PerLane = kNumChunkUint4 / 32;
+        DG_STATIC_ASSERT(kHidden % kNumChunks == 0, "Hidden must be divisible by number of chunks");
+        DG_STATIC_ASSERT(kNumChunkSlots * kNumCombineWarps * kNumHiddenBytes / kNumChunks <= SMEM_BEFORE_BARRIER_SIZE, "Hidden is too large");
+        DG_STATIC_ASSERT(kNumChunkBytes % 16 == 0, "Combine chunk must be TMA-aligned (16 bytes)");
+        DG_STATIC_ASSERT(kNumChunkBytes % sizeof(uint4) == 0, "Combine chunk must be divisible by 16 bytes");
+        DG_STATIC_ASSERT(kNumChunkUint4 % 32 == 0, "Combine chunk must be a multiple of 32 16-byte elements");
+        DG_STATIC_ASSERT(kNumTopk <= 32, "Top-k must fit in a single warp");
+
+        DG_TRAP_ONLY_DEVICE_ASSERT(kNumChunkSlots * kNumCombineWarps * kNumChunkBytes <= static_cast<uint32_t>(
+            reinterpret_cast<uint8_t*>(barrier_start_ptr) - smem_buffer));
+
+        const auto combine_load_buffer = utils::PatternVisitor([&](const uint32_t& i) {
+            return math::advance_ptr<uint4>(smem_buffer, (epilogue_warp_idx + i * kNumCombineWarps) * kNumChunkBytes);
+        });
+        const auto combine_store_buffer = math::advance_ptr<uint4>(
+            smem_buffer, (epilogue_warp_idx + kNumCombineWarps * 2) * kNumChunkBytes);
+
+        auto combine_load_barriers = utils::PatternVisitor([&](const uint32_t& i) {
+            return combine_barriers[i + epilogue_warp_idx * 2];
+        });
+
+        uint32_t combine_phase = 0;
+        uint32_t load_stage_idx = 0;
+        for (uint32_t token_idx = sm_idx * kNumCombineWarps + epilogue_warp_idx;
+             token_idx < num_tokens;
+             token_idx += kNumSMs * kNumCombineWarps) {
+            const int stored_topk_slot_idx = lane_idx < kNumTopk ?
+                static_cast<int>(__ldg(input_topk_idx_buffer.get_base_ptr<int64_t>() + token_idx * kNumTopk + lane_idx)) : -1;
+            const uint32_t total_mask = __ballot_sync(0xffffffff, stored_topk_slot_idx >= 0);
+
+            for (uint32_t chunk = 0; chunk < kNumChunks; ++ chunk) {
+                const uint32_t chunk_byte_offset = chunk * kNumChunkBytes;
+
+                uint32_t mask = total_mask;
+                const auto move_mask_and_load = [&](const uint32_t& i) {
+                    if (mask) {
+                        const uint32_t slot_idx = __ffs(mask) - 1;
+                        mask ^= 1 << slot_idx;
+                        if (cute::elect_one_sync()) {
+                            const auto src_ptr = math::advance_ptr<uint8_t>(
+                                combine_token_buffer.get_rank_buffer(slot_idx)
+                                                    .get_data_buffer(token_idx).get_base_ptr(),
+                                chunk_byte_offset);
+                            ptx::tma_load_1d(combine_load_buffer[i], src_ptr, combine_load_barriers[i], kNumChunkBytes);
+                            ptx::mbarrier_arrive_and_set_tx(combine_load_barriers[i], kNumChunkBytes);
+                        }
+                        __syncwarp();
+                        return true;
+                    }
+                    return false;
+                };
+
+                bool do_reduce = move_mask_and_load(load_stage_idx);
+
+                float2 reduced[kNumUint4PerLane * kNumElemsPerUint4] = {};
+                while (do_reduce) {
+                    do_reduce = move_mask_and_load(load_stage_idx ^ 1);
+                    combine_load_barriers[load_stage_idx]->wait(combine_phase);
+                    #pragma unroll
+                    for (uint32_t j = 0; j < kNumUint4PerLane; ++ j) {
+                        const auto uint4_values = combine_load_buffer[load_stage_idx][j * 32 + lane_idx];
+                        const auto bf16_values = reinterpret_cast<const nv_bfloat162*>(&uint4_values);
+                        #pragma unroll
+                        for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l)
+                            ptx::accumulate(reduced[j * kNumElemsPerUint4 + l], bf16_values[l]);
+                    }
+                    combine_phase ^= load_stage_idx;
+                    load_stage_idx ^= 1;
+                }
+
+                #pragma unroll
+                for (uint32_t j = 0; j < kNumUint4PerLane; ++ j) {
+                    uint4 casted;
+                    auto casted_bf16 = reinterpret_cast<nv_bfloat162*>(&casted);
+                    #pragma unroll
+                    for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l)
+                        casted_bf16[l] = __float22bfloat162_rn(reduced[j * kNumElemsPerUint4 + l]);
+
+                    if (j == 0) {
+                        ptx::tma_store_wait<0>();
+                        __syncwarp();
+                    }
+                    ptx::st_shared(combine_store_buffer + j * 32 + lane_idx,
+                                   casted.x, casted.y, casted.z, casted.w);
+                }
+                __syncwarp();
+
+                if (cute::elect_one_sync()) {
+                    cute::tma_store_fence();
+                    ptx::tma_store_1d(
+                        math::advance_ptr(y, static_cast<uint64_t>(token_idx) * kNumHiddenBytes + chunk_byte_offset),
+                        combine_store_buffer, kNumChunkBytes);
+                    cute::tma_store_arrive();
+                }
+                __syncwarp();
+            }
+        }
+    }
+#else
+    if (blockIdx.x == 0 and threadIdx.x == 0)
+        DG_DEVICE_ASSERT(false and "This kernel only supports sm_90");
+#endif
+}
+
+} // namespace deep_gemm
+
+#pragma clang diagnostic pop

--- a/sgl_deep_gemm/__init__.py
+++ b/sgl_deep_gemm/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import torch
 import tvm_ffi
@@ -264,13 +264,148 @@ except AttributeError:
     pass
 
 # Mega kernels
+from . import mega
 from .mega import (
     SymmBuffer,
-    get_symm_buffer_for_mega_moe,
     transform_weights_for_mega_moe,
     fp8_fp4_mega_moe,
     mega_moe_pre_dispatch,
 )
+
+
+def _from_dlpack_if_needed(tensor, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
+    if not isinstance(tensor, torch.Tensor):
+        tensor = torch.utils.dlpack.from_dlpack(tensor)
+    if dtype is not None and tensor.dtype != dtype:
+        tensor = tensor.view(dtype)
+    return tensor
+
+
+class SM90SymmBuffer:
+    def __init__(self, group,
+                 num_experts: int,
+                 num_max_tokens_per_rank: int, num_topk: int,
+                 hidden: int, intermediate_hidden: int,
+                 use_fp8_dispatch: bool = True,
+                 activation: str = 'swiglu'):
+        import torch.distributed._symmetric_memory as symm_mem
+
+        self.group = group
+        self.num_experts = num_experts
+        self.num_max_tokens_per_rank = num_max_tokens_per_rank
+        self.num_topk = num_topk
+        self.hidden = hidden
+        self.intermediate_hidden = intermediate_hidden
+
+        num_bytes, slice_input_buffers = _C.get_symm_buffer_size_for_sm90_mega_moe(
+            group.size(), num_experts,
+            num_max_tokens_per_rank, num_topk,
+            hidden, intermediate_hidden,
+            use_fp8_dispatch, activation
+        )
+        self.buffer = symm_mem.empty(num_bytes, dtype=torch.int8, device='cuda')
+        self.handle = symm_mem.rendezvous(self.buffer, group=group)
+        self.buffer.zero_()
+        self.group.barrier()
+        torch.cuda.synchronize()
+
+        (x, x_sf, topk_idx, topk_weights,
+         l1_acts, l1_acts_sf, l2_acts, l2_acts_sf) = slice_input_buffers(self.buffer)
+        self.x = _from_dlpack_if_needed(x, torch.float8_e4m3fn)
+        self.x_sf = _from_dlpack_if_needed(x_sf)
+        self.topk_idx = _from_dlpack_if_needed(topk_idx)
+        self.topk_weights = _from_dlpack_if_needed(topk_weights)
+        self.l1_acts = _from_dlpack_if_needed(l1_acts, torch.float8_e4m3fn)
+        self.l1_acts_sf = _from_dlpack_if_needed(l1_acts_sf)
+        self.l2_acts = _from_dlpack_if_needed(l2_acts, torch.float8_e4m3fn)
+        self.l2_acts_sf = _from_dlpack_if_needed(l2_acts_sf)
+
+    def destroy(self):
+        self.handle = None
+        self.buffer = None
+        self.group = None
+        self.x = None
+        self.x_sf = None
+
+
+def get_symm_buffer_for_sm90_mega_moe(group,
+                                      num_experts: int,
+                                      num_max_tokens_per_rank: int, num_topk: int,
+                                      hidden: int, intermediate_hidden: int,
+                                      use_fp8_dispatch: bool = True,
+                                      activation: str = 'swiglu') -> SM90SymmBuffer:
+    from .utils.math import align
+
+    num_max_tokens_per_rank = align(num_max_tokens_per_rank, _C.get_token_alignment_for_mega_moe())
+    return SM90SymmBuffer(
+        group, num_experts,
+        num_max_tokens_per_rank, num_topk,
+        hidden, intermediate_hidden,
+        use_fp8_dispatch, activation
+    )
+
+
+def get_symm_buffer_for_mega_moe(group,
+                                 num_experts: int,
+                                 num_max_tokens_per_rank: int, num_topk: int,
+                                 hidden: int, intermediate_hidden: int,
+                                 use_fp8_dispatch: bool = True,
+                                 activation: str = 'swiglu'):
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 9:
+        return get_symm_buffer_for_sm90_mega_moe(
+            group, num_experts,
+            num_max_tokens_per_rank, num_topk,
+            hidden, intermediate_hidden,
+            use_fp8_dispatch, activation
+        )
+    return mega.get_symm_buffer_for_mega_moe(
+        group, num_experts,
+        num_max_tokens_per_rank, num_topk,
+        hidden, intermediate_hidden,
+        use_fp8_dispatch, activation
+    )
+
+
+def transform_weights_for_mega_moe_sm90(
+    l1_weights: Tuple[torch.Tensor, torch.Tensor],
+    l2_weights: Tuple[torch.Tensor, torch.Tensor]
+) -> Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]:
+    l1_fp8, l1_sf = l1_weights
+
+    def _interleave_one(t, gran: int = 8) -> torch.Tensor:
+        g, n, *rest = t.shape
+        half = n // 2
+        gate = t[:, :half].reshape(g, half // gran, gran, *rest)
+        up = t[:, half:].reshape(g, half // gran, gran, *rest)
+        return torch.empty_like(t).copy_(torch.stack([gate, up], dim=2).reshape(g, n, *rest))
+
+    return (_interleave_one(l1_fp8), l1_sf), l2_weights
+
+
+def fp8_mega_moe(y: torch.Tensor,
+                 l1_weights: Tuple[torch.Tensor, torch.Tensor],
+                 l2_weights: Tuple[torch.Tensor, torch.Tensor],
+                 sym_buffer: SM90SymmBuffer,
+                 cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
+                 recipe: Tuple[int, int, int] = (128, 128, 128),
+                 activation: str = 'swiglu',
+                 activation_clamp: Optional[float] = None,
+                 fast_math: bool = True):
+    (l1_weights_data, l1_weights_sf) = l1_weights
+    (l2_weights_data, l2_weights_sf) = l2_weights
+    _C.fp8_mega_moe(
+        y,
+        l1_weights_data, l1_weights_sf,
+        l2_weights_data, l2_weights_sf,
+        cumulative_local_expert_recv_stats,
+        sym_buffer.buffer,
+        sym_buffer.handle.buffer_ptrs, sym_buffer.group.rank(),
+        sym_buffer.num_max_tokens_per_rank,
+        sym_buffer.num_experts, sym_buffer.num_topk,
+        recipe,
+        activation, activation_clamp,
+        fast_math
+    )
 
 # Some utils
 from . import testing

--- a/tests/test_mega_moe_hopper.py
+++ b/tests/test_mega_moe_hopper.py
@@ -1,0 +1,1946 @@
+"""SM90 (Hopper) MegaMoE fused-kernel and same-pipeline baseline benchmark.
+
+This follows the structure of ``tests/test_mega_moe.py`` for the SM100 FP4
+path, with the compute path changed to SM90 FP8:
+
+* fused: calls ``deep_gemm.fp8_mega_moe`` (kernel symbol
+  ``sm90_fp8_mega_moe_impl``) with weights transformed by
+  ``transform_weights_for_mega_moe_sm90`` and a ``SymmBuffer``.
+* baseline: DeepEP dispatch, two grouped FP8 GEMMs, Triton SwiGLU, and DeepEP
+  combine with untransformed weights. The current SM90 grouped GEMM path accepts
+  per-128-K L2 activation SF, while the fused SM90 MegaMoE L1 epilogue writes
+  per-64-K L2 activation SF to avoid cross-CTA synchronization. This is a
+  same-pipeline performance reference, not a bitwise correctness oracle.
+* low-latency baseline (optional, ``--run-low-latency-baseline``): mirrors the
+  sglang low-latency MoE pipeline (see
+  ``sglang/srt/layers/moe/token_dispatcher/deepep.py::_DeepEPDispatcherImplLowLatency``):
+  ``Buffer.low_latency_dispatch`` (use_fp8=True) -> per-expert masked-layout
+  FP8 grouped GEMM -> masked SwiGLU + FP8 quant -> masked FP8 grouped GEMM ->
+  ``Buffer.low_latency_combine`` (which applies topk weights internally). This
+  is the canonical decode path used in production EP serving.
+* fused-only sweep (optional, ``--fused-only-sweep``): replaces the old
+  standalone SM90 benchmark harness. It sweeps token counts, measures
+  only the fused SM90 kernel, and keeps the ``--ncu-profile-only`` /
+  ``--local-rank-idx`` interface for single-rank NCU profiling.
+* accuracy mode (optional, ``--accuracy``): runs the former layered SM90
+  correctness suite with a PyTorch BF16/FP32 reference. It covers smoke,
+  heuristic branches, shape sweeps, edge cases, and optional random stress.
+* output: TFLOPS, overlap-adjusted TFLOPS, HBM GB/s, NVLink GB/s, fused time,
+  reduction estimate, and ``t_baseline / t_fused``.
+"""
+
+import argparse
+import math
+import os
+import random
+import sys
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+from typing import Tuple, List, Dict, Any
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if os.getenv("DG_TEST_USE_SOURCE_TREE", "0") == "1" and REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+import deep_gemm
+from deep_gemm.utils import per_token_cast_to_fp8
+from deep_gemm.utils.dist import dist_print, init_dist, uneven_all_gather
+from deep_gemm.testing import bench_kineto, calc_diff, get_arch_major
+
+_missing_sgl_symbols = [
+    name for name in ("fp8_mega_moe", "transform_weights_for_mega_moe_sm90")
+    if not hasattr(deep_gemm, name)
+]
+if _missing_sgl_symbols:
+    raise RuntimeError(
+        "SM90 MegaMoE tests require the sgl-deep-gemm wheel built with "
+        "`bash build_sgl_deep_gemm.sh`; missing symbols: "
+        f"{', '.join(_missing_sgl_symbols)}"
+    )
+
+try:
+    import deep_ep as _deep_ep
+    _deep_ep_import_error = None
+except Exception as ex:
+    _deep_ep = None
+    _deep_ep_import_error = ex
+
+
+# Must match the template entry point in
+# deep_gemm/include/deep_gemm/impls/sm90_fp8_mega_moe.cuh so bench_kineto can
+# select the fused MegaMoE GPU region from the trace.
+SM90_KERNEL_NAME = "sm90_fp8_mega_moe_impl"
+
+
+# Max finite value of FP8 e4m3fn; quantization uses amax / 448 as the scale.
+FP8_E4M3_MAX = 448.0
+# Triton >= 3 requires Python globals read by a JIT kernel to be tl.constexpr,
+# otherwise compilation can fail with NameError. Host-side torch code still uses
+# the plain float above.
+_FP8_E4M3_MAX_TL = tl.constexpr(448.0)
+L1_ACT_SF_GRAN = 128
+FUSED_L2_ACT_SF_GRAN = 64
+BASELINE_L2_ACT_SF_GRAN = 128
+WEIGHT_SF_GRAN_MN = 128
+WEIGHT_SF_GRAN_K = 128
+
+
+# ============================================================================
+# Section 1: Triton SwiGLU + FP8 quantization kernel.
+# ----------------------------------------------------------------------------
+# The baseline L2 path uses DeepGEMM SM90 grouped FP8 GEMM, which accepts
+# per-128-K activation SF. The scale values still use the same power-of-two
+# rounding as the fused epilogue to avoid adding an exact-FP32-scale difference.
+# Input  x        : (M, 2*H) bf16, laid out as [gate_part | up_part].
+# Input  topk_w   : (M,) fp32, optional.
+# Output y        : (M, H) fp8_e4m3fn.
+# Output y_sf     : (M, H / BLOCK_K) fp32, row-major.
+# ============================================================================
+
+
+@triton.jit
+def _swiglu_apply_weight_to_fp8_kernel(
+    x_ptr,
+    topk_w_ptr,
+    y_ptr,
+    y_sf_ptr,
+    M,
+    H,  # Runtime shape
+    stride_xm,
+    stride_xn,  # x: (M, 2H) stride
+    stride_ym,
+    stride_yn,  # y: (M, H) stride
+    stride_sfm,
+    stride_sfk,  # y_sf: (M, H / BLOCK_K) stride
+    clamp_value,  # Ignored when HAS_CLAMP=False
+    HAS_TOPK: tl.constexpr,
+    HAS_CLAMP: tl.constexpr,
+    USE_UE8M0_SCALE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,  # = num_per_channels
+):
+    # One program handles BLOCK_M tokens and one BLOCK_K column tile.
+    pid_m = tl.program_id(0)
+    pid_k = tl.program_id(1)
+
+    # Row indices handled by this program.
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    # Column indices inside the current K block, in the H dimension.
+    offs_k = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+    mask_m = offs_m < M
+
+    # 1) Load gate from [0, H) and up from [H, 2H).
+    # stride_xn is an element stride, so H + offs_k is also element-based.
+    gate_ptrs = x_ptr + offs_m[:, None] * stride_xm + offs_k[None, :] * stride_xn
+    up_ptrs = x_ptr + offs_m[:, None] * stride_xm + (H + offs_k[None, :]) * stride_xn
+    gate = tl.load(gate_ptrs, mask=mask_m[:, None], other=0.0).to(tl.float32)
+    up = tl.load(up_ptrs, mask=mask_m[:, None], other=0.0).to(tl.float32)
+
+    # 2) Optional clamp: one-sided for gate, two-sided for up.
+    if HAS_CLAMP:
+        gate = tl.minimum(gate, clamp_value)
+        up = tl.minimum(tl.maximum(up, -clamp_value), clamp_value)
+
+    # 3) SwiGLU: silu(gate) * up = gate * sigmoid(gate) * up, accumulated in FP32.
+    y = gate * tl.sigmoid(gate) * up
+
+    # 4) Optional MoE weight scaling with a per-token scalar.
+    if HAS_TOPK:
+        w = tl.load(topk_w_ptr + offs_m, mask=mask_m, other=1.0)
+        y = y * w[:, None]
+
+    # 5) Per-row absmax in the current K block -> scale.
+    amax = tl.max(tl.abs(y), axis=1)  # (BLOCK_M,)
+    sf = tl.maximum(amax / _FP8_E4M3_MAX_TL, 1.0e-30)
+    if USE_UE8M0_SCALE:
+        # Match deep_gemm/common/math.cuh::get_e4m3_sf_and_sf_inv:
+        # scale = 2 ** ceil(log2(amax / 448)).
+        sf = tl.exp2(tl.ceil(tl.log2(sf)))
+
+    # 6) Quantize to FP8 e4m3fn.
+    y_fp8 = (y / sf[:, None]).to(tl.float8e4nv)
+
+    # 7) Store y and sf.
+    y_ptrs = y_ptr + offs_m[:, None] * stride_ym + offs_k[None, :] * stride_yn
+    tl.store(y_ptrs, y_fp8, mask=mask_m[:, None])
+
+    sf_ptrs = y_sf_ptr + offs_m * stride_sfm + pid_k * stride_sfk
+    tl.store(sf_ptrs, sf, mask=mask_m)
+
+
+def swiglu_apply_weight_to_fp8_triton(
+    x: torch.Tensor,
+    topk_weights: torch.Tensor | None,
+    clamp_value: float | None = None,
+    num_per_channels: int = BASELINE_L2_ACT_SF_GRAN,
+    use_ue8m0_scale: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """SwiGLU + FP8 quantization. Semantically equivalent to:
+    gate, up = x[:, :H], x[:, H:]
+    y = silu(gate.clamp(max=c)) * up.clamp(-c, c) * topk_w
+    y_sf = y.view(M, H/np, np).abs().amax(-1) / 448
+    if use_ue8m0_scale: y_sf = ceil_to_power_of_2(y_sf)
+    y_fp8 = (y / y_sf.unsqueeze(-1)).to(fp8)
+    """
+    assert x.is_cuda and x.dtype == torch.bfloat16
+    assert x.is_contiguous(), "This implementation expects contiguous x"
+    M, two_H = x.shape
+    H = two_H // 2
+    assert H % num_per_channels == 0, f"H={H} must be divisible by {num_per_channels}"
+
+    y = torch.empty((M, H), dtype=torch.float8_e4m3fn, device=x.device)
+    y_sf = torch.empty((M, H // num_per_channels), dtype=torch.float32, device=x.device)
+
+    # BLOCK_M=16 keeps register pressure low for the Triton reference kernel.
+    BLOCK_M = 16
+    grid = (triton.cdiv(M, BLOCK_M), H // num_per_channels)
+
+    # Triton still needs a valid pointer when HAS_TOPK=False; x is a placeholder.
+    topk_ptr = topk_weights if topk_weights is not None else x
+
+    _swiglu_apply_weight_to_fp8_kernel[grid](
+        x,
+        topk_ptr,
+        y,
+        y_sf,
+        M,
+        H,
+        x.stride(0),
+        x.stride(1),
+        y.stride(0),
+        y.stride(1),
+        y_sf.stride(0),
+        y_sf.stride(1),
+        float(clamp_value) if clamp_value is not None else 0.0,
+        HAS_TOPK=topk_weights is not None,
+        HAS_CLAMP=clamp_value is not None,
+        USE_UE8M0_SCALE=use_ue8m0_scale,
+        BLOCK_M=BLOCK_M,
+        BLOCK_K=num_per_channels,
+    )
+    return y, y_sf
+
+
+# ============================================================================
+# Section 2: grouped weight block-(128, 128) FP8 quantization.
+# ----------------------------------------------------------------------------
+# SM90 m_grouped_fp8_gemm_nt_contiguous expects each (128, 128) weight block to
+# share one FP32 SF, with K as the inner contiguous SF dimension (K-major).
+# Unlike the SM100 FP4 path:
+#   * deep_gemm.transform_sf_into_required_layout is not needed.
+#   * SF is FP32, not packed UE8M0.
+# ============================================================================
+
+
+def _quantize_grouped_fp8_block_128_128(
+    w: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """(G, N, K) bf16 -> (G, N, K) fp8_e4m3fn plus FP32 block SF."""
+    g, n, k = w.shape
+    assert n % 128 == 0 and k % 128 == 0, f"weight N={n}, K={k} must be multiples of 128"
+
+    # Split (N, K) into (N/128, 128, K/128, 128) block interiors.
+    w_view = w.view(g, n // 128, 128, k // 128, 128).float()
+
+    # In-block absmax -> scale = amax / 448; clamp avoids all-zero scales.
+    amax = w_view.abs().amax(dim=(-1, -3)).clamp(1e-4)  # (G, N/128, K/128)
+    sf = amax / FP8_E4M3_MAX
+
+    # Divide by the owning block's SF before casting to FP8.
+    w_fp8 = (w_view / sf.unsqueeze(-1).unsqueeze(-3)).to(torch.float8_e4m3fn)
+    return w_fp8.view(g, n, k).contiguous(), sf.contiguous()
+
+
+# ============================================================================
+# Section 3: layered accuracy reference and scenarios.
+# ============================================================================
+
+
+def _dequant_block_128_128(w_fp8: torch.Tensor, sf: torch.Tensor) -> torch.Tensor:
+    """Inverse of _quantize_grouped_fp8_block_128_128. Returns fp32."""
+    *prefix, n, k = w_fp8.shape
+    assert n % 128 == 0 and k % 128 == 0
+    w_view = w_fp8.float().view(*prefix, n // 128, 128, k // 128, 128)
+    return (w_view * sf.unsqueeze(-1).unsqueeze(-3)).view(*prefix, n, k)
+
+
+def _dequant_per_token_per_128_k(x_fp8: torch.Tensor, sf: torch.Tensor) -> torch.Tensor:
+    """Dequantize (M, K) fp8 with per-token, per-128-K float scales."""
+    m, k = x_fp8.shape
+    assert k % 128 == 0
+    x_view = x_fp8.float().view(m, k // 128, 128)
+    return (x_view * sf.unsqueeze(-1)).view(m, k)
+
+
+def _swiglu_fp32(gate_up: torch.Tensor, clamp: float) -> torch.Tensor:
+    """SwiGLU matching the fused SM90 path's clamp semantics."""
+    n2 = gate_up.size(-1)
+    half = n2 // 2
+    gate, up = gate_up[..., :half], gate_up[..., half:]
+    if math.isfinite(clamp):
+        gate = gate.clamp(max=clamp)
+        up = up.clamp(min=-clamp, max=clamp)
+    return torch.nn.functional.silu(gate) * up
+
+
+def _reference_fused(
+    x_fp8_local: torch.Tensor,
+    x_sf_local: torch.Tensor,
+    topk_idx_local: torch.Tensor,
+    topk_weights_local: torch.Tensor,
+    l1_w_fp8: torch.Tensor,
+    l1_w_sf: torch.Tensor,
+    l2_w_fp8: torch.Tensor,
+    l2_w_sf: torch.Tensor,
+    rank_idx: int,
+    num_ranks: int,
+    group: dist.ProcessGroup,
+    num_experts: int,
+    num_topk: int,
+    hidden: int,
+    intermediate_hidden: int,
+    activation_clamp: float,
+) -> torch.Tensor:
+    """PyTorch BF16/FP32 reference for this rank's fused output."""
+    num_experts_per_rank = num_experts // num_ranks
+
+    x_fp8_g = uneven_all_gather(x_fp8_local, group=group)
+    x_sf_g = uneven_all_gather(x_sf_local, group=group)
+    topk_idx_g = uneven_all_gather(topk_idx_local, group=group)
+    topk_w_g = uneven_all_gather(topk_weights_local, group=group)
+    mg = x_fp8_g.size(0)
+
+    local_size = torch.tensor([x_fp8_local.size(0)], device="cuda", dtype=torch.long)
+    sizes_t = torch.empty(num_ranks, dtype=torch.long, device="cuda")
+    dist.all_gather_into_tensor(sizes_t, local_size, group=group)
+    sizes_list = sizes_t.tolist()
+    assert sum(sizes_list) == mg
+
+    l1_w_g = [torch.empty_like(l1_w_fp8) for _ in range(num_ranks)]
+    l1_sf_g = [torch.empty_like(l1_w_sf) for _ in range(num_ranks)]
+    l2_w_g = [torch.empty_like(l2_w_fp8) for _ in range(num_ranks)]
+    l2_sf_g = [torch.empty_like(l2_w_sf) for _ in range(num_ranks)]
+    dist.all_gather(l1_w_g, l1_w_fp8, group=group)
+    dist.all_gather(l1_sf_g, l1_w_sf, group=group)
+    dist.all_gather(l2_w_g, l2_w_fp8, group=group)
+    dist.all_gather(l2_sf_g, l2_w_sf, group=group)
+    l1_w_all = torch.stack(l1_w_g, dim=0)
+    l1_sf_all = torch.stack(l1_sf_g, dim=0)
+    l2_w_all = torch.stack(l2_w_g, dim=0)
+    l2_sf_all = torch.stack(l2_sf_g, dim=0)
+
+    combine_buf = torch.zeros(mg, num_topk, hidden, dtype=torch.float32, device="cuda")
+    x_fp32 = _dequant_per_token_per_128_k(x_fp8_g, x_sf_g)
+
+    chunk = 256
+    for k in range(num_topk):
+        mask = topk_idx_g[:, k] >= 0
+        if not mask.any():
+            continue
+        sel_idx_full = mask.nonzero(as_tuple=False).squeeze(-1)
+        for c0 in range(0, sel_idx_full.numel(), chunk):
+            sel_idx = sel_idx_full[c0:c0 + chunk]
+            eids = topk_idx_g[sel_idx, k]
+            weights = topk_w_g[sel_idx, k]
+            x_sel = x_fp32[sel_idx]
+
+            dst_rank = (eids // num_experts_per_rank).long()
+            dst_local = (eids % num_experts_per_rank).long()
+
+            l1_w_sel = _dequant_block_128_128(
+                l1_w_all[dst_rank, dst_local],
+                l1_sf_all[dst_rank, dst_local],
+            )
+            l1_y = torch.einsum("sk,snk->sn", x_sel, l1_w_sel)
+            del l1_w_sel
+
+            l1_y = _swiglu_fp32(l1_y, activation_clamp) * weights.unsqueeze(-1)
+            s, ih = l1_y.shape
+            assert ih == intermediate_hidden and ih % 64 == 0
+            l1_view = l1_y.view(s, ih // 64, 64)
+            amax = l1_view.abs().amax(dim=-1).clamp(1e-4)
+            sf2 = amax / FP8_E4M3_MAX
+            l1_q = (l1_view / sf2.unsqueeze(-1)).to(torch.float8_e4m3fn).float()
+            l2_in = (l1_q * sf2.unsqueeze(-1)).view(s, ih)
+
+            l2_w_sel = _dequant_block_128_128(
+                l2_w_all[dst_rank, dst_local],
+                l2_sf_all[dst_rank, dst_local],
+            )
+            l2_y = torch.einsum("sn,smn->sm", l2_in, l2_w_sel)
+            del l2_w_sel
+
+            combine_buf[sel_idx, k] = l2_y.to(torch.bfloat16).float()
+
+    y_full_bf16 = combine_buf.to(torch.bfloat16).sum(dim=1).to(torch.bfloat16)
+    start = sum(sizes_list[:rank_idx])
+    end = start + sizes_list[rank_idx]
+    return y_full_bf16[start:end].contiguous()
+
+
+def _run_accuracy_scenario(
+    name: str,
+    cfg: Dict[str, Any],
+    rank_idx: int,
+    num_ranks: int,
+    group: dist.ProcessGroup,
+    diff_tol: float,
+):
+    num_max = cfg["num_max_tokens_per_rank"]
+    num_tokens = cfg.get("num_tokens", num_max)
+    hidden = cfg["hidden"]
+    intermediate_hidden = cfg["intermediate_hidden"]
+    num_experts = cfg["num_experts"]
+    num_topk = cfg["num_topk"]
+    masked_ratio = cfg.get("masked_ratio", 0.0)
+    activation_clamp = cfg.get("activation_clamp", 10.0)
+    fast_math = cfg.get("fast_math", True)
+
+    assert num_experts % num_ranks == 0, (
+        f"{name}: experts {num_experts} not divisible by ranks {num_ranks}"
+    )
+    num_experts_per_rank = num_experts // num_ranks
+    assert num_tokens <= num_max
+    assert hidden % 128 == 0 and intermediate_hidden % 128 == 0
+
+    verbose = bool(int(os.environ.get("DG_TEST_VERBOSE", "0")))
+
+    def trace(stage: str):
+        if verbose:
+            print(f"[rank{rank_idx}] {name} :: {stage}", flush=True)
+
+    trace("begin")
+    torch.manual_seed(rank_idx * 1000 + abs(hash(name)) % 1000)
+    random.seed(rank_idx * 1000 + abs(hash(name)) % 1000)
+
+    x_bf16 = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    l1_weights_bf16 = torch.randn(
+        (num_experts_per_rank, intermediate_hidden * 2, hidden),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ) * 0.05
+    l2_weights_bf16 = torch.randn(
+        (num_experts_per_rank, hidden, intermediate_hidden),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ) * 0.05
+    scores = torch.randn((num_tokens, num_experts), dtype=torch.float, device="cuda")
+    topk_weights, topk_idx = torch.topk(
+        scores, num_topk, dim=-1, largest=True, sorted=False
+    )
+    if masked_ratio > 0:
+        rand_mask = torch.rand_like(topk_idx, dtype=torch.float)
+        topk_idx.masked_fill_(rand_mask < masked_ratio, -1)
+        topk_weights.masked_fill_(topk_idx < 0, 0)
+
+    x_fp8 = per_token_cast_to_fp8(
+        x_bf16, use_ue8m0=False, gran_k=128, use_packed_ue8m0=False
+    )
+    l1_weights = _quantize_grouped_fp8_block_128_128(l1_weights_bf16)
+    l2_weights = _quantize_grouped_fp8_block_128_128(l2_weights_bf16)
+
+    trace("weight_transform")
+    transformed_l1, transformed_l2 = deep_gemm.transform_weights_for_mega_moe_sm90(
+        l1_weights, l2_weights
+    )
+
+    trace("alloc_symm_buffer")
+    buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+        group,
+        num_experts,
+        num_max,
+        num_topk,
+        hidden,
+        intermediate_hidden,
+    )
+    cum_stats = torch.zeros((num_experts_per_rank,), dtype=torch.int, device="cuda")
+
+    trace("copy_inputs")
+    buffer.x[:num_tokens].copy_(x_fp8[0])
+    buffer.x_sf[:num_tokens].copy_(x_fp8[1])
+    buffer.topk_idx[:num_tokens].copy_(topk_idx)
+    buffer.topk_weights[:num_tokens].copy_(topk_weights)
+
+    y_fused = torch.empty((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    trace("launch_fused")
+    deep_gemm.fp8_mega_moe(
+        y_fused,
+        transformed_l1,
+        transformed_l2,
+        buffer,
+        cumulative_local_expert_recv_stats=cum_stats,
+        recipe=(128, 128, 128),
+        activation="swiglu",
+        activation_clamp=activation_clamp if math.isfinite(activation_clamp) else None,
+        fast_math=fast_math,
+    )
+    torch.cuda.synchronize()
+
+    trace("reference")
+    y_ref = _reference_fused(
+        x_fp8[0],
+        x_fp8[1],
+        topk_idx,
+        topk_weights,
+        l1_weights[0],
+        l1_weights[1],
+        l2_weights[0],
+        l2_weights[1],
+        rank_idx,
+        num_ranks,
+        group,
+        num_experts,
+        num_topk,
+        hidden,
+        intermediate_hidden,
+        activation_clamp,
+    )
+
+    diff = calc_diff(y_fused, y_ref)
+    ok = diff < diff_tol
+    dist_print(
+        f"  [{name:<32}] diff={diff:.4f} (tol={diff_tol:.2f}) "
+        f"{'OK' if ok else 'FAIL'}",
+        once_in_node=True,
+    )
+    assert ok, f"{name}: diff={diff} >= tol={diff_tol}"
+    if num_tokens > 0 and masked_ratio < 1.0:
+        assert cum_stats.sum().item() >= 0
+
+    buffer.destroy()
+    dist.barrier()
+
+
+_ACCURACY_SMOKE = dict(
+    num_max_tokens_per_rank=64,
+    num_tokens=64,
+    hidden=512,
+    intermediate_hidden=512,
+    num_experts=8,
+    num_topk=2,
+)
+
+
+def _accuracy_layer1_smoke() -> List[Tuple[str, Dict[str, Any]]]:
+    return [("L1.smoke", dict(_ACCURACY_SMOKE))]
+
+
+def _accuracy_layer2_heuristic_branches(num_ranks: int) -> List[Tuple[str, Dict[str, Any]]]:
+    base = dict(
+        hidden=1024,
+        intermediate_hidden=1024,
+        num_experts=8 * num_ranks,
+        num_topk=2,
+    )
+    out: List[Tuple[str, Dict[str, Any]]] = []
+    for tokens, label in [(64, "small"), (256, "midA"), (512, "midB"), (2048, "large")]:
+        cfg = dict(base)
+        cfg.update(num_max_tokens_per_rank=tokens, num_tokens=tokens)
+        out.append((f"L2.heur.{label}.t{tokens}", cfg))
+    return out
+
+
+def _accuracy_layer3_shape_sweep(num_ranks: int) -> List[Tuple[str, Dict[str, Any]]]:
+    out: List[Tuple[str, Dict[str, Any]]] = []
+    base_experts = 8 * num_ranks
+    for hidden in (512, 2048):
+        for ih in (512, 2048):
+            for topk in (1, 2, 4):
+                if topk > base_experts:
+                    continue
+                cfg = dict(
+                    num_max_tokens_per_rank=128,
+                    num_tokens=128,
+                    hidden=hidden,
+                    intermediate_hidden=ih,
+                    num_experts=base_experts,
+                    num_topk=topk,
+                )
+                out.append((f"L3.h{hidden}_ih{ih}_k{topk}", cfg))
+    return out
+
+
+def _accuracy_layer4_edges(num_ranks: int) -> List[Tuple[str, Dict[str, Any]]]:
+    base = dict(
+        num_max_tokens_per_rank=128,
+        hidden=512,
+        intermediate_hidden=512,
+        num_experts=8 * num_ranks,
+        num_topk=2,
+    )
+    out = []
+    for masked_ratio in (0.0, 0.3, 0.7):
+        cfg = dict(base)
+        cfg.update(num_tokens=128, masked_ratio=masked_ratio)
+        out.append((f"L4.mask{masked_ratio:.1f}", cfg))
+    cfg = dict(base)
+    cfg.update(num_tokens=128, masked_ratio=1.0)
+    out.append(("L4.mask_all", cfg))
+    for clamp in (1.0, 10.0, math.inf):
+        cfg = dict(base)
+        cfg.update(num_tokens=128, activation_clamp=clamp)
+        out.append((f"L4.clamp{clamp}", cfg))
+    for fast_math in (True, False):
+        cfg = dict(base)
+        cfg.update(num_tokens=128, fast_math=fast_math)
+        out.append((f"L4.fm{int(fast_math)}", cfg))
+    cfg = dict(base)
+    cfg.update(num_tokens=0)
+    out.append(("L4.tokens0", cfg))
+    cfg = dict(base)
+    cfg.update(num_tokens=base["num_max_tokens_per_rank"])
+    out.append(("L4.tokens_max", cfg))
+    return out
+
+
+def _accuracy_layer5_stress(num_ranks: int, num_tests: int) -> List[Tuple[str, Dict[str, Any]]]:
+    rng = random.Random(0xC0FFEE)
+    out = []
+    for i in range(num_tests):
+        cfg = dict(
+            num_max_tokens_per_rank=rng.choice([32, 64, 128, 256, 512]),
+            hidden=rng.choice([512, 1024, 2048]),
+            intermediate_hidden=rng.choice([512, 1024, 2048]),
+            num_experts=8 * num_ranks,
+            num_topk=rng.choice([1, 2, 4]),
+            masked_ratio=rng.choice([0.0, 0.0, 0.3, 0.5]),
+            activation_clamp=rng.choice([1.0, 10.0, math.inf]),
+            fast_math=rng.choice([True, False]),
+        )
+        cfg["num_tokens"] = cfg["num_max_tokens_per_rank"]
+        out.append((f"L5.rand{i:03d}", cfg))
+    return out
+
+
+def _run_accuracy_tests(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank_idx, num_ranks, group = init_dist(local_rank, num_local_ranks)
+
+    if get_arch_major() != 9:
+        dist_print(
+            f"[SKIP] test_mega_moe_hopper accuracy requires SM90; got SM{get_arch_major()}0",
+            once_in_node=True,
+        )
+        dist.destroy_process_group()
+        return
+
+    layers: List[Tuple[str, Dict[str, Any]]] = []
+    if 1 in args.layers:
+        layers += _accuracy_layer1_smoke()
+    if 2 in args.layers:
+        layers += _accuracy_layer2_heuristic_branches(num_ranks)
+    if 3 in args.layers:
+        layers += _accuracy_layer3_shape_sweep(num_ranks)
+    if 4 in args.layers:
+        layers += _accuracy_layer4_edges(num_ranks)
+    if 5 in args.layers:
+        layers += _accuracy_layer5_stress(num_ranks, args.num_correctness_tests or 8)
+    if args.filter:
+        layers = [(name, cfg) for name, cfg in layers if args.filter in name]
+
+    dist_print(
+        f"SM90 MegaMoE accuracy plan: {len(layers)} scenarios across "
+        f"layers {sorted(args.layers)} on {num_ranks} ranks",
+        once_in_node=True,
+    )
+
+    failures: List[str] = []
+    for name, cfg in layers:
+        try:
+            _run_accuracy_scenario(name, cfg, rank_idx, num_ranks, group, args.diff_tol)
+        except AssertionError as ex:
+            dist_print(f"  [{name}] FAIL: {ex}", once_in_node=True)
+            failures.append(name)
+            if args.fail_fast:
+                break
+
+    dist_print("", once_in_node=True)
+    if failures:
+        dist_print(
+            f"FAILED {len(failures)}/{len(layers)} scenarios: {failures}",
+            once_in_node=True,
+        )
+    else:
+        dist_print(f"PASSED all {len(layers)} scenarios", once_in_node=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    if failures:
+        sys.exit(1)
+
+
+# ============================================================================
+# Section 4: optional deep_ep import for dispatch/combine.
+# ============================================================================
+
+
+def _import_deep_ep():
+    if _deep_ep is None:
+        dist_print(f"Failed to import deep_ep: {_deep_ep_import_error}", once_in_node=True)
+        return None
+    return _deep_ep
+
+
+class _DeepEPHandle:
+    def __init__(self, raw_handle, psum_num_recv_tokens_per_expert: torch.Tensor):
+        self.raw_handle = raw_handle
+        self.psum_num_recv_tokens_per_expert = psum_num_recv_tokens_per_expert
+
+
+class _DeepEPBufferCompat:
+    """Compatibility shim for newer DeepEP versions that expose Buffer, not ElasticBuffer."""
+
+    def __init__(self, deep_ep, group, num_nvl_bytes: int):
+        self.buffer = deep_ep.Buffer(
+            group,
+            num_nvl_bytes=num_nvl_bytes,
+            num_rdma_bytes=0,
+            explicitly_destroy=True,
+        )
+
+    def dispatch(
+        self,
+        x,
+        *,
+        topk_idx,
+        topk_weights,
+        num_experts: int,
+        expert_alignment: int,
+        **_,
+    ):
+        num_tokens_per_rank, num_tokens_per_rdma_rank, num_tokens_per_expert, is_token_in_rank, event = (
+            self.buffer.get_dispatch_layout(topk_idx, num_experts)
+        )
+        recv_x, _, recv_topk_weights, num_recv_tokens_per_expert, raw_handle, event = self.buffer.dispatch(
+            x,
+            num_tokens_per_rank=num_tokens_per_rank,
+            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            expert_alignment=expert_alignment,
+        )
+        psum = torch.tensor(
+            num_recv_tokens_per_expert, dtype=torch.int, device=topk_idx.device
+        ).cumsum(dim=0, dtype=torch.int)
+        return recv_x, None, recv_topk_weights, _DeepEPHandle(raw_handle, psum), event
+
+    def combine(self, x, *, handle):
+        raw_handle = handle.raw_handle if isinstance(handle, _DeepEPHandle) else handle
+        return self.buffer.combine(x, handle=raw_handle)
+
+    def barrier(self, use_comm_stream: bool = False):
+        torch.cuda.synchronize()
+        dist.barrier()
+
+    def destroy(self):
+        self.buffer.destroy()
+
+
+def _make_deep_ep_buffer(deep_ep, group, num_max_tokens_per_rank, hidden, num_topk, sym_buffer_bytes):
+    if hasattr(deep_ep, "ElasticBuffer"):
+        return deep_ep.ElasticBuffer(
+            group,
+            num_max_tokens_per_rank=num_max_tokens_per_rank,
+            hidden=hidden,
+            num_topk=num_topk,
+            use_fp8_dispatch=True,
+            explicitly_destroy=True,
+            allow_multiple_reduction=False,
+        )
+    nvl_alignment = 2 * 1024 * 1024
+    num_nvl_bytes = ((int(sym_buffer_bytes) + nvl_alignment - 1) // nvl_alignment) * nvl_alignment
+    return _DeepEPBufferCompat(deep_ep, group, num_nvl_bytes=num_nvl_bytes)
+
+
+def _make_deep_ep_low_latency_buffer(
+    deep_ep, group, num_max_dispatch_tokens_per_rank, hidden, num_experts
+):
+    """Build a DeepEP ``Buffer`` configured for low-latency dispatch/combine.
+
+    Mirrors the buffer construction used by sglang's
+    ``_DeepEPDispatcherImplLowLatency`` (see
+    ``sglang/srt/layers/moe/token_dispatcher/deepep.py``): RDMA bytes from
+    ``get_low_latency_rdma_size_hint`` and one QP per local expert.
+    """
+    num_rdma_bytes = deep_ep.Buffer.get_low_latency_rdma_size_hint(
+        num_max_dispatch_tokens_per_rank, hidden, group.size(), num_experts
+    )
+    return deep_ep.Buffer(
+        group,
+        num_nvl_bytes=0,
+        num_rdma_bytes=num_rdma_bytes,
+        low_latency_mode=True,
+        num_qps_per_rank=num_experts // group.size(),
+        allow_nvlink_for_low_latency_mode=True,
+        explicitly_destroy=True,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Masked SwiGLU + FP8 quantization (low-latency layout).
+# ----------------------------------------------------------------------------
+# DeepEP low-latency dispatch returns tokens packed as
+#   x: [num_local_experts, num_max_dispatch_tokens_per_rank * num_ranks, 2*IH]
+# with a per-expert valid-token count ``masked_m[g]``. The masked GEMM does
+# not care about the trailing junk rows, but to feed the L2 masked GEMM with
+# correct scales we still need a per-token-per-128-K FP32 scale tensor with
+# the same masked-layout convention. This kernel produces:
+#   y    : [E, M, IH]                    fp8_e4m3fn
+#   y_sf : [E, M, IH // BLOCK_K]         fp32 (row-major; DeepGEMM SM90 path
+#                                              accepts this layout)
+# Modeled on sglang's ``_silu_and_mul_post_quant_kernel`` in
+# ``sglang/srt/layers/moe/ep_moe/kernels.py``.
+
+
+@triton.jit
+def _swiglu_masked_post_quant_kernel(
+    x_ptr,
+    stride_x_e,
+    stride_x_m,
+    stride_x_n,
+    y_ptr,
+    stride_y_e,
+    stride_y_m,
+    stride_y_n,
+    y_sf_ptr,
+    stride_sf_e,
+    stride_sf_m,
+    stride_sf_k,
+    masked_m_ptr,
+    H,
+    clamp_value,
+    HAS_CLAMP: tl.constexpr,
+    USE_UE8M0_SCALE: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+):
+    pid_k = tl.program_id(0)  # column tile within IH
+    pid_m = tl.program_id(1)  # token-stripe within this expert
+    pid_e = tl.program_id(2)  # expert
+
+    num_token_stripes = tl.num_programs(1)
+    num_valid_tokens = tl.load(masked_m_ptr + pid_e)
+
+    offs_k = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+
+    # Element ptrs for one (expert, token_index, k_block).
+    x_base = x_ptr + pid_e * stride_x_e + offs_k * stride_x_n
+    y_base = y_ptr + pid_e * stride_y_e + offs_k * stride_y_n
+    sf_base = y_sf_ptr + pid_e * stride_sf_e + pid_k * stride_sf_k
+
+    for token in tl.range(pid_m, num_valid_tokens, num_token_stripes, num_stages=NUM_STAGES):
+        gate = tl.load(x_base + token * stride_x_m).to(tl.float32)
+        up = tl.load(x_base + token * stride_x_m + H * stride_x_n).to(tl.float32)
+
+        if HAS_CLAMP:
+            gate = tl.minimum(gate, clamp_value)
+            up = tl.minimum(tl.maximum(up, -clamp_value), clamp_value)
+
+        y = gate * tl.sigmoid(gate) * up
+
+        amax = tl.max(tl.abs(y))
+        sf = tl.maximum(amax / _FP8_E4M3_MAX_TL, 1.0e-30)
+        if USE_UE8M0_SCALE:
+            sf = tl.exp2(tl.ceil(tl.log2(sf)))
+
+        y_fp8 = (y / sf).to(tl.float8e4nv)
+
+        tl.store(y_base + token * stride_y_m, y_fp8)
+        tl.store(sf_base + token * stride_sf_m, sf)
+
+
+def swiglu_masked_post_quant_to_fp8(
+    x: torch.Tensor,
+    masked_m: torch.Tensor,
+    quant_group_size: int = BASELINE_L2_ACT_SF_GRAN,
+    clamp_value: float | None = None,
+    use_ue8m0_scale: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """SwiGLU + per-(token, BLOCK_K) FP8 quant on masked-layout input.
+
+    Input:
+        x          : (E, M, 2*H) bf16, contiguous
+        masked_m   : (E,) int, number of valid rows per expert
+    Returns:
+        y          : (E, M, H) fp8_e4m3fn
+        y_sf       : (E, M, H // quant_group_size) fp32 (row-major)
+
+    The MoE low-latency path applies topk weights inside
+    ``low_latency_combine``, so this kernel does NOT multiply by topk weights.
+    """
+    assert x.is_cuda and x.dtype == torch.bfloat16
+    assert x.is_contiguous(), "Expects contiguous masked-layout input"
+    assert x.dim() == 3 and x.shape[-1] % 2 == 0
+    E, M, two_H = x.shape
+    H = two_H // 2
+    assert H % quant_group_size == 0
+    assert masked_m.shape == (E,)
+
+    y = torch.empty((E, M, H), dtype=torch.float8_e4m3fn, device=x.device)
+    y_sf = torch.empty(
+        (E, M, H // quant_group_size), dtype=torch.float32, device=x.device
+    )
+
+    BLOCK_K = quant_group_size
+    # Heuristic similar to sglang's silu_and_mul_masked_post_quant_fwd.
+    block_num_per_expert = 64 if E < 4 else 32
+
+    grid = (H // BLOCK_K, block_num_per_expert, E)
+
+    _swiglu_masked_post_quant_kernel[grid](
+        x,
+        x.stride(0),
+        x.stride(1),
+        x.stride(2),
+        y,
+        y.stride(0),
+        y.stride(1),
+        y.stride(2),
+        y_sf,
+        y_sf.stride(0),
+        y_sf.stride(1),
+        y_sf.stride(2),
+        masked_m,
+        H,
+        float(clamp_value) if clamp_value is not None else 0.0,
+        HAS_CLAMP=clamp_value is not None,
+        USE_UE8M0_SCALE=use_ue8m0_scale,
+        BLOCK_K=BLOCK_K,
+        NUM_STAGES=4,
+        num_warps=1,
+    )
+    return y, y_sf
+
+
+# ============================================================================
+# Section 5: CUDA event median timing, independent of tilelang.do_bench.
+# ============================================================================
+
+
+def _bench_cuda_events(
+    fn, num_warmup: int = 5, num_repeat: int = 20, l2_flush_gb: float = 8.0
+) -> float:
+    """Return median runtime of fn in seconds."""
+    for _ in range(num_warmup):
+        fn()
+    torch.cuda.synchronize()
+    times_ms = []
+    for _ in range(num_repeat):
+        # Flush L2 to avoid optimistic timings from repeated cache hits.
+        if l2_flush_gb > 0:
+            free_bytes, _ = torch.cuda.mem_get_info()
+            flush_bytes = min(int(l2_flush_gb * 1e9), int(free_bytes * 0.5))
+            if flush_bytes >= 4:
+                torch.empty(flush_bytes // 4, dtype=torch.int, device="cuda").zero_()
+        s = torch.cuda.Event(enable_timing=True)
+        e = torch.cuda.Event(enable_timing=True)
+        s.record()
+        fn()
+        e.record()
+        e.synchronize()
+        times_ms.append(s.elapsed_time(e))
+    times_ms.sort()
+    return times_ms[len(times_ms) // 2] / 1e3
+
+
+# ============================================================================
+# Section 6: fused-only sweep / NCU profile mode.
+# ============================================================================
+
+
+def _run_fused_only_config(
+    args: argparse.Namespace,
+    num_tokens: int,
+    num_max_tokens_per_rank: int,
+    hidden: int,
+    intermediate_hidden: int,
+    num_experts: int,
+    num_topk: int,
+    num_ranks: int,
+    rank_idx: int,
+    group: dist.ProcessGroup,
+):
+    num_experts_per_rank = num_experts // num_ranks
+    assert num_tokens <= num_max_tokens_per_rank
+    assert num_experts % num_ranks == 0, (
+        f"num_experts={num_experts} must be divisible by num_ranks={num_ranks}"
+    )
+    assert hidden % 128 == 0
+    assert intermediate_hidden % 128 == 0
+    assert intermediate_hidden // 64 <= 64, (
+        f"SM90 fused kernel requires intermediate_hidden <= 4096, got {intermediate_hidden}"
+    )
+
+    buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+        group,
+        num_experts,
+        num_max_tokens_per_rank,
+        num_topk,
+        hidden,
+        intermediate_hidden,
+    )
+
+    x_bf16 = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    l1_weights_bf16 = torch.randn(
+        (num_experts_per_rank, intermediate_hidden * 2, hidden),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ) * 0.05
+    l2_weights_bf16 = torch.randn(
+        (num_experts_per_rank, hidden, intermediate_hidden),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ) * 0.05
+    scores = torch.randn((num_tokens, num_experts), dtype=torch.float, device="cuda")
+    topk_weights, topk_idx = torch.topk(
+        scores, num_topk, dim=-1, largest=True, sorted=False
+    )
+    if args.masked_ratio > 0:
+        rand_mask = torch.rand_like(topk_idx, dtype=torch.float)
+        topk_idx.masked_fill_(rand_mask < args.masked_ratio, -1)
+        topk_weights.masked_fill_(topk_idx < 0, 0)
+
+    x_fp8 = per_token_cast_to_fp8(
+        x_bf16, use_ue8m0=False, gran_k=128, use_packed_ue8m0=False
+    )
+    l1_weights = _quantize_grouped_fp8_block_128_128(l1_weights_bf16)
+    l2_weights = _quantize_grouped_fp8_block_128_128(l2_weights_bf16)
+    transformed_l1, transformed_l2 = deep_gemm.transform_weights_for_mega_moe_sm90(
+        l1_weights, l2_weights
+    )
+
+    cum_stats = torch.zeros((num_experts_per_rank,), dtype=torch.int, device="cuda")
+    y_fused = torch.empty((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    clamp_arg = args.activation_clamp if math.isfinite(args.activation_clamp) else None
+
+    def run_fused():
+        buffer.x[:num_tokens].copy_(x_fp8[0])
+        buffer.x_sf[:num_tokens].copy_(x_fp8[1])
+        buffer.topk_idx[:num_tokens].copy_(topk_idx)
+        buffer.topk_weights[:num_tokens].copy_(topk_weights)
+        deep_gemm.fp8_mega_moe(
+            y_fused,
+            transformed_l1,
+            transformed_l2,
+            buffer,
+            cumulative_local_expert_recv_stats=cum_stats,
+            recipe=(128, 128, 128),
+            activation="swiglu",
+            activation_clamp=clamp_arg,
+            fast_math=bool(args.fast_math),
+        )
+        return y_fused
+
+    if args.ncu_profile_only:
+        dist_print(
+            f"[NCU] tokens={num_tokens} hidden={hidden} ih={intermediate_hidden}",
+            once_in_node=True,
+        )
+        run_fused()
+        torch.cuda.synchronize()
+        dist.barrier()
+        buffer.destroy()
+        return
+
+    run_fused()
+    dist.barrier()
+    t_fused = bench_kineto(
+        run_fused,
+        SM90_KERNEL_NAME,
+        barrier=lambda: dist.barrier(),
+        num_tests=args.num_bench_tests,
+        suppress_kineto_output=True,
+    )
+
+    gathered_topk_idx = uneven_all_gather(topk_idx, group=group)
+    gathered_topk_idx[
+        (gathered_topk_idx < rank_idx * num_experts_per_rank)
+        | (gathered_topk_idx >= (rank_idx + 1) * num_experts_per_rank)
+    ] = -1
+    local_expert_ids = gathered_topk_idx[gathered_topk_idx != -1]
+    num_recv_tokens = int(local_expert_ids.numel())
+    num_touched_experts = int(torch.unique(local_expert_ids).numel()) if num_recv_tokens else 0
+
+    def safe_div(a, b):
+        return float("nan") if b == 0 else a / b
+
+    tflops = safe_div(
+        2 * num_recv_tokens * (hidden * intermediate_hidden * 3) / 1e12,
+        t_fused,
+    )
+    num_hbm_bytes = (
+        num_touched_experts * intermediate_hidden * 2 * hidden
+        + num_touched_experts * hidden * intermediate_hidden
+        + num_recv_tokens * hidden
+        + num_recv_tokens * intermediate_hidden
+        + num_recv_tokens * intermediate_hidden
+        + num_recv_tokens * hidden * 2
+    )
+    hbm_gbs = safe_div(num_hbm_bytes / 1e9, t_fused)
+
+    dist_print(
+        f" tokens={num_tokens:4d}  recv={num_recv_tokens:5d}  "
+        f"experts={num_touched_experts:4d}  {t_fused * 1e6:7.1f} us  "
+        f"{tflops:6.1f} TFLOPS  {hbm_gbs:6.0f} GB/s  (rank{rank_idx})",
+        once_in_node=True,
+    )
+
+    dist.barrier()
+    buffer.destroy()
+
+
+def _run_fused_only_sweep(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank_idx, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    torch.manual_seed(rank_idx)
+    random.seed(rank_idx)
+
+    if get_arch_major() != 9:
+        dist_print(
+            f"[SKIP] test_mega_moe_hopper fused-only sweep requires SM90; got SM{get_arch_major()}0",
+            once_in_node=True,
+        )
+        dist.destroy_process_group()
+        return
+
+    batches = args.batches if args.batches is not None else [1, 2, 4, 8, 16, 32]
+    if args.ncu_profile_only:
+        batches = batches[:1]
+
+    dist_print(
+        f"SM90 MegaMoE fused-only sweep: ranks={num_ranks} hidden={args.hidden} "
+        f"ih={args.intermediate_hidden} experts={args.num_experts} topk={args.num_topk} "
+        f"masked_ratio={args.masked_ratio} fast_math={bool(args.fast_math)}",
+        once_in_node=True,
+    )
+
+    num_max_tokens_per_rank = max(batches)
+    for num_tokens in batches:
+        _run_fused_only_config(
+            args,
+            num_tokens,
+            num_max_tokens_per_rank,
+            args.hidden,
+            args.intermediate_hidden,
+            args.num_experts,
+            args.num_topk,
+            num_ranks,
+            rank_idx,
+            group,
+        )
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+# ============================================================================
+# Section 7: per-rank comparison entry point.
+# ============================================================================
+
+
+def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    if args.accuracy:
+        _run_accuracy_tests(local_rank, num_local_ranks, args)
+        return
+
+    if args.fused_only_sweep:
+        _run_fused_only_sweep(local_rank, num_local_ranks, args)
+        return
+
+    # Initialize distributed state; rank_idx is global rank and group is NCCL.
+    rank_idx, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    torch.manual_seed(rank_idx)
+    random.seed(rank_idx)
+
+    if get_arch_major() != 9:
+        dist_print(
+            f"[SKIP] test_mega_moe_hopper requires SM90; got SM{get_arch_major()}0",
+            once_in_node=True,
+        )
+        dist.destroy_process_group()
+        return
+
+    # Shape parameters, with names matching tests/test_mega_moe.py.
+    num_max_tokens_per_rank = args.num_max_tokens_per_rank
+    num_tokens = (
+        max(
+            0,
+            args.num_max_tokens_per_rank
+            - random.randint(0, args.num_max_removed_tokens),
+        )
+        if args.num_tokens == 0
+        else args.num_tokens
+    )
+    hidden, intermediate_hidden = args.hidden, args.intermediate_hidden
+    num_experts, num_topk = args.num_experts, args.num_topk
+    num_experts_per_rank = num_experts // num_ranks
+    assert num_tokens <= num_max_tokens_per_rank
+    assert num_experts % num_ranks == 0, (
+        f"num_experts={num_experts} must be divisible by num_ranks={num_ranks}"
+    )
+
+    # SM90 fused-kernel shape constraints from csrc/apis/sm90_mega.hpp::fp8_mega_moe:
+    #   * H and IH must be multiples of 128 (L1 input per-128-K SF and
+    #     block-(128,128) weight SF).
+    #   * IH / 64 <= 64, i.e. IH <= 4096, because l2_arrival_mask is uint64
+    #     with one bit per 64-column block.
+    assert hidden % 128 == 0
+    assert intermediate_hidden % 128 == 0
+    assert intermediate_hidden // 64 <= 64, (
+        f"SM90 fused kernel requires intermediate_hidden <= 4096, got {intermediate_hidden}"
+    )
+
+    # ---- Create BF16 token and weight inputs ----
+    # x: local tokens for this rank.
+    x_bf16 = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    # L1 weight maps hidden -> 2*intermediate_hidden (gate and up packed).
+    l1_weights_bf16 = torch.randn(
+        (num_experts_per_rank, intermediate_hidden * 2, hidden),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    # L2 weight maps intermediate_hidden -> hidden.
+    l2_weights_bf16 = torch.randn(
+        (num_experts_per_rank, hidden, intermediate_hidden),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    # Routing: scores -> topk_idx (M, K) and topk_weights (M, K).
+    scores = torch.randn((num_tokens, num_experts), dtype=torch.float, device="cuda")
+    topk_weights, topk_idx = torch.topk(
+        scores, num_topk, dim=-1, largest=True, sorted=False
+    )
+    if args.masked_ratio > 0:
+        rand_mask = torch.rand_like(topk_idx, dtype=torch.float)
+        topk_idx.masked_fill_(rand_mask < args.masked_ratio, -1)
+        topk_weights.masked_fill_(topk_idx < 0, 0)
+
+    # Keep separate recv counters so fused and baseline do not overwrite each other.
+    cum_stats_fused = torch.zeros(
+        (num_experts_per_rank,), dtype=torch.int, device="cuda"
+    )
+    cum_stats_baseline = cum_stats_fused.clone()
+
+    # ---- BF16 -> FP8 quantization ----
+    # x_fp8 is (token_fp8 (M, hidden), token_sf (M, hidden//128) row-major FP32).
+    # SM90 expects FP32 SF, not packed UE8M0.
+    x_fp8 = per_token_cast_to_fp8(
+        x_bf16, use_ue8m0=False, gran_k=128, use_packed_ue8m0=False
+    )
+
+    # Weight quantization: (G, N, K) bf16 -> FP8 e4m3fn plus block FP32 SF.
+    # The DeepEP grouped-GEMM baseline uses these untransformed tuples directly.
+    l1_weights = _quantize_grouped_fp8_block_128_128(l1_weights_bf16)
+    l2_weights = _quantize_grouped_fp8_block_128_128(l2_weights_bf16)
+
+    # Fused path: interleave gate/up along N for FP8 L1 weights; SF is unchanged.
+    transformed_l1, transformed_l2 = deep_gemm.transform_weights_for_mega_moe_sm90(
+        l1_weights, l2_weights
+    )
+
+    # SwiGLU clamp: finite values enable clamp; inf maps to None and disables it.
+    clamp_arg = args.activation_clamp if math.isfinite(args.activation_clamp) else None
+    run_baseline_enabled = args.run_baseline or bool(args.check_output_diff)
+    run_ll_baseline_enabled = bool(args.run_low_latency_baseline)
+
+    # ---- M-dimension alignment for the grouped-GEMM baseline ----
+    alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout()
+    deep_gemm.set_mk_alignment_for_contiguous_layout(alignment)
+
+    # ---- Allocate fused SymmBuffer and output buffer ----
+    sym_buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+        group,
+        num_experts,
+        num_max_tokens_per_rank,
+        num_topk,
+        hidden,
+        intermediate_hidden,
+    )
+    y_fused = torch.empty((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+
+    def run_fused():
+        # Match the SM100 test: DG_COMM_KERNEL_DEBUG=1 zeros the whole
+        # sym_buffer at kernel exit, so inputs must be re-copied every call.
+        sym_buffer.x[:num_tokens].copy_(x_fp8[0])
+        sym_buffer.x_sf[:num_tokens].copy_(x_fp8[1])
+        sym_buffer.topk_idx[:num_tokens].copy_(topk_idx)
+        sym_buffer.topk_weights[:num_tokens].copy_(topk_weights)
+
+        deep_gemm.fp8_mega_moe(
+            y_fused,
+            transformed_l1,
+            transformed_l2,
+            sym_buffer,
+            cumulative_local_expert_recv_stats=cum_stats_fused,
+            recipe=(128, 128, 128),
+            activation="swiglu",
+            activation_clamp=clamp_arg,
+            fast_math=bool(args.fast_math),
+        )
+        return y_fused
+
+    # ---- Print config ----
+    dist_print("Config (SM90 fused MegaMoE):", once_in_node=True)
+    dist_print(f" > Tokens: {num_tokens}/{num_max_tokens_per_rank}", once_in_node=True)
+    dist_print(
+        f" > Hidden: {hidden}, Intermediate: {intermediate_hidden}", once_in_node=True
+    )
+    dist_print(
+        f" > Experts: {num_topk}/{num_experts} (per-rank: {num_experts_per_rank})",
+        once_in_node=True,
+    )
+    dist_print(f" > Masked ratio: {args.masked_ratio}", once_in_node=True)
+    dist_print(
+        f" > Activation SF: fused L2 per-{FUSED_L2_ACT_SF_GRAN} FP32 pow2, "
+        f"baseline L2 per-{BASELINE_L2_ACT_SF_GRAN} FP32 pow2 "
+        f"(SM90 grouped-GEMM constraint)",
+        once_in_node=True,
+    )
+    dist_print(
+        f" > Baseline: {'enabled' if run_baseline_enabled else 'disabled'}",
+        once_in_node=True,
+    )
+    dist_print(
+        f" > Low-latency baseline: {'enabled' if run_ll_baseline_enabled else 'disabled'}",
+        once_in_node=True,
+    )
+    dist_print(
+        f" > Buffer: {sym_buffer.buffer.nbytes / 2**30:.3f} GiB", once_in_node=True
+    )
+    dist_print(once_in_node=True)
+
+    # Match tests/test_mega_moe.py: NCU mode runs only the fused kernel to avoid
+    # baseline noise in the profile.
+    if args.ncu_profile_only:
+        dist_print("Run fused SM90 mega-MoE kernel:", once_in_node=True)
+        y = run_fused()
+        torch.cuda.synchronize()
+        assert y.shape == (num_tokens, hidden) and y.dtype == torch.bfloat16
+        dist_print(" > Done, exiting", once_in_node=True)
+        dist.barrier()
+        sym_buffer.destroy()
+        dist.destroy_process_group()
+        return
+
+    # ---- Allocate DeepEP buffer for the baseline ----
+    deep_ep = (
+        _import_deep_ep()
+        if (run_baseline_enabled or run_ll_baseline_enabled)
+        else None
+    )
+    ep_buffer = None
+    if deep_ep is not None and run_baseline_enabled:
+        ep_buffer = _make_deep_ep_buffer(
+            deep_ep,
+            group,
+            num_max_tokens_per_rank,
+            hidden,
+            num_topk,
+            sym_buffer.buffer.nbytes,
+        )
+
+    # ---- Allocate DeepEP buffer for the low-latency baseline ----
+    # Low-latency mode requires its own ``Buffer(low_latency_mode=True, ...)``
+    # with ``num_qps_per_rank == num_local_experts`` and RDMA bytes sized via
+    # ``get_low_latency_rdma_size_hint``. See sglang's
+    # ``DeepEPBuffer.get_deepep_buffer`` for the canonical setup.
+    ll_buffer = None
+    if deep_ep is not None and run_ll_baseline_enabled:
+        ll_buffer = _make_deep_ep_low_latency_buffer(
+            deep_ep,
+            group,
+            num_max_tokens_per_rank,
+            hidden,
+            num_experts,
+        )
+
+    # ----------------------------------------------------------------
+    # Baseline body: dispatch -> L1 GEMM -> SwiGLU+quantize -> L2 GEMM -> combine.
+    # It uses the same FP8 weights and FP32 block-(128,128) SF as the fused path,
+    # but without the fused-only gate/up interleave.
+    # ----------------------------------------------------------------
+    def run_baseline():
+        recv_x, _, recv_topk_weights, handle, _ = ep_buffer.dispatch(
+            x_fp8,
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            cumulative_local_expert_recv_stats=cum_stats_baseline,
+            num_experts=num_experts,
+            expert_alignment=alignment,
+            do_cpu_sync=False,
+            do_handle_copy=False,
+            do_expand=True,
+            use_tma_aligned_col_major_sf=False,  # SM90: row-major float SF
+        )
+        n = recv_x[0].size(0)
+
+        # L1 GEMM: FP8 token @ FP8 W1 -> BF16 intermediate activation (gate||up).
+        l1_y = torch.empty(
+            (n, intermediate_hidden * 2), dtype=torch.bfloat16, device="cuda"
+        )
+        deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
+            recv_x,
+            l1_weights,
+            l1_y,
+            handle.psum_num_recv_tokens_per_expert,
+            use_psum_layout=True,
+            disable_ue8m0_cast=True,
+        )
+
+        # Triton SwiGLU + FP8 quantization, including topk weight scaling.
+        # The fused SM90 MegaMoE L2 activation SF is per-64-K. The current
+        # DeepGEMM SM90 grouped GEMM supports only per-128-K activation SF, so
+        # the baseline uses per-128-K FP32 scales with the same power-of-two
+        # rounding rule as the fused epilogue.
+        l1_y = swiglu_apply_weight_to_fp8_triton(
+            x=l1_y,
+            topk_weights=recv_topk_weights,
+            clamp_value=clamp_arg,
+            num_per_channels=BASELINE_L2_ACT_SF_GRAN,
+            use_ue8m0_scale=True,
+        )
+
+        # L2 GEMM: FP8 intermediate activation @ FP8 W2 -> BF16.
+        l2_y = torch.empty((n, hidden), dtype=torch.bfloat16, device="cuda")
+        deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
+            l1_y,
+            l2_weights,
+            l2_y,
+            handle.psum_num_recv_tokens_per_expert,
+            use_psum_layout=True,
+            disable_ue8m0_cast=True,
+        )
+
+        # DeepEP combine: gather each token's topk expert outputs back to source rank.
+        return ep_buffer.combine(l2_y, handle=handle)[0]
+
+    # ----------------------------------------------------------------
+    # Low-latency baseline body. Mirrors the sglang
+    # ``_DeepEPDispatcherImplLowLatency`` pipeline:
+    #   1. ``low_latency_dispatch(use_fp8=True)`` -> per-expert packed FP8 tokens
+    #      with shape ``[E_local, M_max, hidden]`` plus FP32 scales
+    #      ``[E_local, M_max, hidden // 128]`` and per-expert ``masked_m``.
+    #   2. Masked grouped FP8 GEMM with L1 weights.
+    #   3. Masked SwiGLU + per-128-K FP8 quantize. (topk weights are NOT
+    #      applied here — ``low_latency_combine`` applies them internally.)
+    #   4. Masked grouped FP8 GEMM with L2 weights.
+    #   5. ``low_latency_combine`` (reduces with topk weights).
+    # ----------------------------------------------------------------
+    if run_ll_baseline_enabled:
+        M_max_ll = num_max_tokens_per_rank * num_ranks
+        # Expected per-expert mean of ``masked_m`` after dispatch. Used as the
+        # ``expected_m`` hint for the DeepGEMM masked kernel selector.
+        expected_m_ll = max(
+            1,
+            (num_max_tokens_per_rank * num_ranks * num_topk + num_experts - 1)
+            // num_experts,
+        )
+        # Pre-allocate per-call output buffers; the masked GEMM writes into them
+        # in place and ignores rows past ``masked_m[g]``.
+        ll_l1_y = torch.empty(
+            (num_experts_per_rank, M_max_ll, intermediate_hidden * 2),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        ll_l2_y = torch.empty(
+            (num_experts_per_rank, M_max_ll, hidden),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        ll_combined = torch.empty(
+            (num_tokens, hidden), dtype=torch.bfloat16, device="cuda"
+        )
+        # DeepEP low-latency dispatch requires int64 topk indices.
+        topk_idx_ll = topk_idx.to(torch.int64)
+
+    def run_baseline_low_latency():
+        # 1) Low-latency dispatch with FP8 cast.
+        (recv_x_data, recv_x_sf), masked_m, ll_handle, event, hook = (
+            ll_buffer.low_latency_dispatch(
+                x_bf16,
+                topk_idx_ll,
+                num_max_tokens_per_rank,
+                num_experts,
+                use_fp8=True,
+                round_scale=False,
+                use_ue8m0=False,
+                async_finish=False,
+                return_recv_hook=False,
+            )
+        )
+
+        # 2) L1 masked grouped FP8 GEMM:
+        #    (E_local, M_max, hidden) @ (E_local, 2*IH, hidden)^T -> (E_local, M_max, 2*IH).
+        deep_gemm.fp8_m_grouped_gemm_nt_masked(
+            (recv_x_data, recv_x_sf),
+            l1_weights,
+            ll_l1_y,
+            masked_m,
+            expected_m_ll,
+            disable_ue8m0_cast=True,
+        )
+
+        # 3) Masked SwiGLU + per-128-K FP8 quant. Topk weights are NOT applied
+        #    here — they are reduced inside ``low_latency_combine``.
+        l1_fp8, l1_sf = swiglu_masked_post_quant_to_fp8(
+            ll_l1_y,
+            masked_m,
+            quant_group_size=BASELINE_L2_ACT_SF_GRAN,
+            clamp_value=clamp_arg,
+            use_ue8m0_scale=False,
+        )
+
+        # 4) L2 masked grouped FP8 GEMM:
+        #    (E_local, M_max, IH) @ (E_local, H, IH)^T -> (E_local, M_max, H).
+        deep_gemm.fp8_m_grouped_gemm_nt_masked(
+            (l1_fp8, l1_sf),
+            l2_weights,
+            ll_l2_y,
+            masked_m,
+            expected_m_ll,
+            disable_ue8m0_cast=True,
+        )
+
+        # 5) Low-latency combine: per-token weighted reduction across topk
+        #    expert replicas; outputs (num_tokens, hidden) bf16.
+        combined_x, event, hook = ll_buffer.low_latency_combine(
+            ll_l2_y,
+            topk_idx_ll,
+            topk_weights,
+            ll_handle,
+            use_logfmt=False,
+            zero_copy=False,
+            async_finish=False,
+            return_recv_hook=False,
+            out=ll_combined,
+        )
+        return combined_x
+
+    # ---- Run once to check fused and optional baseline paths ----
+    y = run_fused()
+    assert y.shape == (num_tokens, hidden) and y.dtype == torch.bfloat16, (
+        f"unexpected fused output shape/dtype: shape={y.shape}, dtype={y.dtype}"
+    )
+    if ep_buffer is not None:
+        out_b = run_baseline()
+        assert out_b.shape == (num_tokens, hidden) and out_b.dtype == torch.bfloat16, (
+            f"unexpected baseline output shape/dtype: shape={out_b.shape}, dtype={out_b.dtype}"
+        )
+        if args.check_output_diff:
+            diff = (y.float() - out_b.float()).abs()
+            denom = out_b.float().abs().mean().clamp_min(1e-12)
+            dist_print(
+                "Output diff (fused vs per-128 baseline):", once_in_node=True
+            )
+            dist_print(
+                f" > max_abs={diff.max().item():.6e}, "
+                f"mean_abs={diff.mean().item():.6e}, "
+                f"mean_abs/mean_ref={diff.mean().div(denom).item():.6e}",
+                once_in_node=True,
+            )
+            dist_print(once_in_node=True)
+    if ll_buffer is not None:
+        out_ll = run_baseline_low_latency()
+        assert out_ll.shape == (num_tokens, hidden) and out_ll.dtype == torch.bfloat16, (
+            f"unexpected LL baseline output shape/dtype: shape={out_ll.shape}, dtype={out_ll.dtype}"
+        )
+        if args.check_output_diff:
+            diff = (y.float() - out_ll.float()).abs()
+            denom = out_ll.float().abs().mean().clamp_min(1e-12)
+            dist_print(
+                "Output diff (fused vs low-latency baseline):", once_in_node=True
+            )
+            dist_print(
+                f" > max_abs={diff.max().item():.6e}, "
+                f"mean_abs={diff.mean().item():.6e}, "
+                f"mean_abs/mean_ref={diff.mean().div(denom).item():.6e}",
+                once_in_node=True,
+            )
+            dist_print(once_in_node=True)
+
+    # ---- Count tokens routed to this rank and touched local experts ----
+    # Gather all topk_idx tensors and mark entries outside this rank's local
+    # expert range as -1. Remaining entries are routed (token, slot) pairs.
+    gathered_topk_idx = uneven_all_gather(topk_idx, group=group)
+    gathered_topk_idx[
+        (gathered_topk_idx < rank_idx * num_experts_per_rank)
+        | (gathered_topk_idx >= (rank_idx + 1) * num_experts_per_rank)
+    ] = -1
+    local_expert_ids = gathered_topk_idx[gathered_topk_idx != -1]
+    num_recv_tokens = int(local_expert_ids.numel())
+    num_touched_experts = int(torch.unique(local_expert_ids).numel())
+
+    # ---- benchmark ----
+    # Fused: bench_kineto selects the sm90_fp8_mega_moe_impl GPU region only.
+    t_fused = bench_kineto(
+        run_fused,
+        SM90_KERNEL_NAME,
+        num_tests=args.num_bench_tests,
+        barrier=lambda: ep_buffer.barrier(use_comm_stream=False)
+        if ep_buffer is not None
+        else dist.barrier(),
+        trace_path=(
+            f"{args.dump_profile_traces}/mega_moe_hopper_rank{rank_idx}.json"
+            if args.dump_profile_traces
+            else None
+        ),
+    )
+    # Baseline: use CUDA event median timing for consistency across SM90 setups.
+    t_baseline = (
+        _bench_cuda_events(
+            run_baseline,
+            num_warmup=args.num_warmup,
+            num_repeat=args.num_repeat,
+            l2_flush_gb=args.l2_flush_gb,
+        )
+        if ep_buffer is not None
+        else 0.0
+    )
+    # Low-latency baseline timing (same CUDA-event median methodology).
+    t_baseline_ll = (
+        _bench_cuda_events(
+            run_baseline_low_latency,
+            num_warmup=args.num_warmup,
+            num_repeat=args.num_repeat,
+            l2_flush_gb=args.l2_flush_gb,
+        )
+        if ll_buffer is not None
+        else 0.0
+    )
+
+    def safe_div(a, b):
+        return float("nan") if b == 0 else a / b
+
+    # End-to-end TFLOPS: three matmuls (L1 gate, L1 up, L2), each 2*M*N*K.
+    tflops = safe_div(
+        2 * num_recv_tokens * (hidden * intermediate_hidden * 3) / 1e12, t_fused
+    )
+
+    # HBM byte estimate (SM90 weights are FP8 = 1B/elem, unlike SM100 FP4).
+    l1_weight_bytes = num_touched_experts * intermediate_hidden * 2 * hidden
+    l2_weight_bytes = num_touched_experts * hidden * intermediate_hidden
+    l1_weight_sf_bytes = (
+        num_touched_experts
+        * (intermediate_hidden * 2 // WEIGHT_SF_GRAN_MN)
+        * (hidden // WEIGHT_SF_GRAN_K)
+        * 4
+    )
+    l2_weight_sf_bytes = (
+        num_touched_experts
+        * (hidden // WEIGHT_SF_GRAN_MN)
+        * (intermediate_hidden // WEIGHT_SF_GRAN_K)
+        * 4
+    )
+    l1_input_sf_bytes = num_recv_tokens * (hidden // L1_ACT_SF_GRAN) * 4
+    l2_act_sf_bytes = (
+        num_recv_tokens * (intermediate_hidden // FUSED_L2_ACT_SF_GRAN) * 4
+    )
+    num_hbm_bytes = (
+        l1_weight_bytes
+        + l2_weight_bytes  # weights (FP8)
+        + l1_weight_sf_bytes
+        + l2_weight_sf_bytes  # weight SF (FP32)
+        + num_recv_tokens * hidden
+        + l1_input_sf_bytes  # L1 input read (FP8 + SF)
+        + num_recv_tokens * intermediate_hidden
+        + l2_act_sf_bytes  # L1 output write (FP8 + SF)
+        + num_recv_tokens * intermediate_hidden
+        + l2_act_sf_bytes  # L2 input read (FP8 + SF)
+        + num_recv_tokens * hidden * 2  # L2 output write (BF16)
+    )
+    hbm_gbs = safe_div(num_hbm_bytes / 1e9, t_fused)
+
+    # NVLink bytes: dispatch pulls token + input SF + topk weight; combine writes BF16.
+    num_nvlink_bytes = num_recv_tokens * (hidden + hidden // 32 + 4 + hidden * 2)
+    nvlink_gbs = safe_div(num_nvlink_bytes / 1e9, t_fused)
+
+    # Serial lower bound for combine reduction, using 6.5e12 B/s as an estimate.
+    t_reduction = num_tokens * hidden * 2 * (1 + num_topk) / 6.5e12
+
+    # Overlap adjustment: remove the non-overlapped serial reduction estimate.
+    approx_factor = t_fused / max(t_fused - t_reduction, 1e-12)
+
+    # Baseline uses the same FLOPs and HBM byte estimate, with t_baseline.
+    tflops_baseline = safe_div(
+        2 * num_recv_tokens * (hidden * intermediate_hidden * 3) / 1e12, t_baseline
+    )
+    hbm_gbs_baseline = safe_div(num_hbm_bytes / 1e9, t_baseline)
+    nvlink_gbs_baseline = safe_div(num_nvlink_bytes / 1e9, t_baseline)
+    # Low-latency baseline pads each expert's activation to ``M_max_ll``, so
+    # the weights are streamed once per expert regardless of routing. NVLink
+    # bytes match the normal-mode baseline (same per-routed-token volume).
+    tflops_baseline_ll = safe_div(
+        2 * num_recv_tokens * (hidden * intermediate_hidden * 3) / 1e12, t_baseline_ll
+    )
+    hbm_gbs_baseline_ll = safe_div(num_hbm_bytes / 1e9, t_baseline_ll)
+    nvlink_gbs_baseline_ll = safe_div(num_nvlink_bytes / 1e9, t_baseline_ll)
+
+    def fmt_perf_line(
+        name: str,
+        t: float,
+        compute_tflops: float,
+        hbm_gbs_: float,
+        nvlink_gbs_: float,
+        reduction_us: float | None = None,
+        speedup: float | None = None,
+    ) -> str:
+        reduction = f"{reduction_us:13.1f}" if reduction_us is not None else f"{'-':>13}"
+        speedup_text = (
+            f"{speedup:6.2f}x {'fused faster' if speedup > 1 else 'baseline faster'}"
+            if speedup is not None else
+            f"{'-':>21}"
+        )
+        return (
+            f" > {name:<10} {rank_idx:2d}/{num_ranks:<2d} "
+            f"{num_recv_tokens:12d} "
+            f"{num_touched_experts:14d} | "
+            f"{compute_tflops:15.0f} "
+            f"{hbm_gbs_:9.0f} "
+            f"{nvlink_gbs_:9.0f} "
+            f"{t * 1e6:9.0f} "
+            f"{reduction} "
+            f"{speedup_text}"
+        )
+
+    dist_print("Performance:", once_in_node=True)
+    dist_print(
+        " > kind       EP    recv_tokens active_experts | "
+        "compute(TFLOPS) HBM(GB/s) NVL(GB/s)  time(us) reduction(us) speedup",
+        once_in_node=True,
+    )
+    dist_print(
+        fmt_perf_line(
+            "[fused]",
+            t_fused,
+            tflops * approx_factor,
+            hbm_gbs * approx_factor,
+            nvlink_gbs * approx_factor,
+            reduction_us=t_reduction * 1e6,
+        )
+    )
+    if ep_buffer is not None:
+        speedup = safe_div(t_baseline, t_fused)
+        dist_print(
+            fmt_perf_line(
+                "[baseline]",
+                t_baseline,
+                tflops_baseline,
+                hbm_gbs_baseline,
+                nvlink_gbs_baseline,
+                speedup=speedup,
+            )
+        )
+    else:
+        reason = (
+            "disabled; pass --run-baseline or --check-output-diff to compare"
+            if not run_baseline_enabled
+            else "deep_ep unavailable"
+        )
+        dist_print(f" > [baseline] ({reason})", once_in_node=True)
+    if ll_buffer is not None:
+        speedup_ll = safe_div(t_baseline_ll, t_fused)
+        dist_print(
+            fmt_perf_line(
+                "[ll_base]",
+                t_baseline_ll,
+                tflops_baseline_ll,
+                hbm_gbs_baseline_ll,
+                nvlink_gbs_baseline_ll,
+                speedup=speedup_ll,
+            )
+        )
+    elif run_ll_baseline_enabled:
+        dist_print(" > [ll_base] (deep_ep unavailable)", once_in_node=True)
+
+    # ---- Cleanup ----
+    dist.barrier()
+    sym_buffer.destroy()
+    if ep_buffer is not None:
+        ep_buffer.destroy()
+    if ll_buffer is not None:
+        ll_buffer.destroy()
+    dist.destroy_process_group()
+
+
+# ============================================================================
+# Section 8: argparse + spawn.
+# ============================================================================
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="SM90 MegaMoE: fused (deep_gemm.fp8_mega_moe) vs DeepEP+grouped-FP8 baseline"
+    )
+
+    # Resources.
+    parser.add_argument(
+        "--ncu-profile-only",
+        action="store_true",
+        help="Run the fused SM90 kernel once for NCU/Nsight profiling",
+    )
+    parser.add_argument(
+        "--fused-only-sweep",
+        action="store_true",
+        help="Run the fused-only token sweep benchmark mode",
+    )
+    parser.add_argument(
+        "--accuracy",
+        action="store_true",
+        help="Run the layered SM90 accuracy suite instead of benchmark modes",
+    )
+    parser.add_argument(
+        "--num-processes", type=int, default=8, help="Number of spawned processes, one per GPU"
+    )
+    parser.add_argument(
+        "--local-rank-idx",
+        type=int,
+        default=None,
+        help="Local rank for single-process mode, useful for external launchers/NCU",
+    )
+
+    # Model shape.
+    # SM90 fused kernel requires intermediate_hidden <= 4096.
+    parser.add_argument("--num-max-tokens-per-rank", type=int, default=8192)
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        default=0,
+        help="Actual per-rank token count; 0 means num-max-tokens-per-rank",
+    )
+    parser.add_argument(
+        "--num-max-removed-tokens",
+        type=int,
+        default=0,
+        help="Max random token removals per rank when num-tokens is 0",
+    )
+    parser.add_argument(
+        "--batches",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Token counts for --fused-only-sweep (default: 1 2 4 8 16 32)",
+    )
+    parser.add_argument("--hidden", type=int, default=7168)
+    parser.add_argument(
+        "--intermediate-hidden",
+        type=int,
+        default=3072,
+        help="Intermediate dimension, constrained to <= 4096 by SM90 l2_arrival_mask",
+    )
+    parser.add_argument(
+        "--activation-clamp",
+        type=float,
+        default=10.0,
+        help="Clamp threshold for gate/up before SwiGLU; pass inf to disable",
+    )
+    parser.add_argument("--num-experts", type=int, default=384)
+    parser.add_argument("--num-topk", type=int, default=6)
+    parser.add_argument(
+        "--masked-ratio",
+        type=float,
+        default=0.0,
+        help="Randomly mask some topk expert selections to test sparse routing edges",
+    )
+    parser.add_argument(
+        "--fast-math",
+        type=int,
+        default=1,
+        help="Whether fused SwiGLU uses fast math (0/1)",
+    )
+
+    # Timing.
+    parser.add_argument(
+        "--num-bench-tests",
+        "--num-tests",
+        dest="num_bench_tests",
+        type=int,
+        default=30,
+        help="Number of bench_kineto iterations for the fused kernel",
+    )
+    parser.add_argument(
+        "--num-warmup", type=int, default=5, help="baseline cuda events warmup"
+    )
+    parser.add_argument(
+        "--num-repeat", type=int, default=20, help="Baseline CUDA event timing iterations"
+    )
+    parser.add_argument(
+        "--l2-flush-gb",
+        type=float,
+        default=8.0,
+        help="Temporary write size used to flush L2 before baseline timing; 0 disables it",
+    )
+    parser.add_argument(
+        "--run-baseline",
+        action="store_true",
+        help="Enable the DeepEP+grouped-FP8 baseline; disabled by default",
+    )
+    parser.add_argument(
+        "--run-low-latency-baseline",
+        action="store_true",
+        help=(
+            "Enable the sglang low-latency baseline "
+            "(DeepEP low_latency_dispatch -> masked grouped FP8 GEMM -> masked "
+            "SwiGLU+FP8 quant -> masked FP8 GEMM -> low_latency_combine); "
+            "disabled by default"
+        ),
+    )
+    parser.add_argument(
+        "--check-output-diff",
+        type=int,
+        default=0,
+        help="If nonzero, print fused vs per-128 baseline output differences",
+    )
+    parser.add_argument(
+        "--dump-profile-traces",
+        type=str,
+        default="",
+        help="If nonempty, write one fused Chrome trace per rank to this directory",
+    )
+
+    # Accuracy mode.
+    parser.add_argument(
+        "--layers",
+        type=int,
+        nargs="+",
+        default=[1, 2, 3, 4],
+        help="Accuracy layers to run with --accuracy (1..5); default: 1 2 3 4",
+    )
+    parser.add_argument(
+        "--num-correctness-tests",
+        type=int,
+        default=None,
+        help="Layer-5 random stress scenario count for --accuracy",
+    )
+    parser.add_argument(
+        "--filter",
+        type=str,
+        default="",
+        help="Substring filter for --accuracy scenario names",
+    )
+    parser.add_argument(
+        "--diff-tol",
+        type=float,
+        default=0.07,
+        help="calc_diff tolerance for --accuracy; default: 0.07",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop --accuracy on the first failing scenario",
+    )
+
+    args = parser.parse_args()
+
+    if args.dump_profile_traces:
+        os.makedirs(args.dump_profile_traces, exist_ok=True)
+
+    if args.local_rank_idx is not None:
+        # Single-process mode: external launcher sets MASTER_ADDR/PORT/WORLD_SIZE/RANK.
+        test(args.local_rank_idx, args.num_processes, args)
+    else:
+        # Multi-process mode: one process per GPU; test() creates the NCCL group.
+        torch.multiprocessing.spawn(
+            test, args=(args.num_processes, args), nprocs=args.num_processes
+        )


### PR DESCRIPTION
# MegaMoE SM90 Perf Summary

## Flash vs normal baseline

| batch | status | fused avg us | baseline avg us | speedup | timing ranks | note |
|---:|---:|---:|---:|---:|---:|---|
| 1 | 0 | 207.5 | 491.1 | 2.37x | 8/8 |  |
| 2 | 0 | 235.2 | 614.5 | 2.61x | 8/8 |  |
| 4 | 0 | 350.4 | 817.8 | 2.33x | 8/8 |  |
| 8 | 0 | 423.8 | 938.1 | 2.21x | 8/8 |  |
| 16 | 0 | 485.8 | 1056.9 | 2.18x | 8/8 |  |
| 32 | 0 | 494.6 | 1090.2 | 2.20x | 8/8 |  |
| 64 | 0 | 495.2 | 1070.6 | 2.16x | 8/8 |  |
| 128 | 0 | 508.1 | 1062.2 | 2.09x | 8/8 |  |
| 256 | 0 | 524.6 | 1169.4 | 2.23x | 8/8 |  |
| 512 | 0 | 874.0 | 1237.8 | 1.42x | 8/8 |  |
| 1024 | 0 | 1637.5 | 2091.4 | 1.28x | 8/8 |  |
| 2048 | 0 | 2856.1 | 3572.2 | 1.25x | 8/8 |  |
| 4096 | 0 | 5213.8 | 6375.6 | 1.22x | 8/8 |  |
| 8192 | 0 | 9812.0 | 11974.9 | 1.22x | 8/8 |  |

## Flash vs low-latency baseline

| batch | status | fused avg us | baseline avg us | speedup | timing ranks | note |
|---:|---:|---:|---:|---:|---:|---|
| 1 | 1 | 172.6 | 199.0 | 1.15x | 8/8 | nonzero exit after timing |
| 2 | 1 | 239.8 | 272.2 | 1.14x | 8/8 | nonzero exit after timing |
| 4 | 1 | 349.5 | 390.4 | 1.12x | 8/8 | nonzero exit after timing |
| 8 | 1 | 444.6 | 473.0 | 1.06x | 8/8 | nonzero exit after timing |
| 16 | 1 | 497.0 | 514.9 | 1.04x | 8/8 | nonzero exit after timing |
| 32 | 1 | 520.1 | 515.4 | 0.99x | 8/8 | nonzero exit after timing |
| 64 | 1 | 505.4 | 521.0 | 1.03x | 8/8 | nonzero exit after timing |
| 128 | 1 | 510.1 | 542.6 | 1.06x | 8/8 | nonzero exit after timing |
| 256 | 1 | 530.0 | 616.5 | 1.16x | 8/8 | nonzero exit after timing |

## Pro vs normal baseline

| batch | status | fused avg us | baseline avg us | speedup | timing ranks | note |
|---:|---:|---:|---:|---:|---:|---|
| 1 | 0 | 415.4 | 908.9 | 2.19x | 8/8 |  |
| 2 | 0 | 572.5 | 1275.4 | 2.23x | 8/8 |  |
| 4 | 0 | 861.6 | 1850.9 | 2.15x | 8/8 |  |
| 8 | 0 | 1256.6 | 2715.6 | 2.16x | 8/8 |  |
| 16 | 0 | 1519.5 | 3169.6 | 2.09x | 8/8 |  |
| 32 | 0 | 1562.2 | 3273.9 | 2.10x | 8/8 |  |
| 64 | 0 | 1580.5 | 3277.9 | 2.07x | 8/8 |  |
| 128 | 0 | 1586.9 | 3322.0 | 2.09x | 8/8 |  |
| 256 | 0 | 1615.5 | 3360.5 | 2.08x | 8/8 |  |
| 512 | 0 | 3021.2 | 3461.9 | 1.15x | 8/8 |  |
| 1024 | 0 | 4773.5 | 5365.8 | 1.12x | 8/8 |  |
| 2048 | 0 | 7856.6 | 8744.8 | 1.11x | 8/8 |  |
| 4096 | 0 | 13650.2 | 15095.4 | 1.11x | 8/8 |  |
| 8192 | 0 | 25454.1 | 28132.8 | 1.11x | 8/8 |  |

## Pro vs low-latency baseline

| batch | status | fused avg us | baseline avg us | speedup | timing ranks | note |
|---:|---:|---:|---:|---:|---:|---|
| 1 | 1 | 420.6 | 466.5 | 1.11x | 8/8 | nonzero exit after timing |
| 2 | 1 | 587.1 | 635.1 | 1.08x | 8/8 | nonzero exit after timing |
| 4 | 1 | 849.6 | 951.0 | 1.12x | 8/8 | nonzero exit after timing |
| 8 | 1 | 1255.4 | 1344.4 | 1.07x | 8/8 | nonzero exit after timing |
| 16 | 1 | 1529.1 | 1601.2 | 1.05x | 8/8 | nonzero exit after timing |
| 32 | 1 | 1586.4 | 1676.0 | 1.06x | 8/8 | nonzero exit after timing |
| 64 | 1 | 1567.8 | 1692.2 | 1.08x | 8/8 | nonzero exit after timing |
| 128 | 1 | 1597.1 | 1727.5 | 1.08x | 8/8 | nonzero exit after timing |
| 256 | 1 | 1611.9 | 1795.9 | 1.11x | 8/8 | nonzero exit after timing |

# Benchmark DeepSeekV4Flash
| Shape | Track | off tok/s | on tok/s | on/off | off RR/MC | on RR/MC | on SLO status |
|---|---|---:|---:|---:|---|---|---|
| 3500/1500 | SLO-Compliant | 4778.35 | 5007.36 | 1.05x | 4.00/28 | 4.00/28 | OK |
| 3500/1500 | Max-Throughput | 4669.26 | 5027.19 | 1.08x | 4.00/28 | 4.00/28 | OK |
| 32000/1500 | SLO-Compliant | 11373.42 | 14708.10 | 1.29x | 2.00/12 | 2.20/20 | OK |
| 32000/1500 | Max-Throughput | 12742.43 | 15359.18 | 1.21x | 2.00/20 | 2.20/24 | VIOLATE |
| 128000/1500 | SLO-Compliant | 13014.58 | 15362.97 | 1.18x | 1.00/4 | 1.00/4 | OK |
| 128000/1500 | Max-Throughput | 15116.68 | 18694.88 | 1.24x | 1.00/12 | 1.60/12 | VIOLATE |

# OP Accuracy
correctness：28 scenarios PASS，max diff 0.0006

# E2E Accuracy
| MegaMoE | Accuracy | Invalid | Latency(s) | Output tok/s | Throughput vs off |
|---|---:|---:|---:|---:|---:|
| off | 0.956 | 0.000 | 206.924 | 578.897 | 1.00x |
| on | 0.952 | 0.000 | 151.799 | 788.357 | 1.36x |
