### PR TITLE
Expose BF16 grouped GEMM wrappers

### DIFF
--- a/csrc/tvm_ffi_api.cpp
+++ b/csrc/tvm_ffi_api.cpp
@@ -382,6 +382,30 @@ void dg_bf16_gemm_tt(TensorView a, TensorView b, TensorView d,
     gemm::bf16_gemm_tt(convert_to_torch_tensor(a), convert_to_torch_tensor(b), convert_to_torch_tensor(d), c_opt, compiled_dims);
 }
 
+void dg_m_grouped_bf16_gemm_nt_contiguous(TensorView a, TensorView b, TensorView d,
+                                          TensorView grouped_layout,
+                                          std::string compiled_dims,
+                                          bool use_psum_layout,
+                                          Optional<int64_t> expected_m_for_psum_layout) {
+    auto expected_m_opt = expected_m_for_psum_layout.has_value()? std::make_optional((int)expected_m_for_psum_layout.value()) : std::nullopt;
+    gemm::m_grouped_bf16_gemm_nt_contiguous(
+        convert_to_torch_tensor(a), convert_to_torch_tensor(b),
+        convert_to_torch_tensor(d), convert_to_torch_tensor(grouped_layout),
+        compiled_dims, use_psum_layout, expected_m_opt
+    );
+}
+
+void dg_m_grouped_bf16_gemm_nt_masked(TensorView a, TensorView b, TensorView d,
+                                      TensorView masked_m,
+                                      int64_t expected_m,
+                                      std::string compiled_dims) {
+    gemm::m_grouped_bf16_gemm_nt_masked(
+        convert_to_torch_tensor(a), convert_to_torch_tensor(b),
+        convert_to_torch_tensor(d), convert_to_torch_tensor(masked_m),
+        (int) expected_m, compiled_dims
+    );
+}
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fp8_fp4_gemm_nt, dg_fp8_fp4_gemm_nt);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fp8_fp4_gemm_nn, dg_fp8_fp4_gemm_nn);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fp8_fp4_gemm_tn, dg_fp8_fp4_gemm_tn);
@@ -393,6 +417,8 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(bf16_gemm_nt, dg_bf16_gemm_nt);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(bf16_gemm_nn, dg_bf16_gemm_nn);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(bf16_gemm_tn, dg_bf16_gemm_tn);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(bf16_gemm_tt, dg_bf16_gemm_tt);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(m_grouped_bf16_gemm_nt_contiguous, dg_m_grouped_bf16_gemm_nt_contiguous);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(m_grouped_bf16_gemm_nt_masked, dg_m_grouped_bf16_gemm_nt_masked);
 
 // Einsum
 void dg_einsum(std::string expr, TensorView a, TensorView b, TensorView d,

--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -252,7 +252,14 @@ try:
         return _C.m_grouped_fp8_fp4_gemm_nt_masked(a, a_sf, b, b_sf, d, masked_m, expected_m, recipe, recipe_a, recipe_b, compiled_dims, disable_ue8m0_cast)
 
     fp8_m_grouped_gemm_nt_masked = m_grouped_fp8_fp4_gemm_nt_masked
-    bf16_m_grouped_gemm_nt_masked = None
+    
+    def m_grouped_bf16_gemm_nt_contiguous(a, b, d, grouped_layout, compiled_dims='nk', use_psum_layout=False, expected_m_for_psum_layout=None):
+        _C.m_grouped_bf16_gemm_nt_contiguous(a, b, d, grouped_layout, compiled_dims, use_psum_layout, expected_m_for_psum_layout)
+
+    def m_grouped_bf16_gemm_nt_masked(a, b, d, masked_m, expected_m, compiled_dims='nk'):
+        _C.m_grouped_bf16_gemm_nt_masked(a, b, d, masked_m, expected_m, compiled_dims)
+
+    bf16_m_grouped_gemm_nt_masked = m_grouped_bf16_gemm_nt_masked
 
 except AttributeError:
     pass

--- a/sgl_deep_gemm/__init__.py
+++ b/sgl_deep_gemm/__init__.py
@@ -251,7 +251,14 @@ try:
         return _C.m_grouped_fp8_fp4_gemm_nt_masked(a, a_sf, b, b_sf, d, masked_m, expected_m, recipe, recipe_a, recipe_b, compiled_dims, disable_ue8m0_cast)
 
     fp8_m_grouped_gemm_nt_masked = m_grouped_fp8_fp4_gemm_nt_masked
-    bf16_m_grouped_gemm_nt_masked = None
+
+    def m_grouped_bf16_gemm_nt_contiguous(a, b, d, grouped_layout, compiled_dims='nk', use_psum_layout=False, expected_m_for_psum_layout=None):
+        _C.m_grouped_bf16_gemm_nt_contiguous(a, b, d, grouped_layout, compiled_dims, use_psum_layout, expected_m_for_psum_layout)
+
+    def m_grouped_bf16_gemm_nt_masked(a, b, d, masked_m, expected_m, compiled_dims='nk'):
+        _C.m_grouped_bf16_gemm_nt_masked(a, b, d, masked_m, expected_m, compiled_dims)
+
+    bf16_m_grouped_gemm_nt_masked = m_grouped_bf16_gemm_nt_masked
 
 except AttributeError:
     pass


### PR DESCRIPTION
## Summary

Expose the BF16 grouped GEMM wrappers through both the Python package entrypoints and the tvm-ffi `_C` module.

This adds:

- `m_grouped_bf16_gemm_nt_contiguous`
- `m_grouped_bf16_gemm_nt_masked`

## Motivation

This fixes an SGLang MoE path failure where `deep_gemm.m_grouped_bf16_gemm_nt_masked` is called by the DeepGEMM wrapper but is not available from the installed `deep_gemm` module:

```text
File "/sgl-workspace/sglang/python/sglang/srt/layers/moe/moe_runner/runner.py", line 150, in run
    runner_output = self.runner_core.run(
File "/sgl-workspace/sglang/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py", line 155, in run
    hidden_states = self._run_masked_bf16_gemm(
File "/sgl-workspace/sglang/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py", line 520, in _run_masked_bf16_gemm
    deep_gemm_wrapper.grouped_gemm_nt_bf16_masked(
File "/sgl-workspace/sglang/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py", line 103, in grouped_gemm_nt_bf16_masked
    return deep_gemm.m_grouped_bf16_gemm_nt_masked(
AttributeError: module 'deep_gemm' has no attribute 'm_grouped_bf16_gemm_nt_masked'. Did you mean: 'm_grouped_fp8_fp4_gemm_nt_masked'?
```

## Root Cause

The BF16 grouped GEMM implementations already exist in `csrc/apis/gemm.hpp`, but the Python entrypoints and tvm-ffi API did not expose the masked BF16 grouped symbol expected by SGLang.

## Validation

- Ran `python -m py_compile deep_gemm/__init__.py sgl_deep_gemm/__init__.py`
- Ran `git diff --check`
