### PR TITLE
Change license in `pyproject.toml` to avoid build and publish failures with `setuptools>=77 `

### DIFF
--- a/sgl_deep_gemm/pyproject.toml
+++ b/sgl_deep_gemm/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,13 +7,13 @@ name = "sgl-deep-gemm"
 description = "SGLang fork of DeepGemm"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { file = "LICENSE" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     {name = "SGLang Kernel Team", email="sglang@lmsys.org"},
 ]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: Apache Software License",
   "Environment :: GPU :: NVIDIA CUDA"
 ]
 dynamic = ["version"]


### PR DESCRIPTION
https://github.com/sgl-project/sglang/actions/runs/27302299942/job/80664377268

The only reason it fails on cu13, is because cu12 is not on PyPi, so it doesn't encounter this bug