### PR TITLE
Support num_heads == 16 in MQA logits

### DIFF
--- a/csrc/apis/attention.hpp
+++ b/csrc/apis/attention.hpp
@@ -90,7 +90,7 @@ static torch::Tensor fp8_fp4_mqa_logits(const std::tuple<torch::Tensor, std::opt
         // Check FP4 Q
         std::tie(seq_len, num_heads, head_dim) = get_shape<3>(q_fp);
         head_dim *= 2;
-        DG_HOST_ASSERT(num_heads == 32 or num_heads == 64);
+        DG_HOST_ASSERT(num_heads == 16 or num_heads == 32 or num_heads == 64);
         DG_HOST_ASSERT(head_dim == 128);
         DG_HOST_ASSERT(q_fp.is_contiguous());
         DG_HOST_ASSERT(q_fp.scalar_type() == kPackedFP4);
@@ -117,7 +117,7 @@ static torch::Tensor fp8_fp4_mqa_logits(const std::tuple<torch::Tensor, std::opt
     } else {
         // Check FP8 Q
         std::tie(seq_len, num_heads, head_dim) = get_shape<3>(q_fp);
-        DG_HOST_ASSERT(num_heads == 32 or num_heads == 64);
+        DG_HOST_ASSERT(num_heads == 16 or num_heads == 32 or num_heads == 64);
         DG_HOST_ASSERT(head_dim == 32 or head_dim == 64 or head_dim == 128);
         DG_HOST_ASSERT(q_fp.is_contiguous());
         DG_HOST_ASSERT(q_fp.scalar_type() == torch::kFloat8_e4m3fn);
@@ -247,7 +247,7 @@ static torch::Tensor fp8_fp4_paged_mqa_logits(const std::tuple<torch::Tensor, st
         std::tie(batch_size, next_n, num_heads, head_dim) = get_shape<4>(q_fp);
         head_dim *= 2;
         DG_HOST_ASSERT(next_n >= 1);
-        DG_HOST_ASSERT(num_heads == 32 or num_heads == 64);
+        DG_HOST_ASSERT(num_heads == 16 or num_heads == 32 or num_heads == 64);
         DG_HOST_ASSERT(head_dim == 128);
         DG_HOST_ASSERT(q_fp.is_contiguous());
         DG_HOST_ASSERT(q_fp.scalar_type() == kPackedFP4);
@@ -285,7 +285,7 @@ static torch::Tensor fp8_fp4_paged_mqa_logits(const std::tuple<torch::Tensor, st
         // Check FP8 Q
         std::tie(batch_size, next_n, num_heads, head_dim) = get_shape<4>(q_fp);
         DG_HOST_ASSERT(next_n >= 1);
-        DG_HOST_ASSERT(num_heads == 32 or num_heads == 64);
+        DG_HOST_ASSERT(num_heads == 16 or num_heads == 32 or num_heads == 64);
         DG_HOST_ASSERT(head_dim == 32 or head_dim == 64 or head_dim == 128);
         DG_HOST_ASSERT(q_fp.is_contiguous());
         DG_HOST_ASSERT(q_fp.scalar_type() == torch::kFloat8_e4m3fn);

--- a/csrc/jit_kernels/impls/smxx_fp8_fp4_paged_mqa_logits.hpp
+++ b/csrc/jit_kernels/impls/smxx_fp8_fp4_paged_mqa_logits.hpp
@@ -235,7 +235,8 @@ static void smxx_fp8_paged_mqa_logits(const torch::Tensor& q,
         const int smem_q_size_per_stage = next_n_atom * num_heads * head_dim * static_cast<int>(q.element_size());
         const int smem_kv_size_per_stage = split_kv * head_dim * static_cast<int>(kv_cache.element_size());
         const int smem_kv_scale_size_per_stage = split_kv * static_cast<int>(kv_cache_scales.element_size());
-        const int smem_weight_size_per_stage = next_n_atom * num_heads * static_cast<int>(weights.element_size());
+        // The weight stage stride is padded to 128B in the kernel for TMA alignment
+        const int smem_weight_size_per_stage = align(next_n_atom * num_heads * static_cast<int>(weights.element_size()), 128);
 
         const int smem_barriers = (num_q_stages + num_kv_stages) * 2 * 8;
         const int smem_umma_barriers = num_math_warp_groups * 2 * 8;
@@ -415,7 +416,8 @@ static void sm100_fp4_paged_mqa_logits(const torch::Tensor& q,
     const int smem_sf_q_size_per_stage = align(next_n_atom * num_heads, 128) * sizeof(int);
     const int smem_kv_size_per_stage = split_kv * head_dim / 2;
     const int smem_sf_kv_size_per_stage = align(split_kv, 128) * sizeof(int);
-    const int smem_weight_size_per_stage = next_n_atom * num_heads * sizeof(float);
+    // The weight stage stride is padded to 128B in the kernel for TMA alignment
+    const int smem_weight_size_per_stage = align(next_n_atom * num_heads * static_cast<int>(sizeof(float)), 128);
 
     const int smem_barriers = (num_q_stages + num_kv_stages + num_tmem_stages) * 2 * 8;
     const int smem_tmem_ptr = 4;

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_mqa_logits.cuh
@@ -349,10 +349,11 @@ void sm100_fp4_mqa_logits(const uint32_t seq_len, const uint32_t seq_len_kv,
         // Helper lambda for loading tensor memory
         auto tmem_load = [](auto num_elems_c, const uint32_t& tmem_addr, float* accum) {
             constexpr uint32_t N = decltype(num_elems_c)::value;
-            DG_STATIC_ASSERT(N == 32 or N == 64, "Unsupported TMEM load size");
-            using Loader = cute::conditional_t<N == 32,
-                cute::SM100_TMEM_LOAD_32dp32b32x,
-                cute::SM100_TMEM_LOAD_32dp32b64x>;
+            DG_STATIC_ASSERT(N == 8 or N == 16 or N == 32 or N == 64, "Unsupported TMEM load size");
+            using Loader = cute::conditional_t<N == 8,  cute::SM100_TMEM_LOAD_32dp32b8x,
+                           cute::conditional_t<N == 16, cute::SM100_TMEM_LOAD_32dp32b16x,
+                           cute::conditional_t<N == 32, cute::SM100_TMEM_LOAD_32dp32b32x,
+                                                        cute::SM100_TMEM_LOAD_32dp32b64x>>>;
             [&]<size_t... Is>(cute::index_sequence<Is...>) {
                 Loader::copy(tmem_addr, reinterpret_cast<uint32_t*>(accum)[Is]...);
             }(cute::make_index_sequence<N>{});

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_paged_mqa_logits.cuh
@@ -79,6 +79,9 @@ void sm100_fp4_paged_mqa_logits(const uint32_t batch_size,
     static constexpr uint32_t SMEM_KV_SIZE_PER_STAGE     = SPLIT_KV * (kHeadDim / 2);
     static constexpr uint32_t SMEM_SF_KV_SIZE_PER_STAGE  = kNumSFKV * sizeof(int);
     static constexpr uint32_t SMEM_WEIGHT_SIZE_PER_STAGE = kNextNAtom * kNumHeads * sizeof(float);
+    // TMA requires 128B-aligned shared memory addresses, so pad the per-stage stride
+    // (e.g. `kNextNAtom == 1` with 16 heads gives only 64B per stage)
+    static constexpr uint32_t SMEM_WEIGHT_STRIDE_PER_STAGE = SMEM_WEIGHT_SIZE_PER_STAGE < 128 ? 128 : SMEM_WEIGHT_SIZE_PER_STAGE;
 
     // Align to swizzling alignment bytes
     extern __shared__ __align__(kSwizzleAlignment) uint8_t smem_buffer[];
@@ -101,7 +104,7 @@ void sm100_fp4_paged_mqa_logits(const uint32_t batch_size,
     });
     auto smem_weights = utils::PatternVisitor([&](const uint32_t& i) {
         return reinterpret_cast<float*>(smem_sf_ptr + SMEM_SF_Q_SIZE_PER_STAGE * kNumQStages + SMEM_SF_KV_SIZE_PER_STAGE * kNumKVStages
-                                                    + SMEM_WEIGHT_SIZE_PER_STAGE * i);
+                                                    + SMEM_WEIGHT_STRIDE_PER_STAGE * i);
     });
 
     // Barriers and TMEM pointer on shared memory
@@ -382,10 +385,11 @@ void sm100_fp4_paged_mqa_logits(const uint32_t batch_size,
         // Helper lambda for loading tensor memory
         auto tmem_load = [](auto num_elems_c, const uint32_t& tmem_addr, float* accum) {
             constexpr int N = decltype(num_elems_c)::value;
-            DG_STATIC_ASSERT(N == 32 or N == 64, "Unsupported TMEM load size");
-            using Loader = cute::conditional_t<N == 32,
-                cute::SM100_TMEM_LOAD_32dp32b32x,
-                cute::SM100_TMEM_LOAD_32dp32b64x>;
+            DG_STATIC_ASSERT(N == 8 or N == 16 or N == 32 or N == 64, "Unsupported TMEM load size");
+            using Loader = cute::conditional_t<N == 8,  cute::SM100_TMEM_LOAD_32dp32b8x,
+                           cute::conditional_t<N == 16, cute::SM100_TMEM_LOAD_32dp32b16x,
+                           cute::conditional_t<N == 32, cute::SM100_TMEM_LOAD_32dp32b32x,
+                                                        cute::SM100_TMEM_LOAD_32dp32b64x>>>;
             [&]<size_t... Is>(cute::index_sequence<Is...>) {
                 Loader::copy(tmem_addr, reinterpret_cast<uint32_t*>(accum)[Is]...);
             }(cute::make_index_sequence<N>{});

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_mqa_logits.cuh
@@ -293,10 +293,11 @@ void sm100_fp8_mqa_logits(const uint32_t seq_len, const uint32_t seq_len_kv,
         // Helper lambda for loading tensor memory
         auto tmem_load = [](auto num_elems_c, const uint32_t& tmem_addr, float* accum) {
             constexpr int N = decltype(num_elems_c)::value;
-            DG_STATIC_ASSERT(N == 32 or N == 64, "Unsupported TMEM load size");
-            using Loader = cute::conditional_t<N == 32,
-                cute::SM100_TMEM_LOAD_32dp32b32x,
-                cute::SM100_TMEM_LOAD_32dp32b64x>;
+            DG_STATIC_ASSERT(N == 8 or N == 16 or N == 32 or N == 64, "Unsupported TMEM load size");
+            using Loader = cute::conditional_t<N == 8,  cute::SM100_TMEM_LOAD_32dp32b8x,
+                           cute::conditional_t<N == 16, cute::SM100_TMEM_LOAD_32dp32b16x,
+                           cute::conditional_t<N == 32, cute::SM100_TMEM_LOAD_32dp32b32x,
+                                                        cute::SM100_TMEM_LOAD_32dp32b64x>>>;
             [&]<size_t... Is>(cute::index_sequence<Is...>) {
                 Loader::copy(tmem_addr, reinterpret_cast<uint32_t*>(accum)[Is]...);
             }(cute::make_index_sequence<N>{});

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_paged_mqa_logits.cuh
@@ -65,6 +65,9 @@ void sm100_fp8_paged_mqa_logits(const uint32_t batch_size,
     static constexpr uint32_t SMEM_KV_SIZE_PER_STAGE = SPLIT_KV * kHeadDim * sizeof(__nv_fp8_e4m3);
     static constexpr uint32_t SMEM_KV_SCALE_SIZE_PER_STAGE = SPLIT_KV * sizeof(float);
     static constexpr uint32_t SMEM_WEIGHT_SIZE_PER_STAGE = kNextNAtom * kNumHeads * sizeof(float);
+    // TMA requires 128B-aligned shared memory addresses, so pad the per-stage stride
+    // (e.g. `kNextNAtom == 1` with 16 heads gives only 64B per stage)
+    static constexpr uint32_t SMEM_WEIGHT_STRIDE_PER_STAGE = SMEM_WEIGHT_SIZE_PER_STAGE < 128 ? 128 : SMEM_WEIGHT_SIZE_PER_STAGE;
 
     // Align to swizzling alignment bytes
     extern __shared__ __align__(kSwizzleAlignment) uint8_t smem_buffer[];
@@ -83,7 +86,7 @@ void sm100_fp8_paged_mqa_logits(const uint32_t batch_size,
         return reinterpret_cast<float*>(smem_buffer + smem_offset + SMEM_KV_SCALE_SIZE_PER_STAGE * i);
     });
     auto smem_weights = utils::PatternVisitor([&](const uint32_t& i) {
-        return reinterpret_cast<float*>(smem_buffer + smem_offset + SMEM_KV_SCALE_SIZE_PER_STAGE * kNumKVStages + SMEM_WEIGHT_SIZE_PER_STAGE * i);
+        return reinterpret_cast<float*>(smem_buffer + smem_offset + SMEM_KV_SCALE_SIZE_PER_STAGE * kNumKVStages + SMEM_WEIGHT_STRIDE_PER_STAGE * i);
     });
 
     // Barriers and TMEM pointer on shared memory
@@ -307,10 +310,11 @@ void sm100_fp8_paged_mqa_logits(const uint32_t batch_size,
         // Helper lambda for loading tensor memory
         auto tmem_load = [](auto num_elems_c, const uint32_t& tmem_addr, float* accum) {
             constexpr int N = decltype(num_elems_c)::value;
-            DG_STATIC_ASSERT(N == 32 or N == 64, "Unsupported TMEM load size");
-            using Loader = cute::conditional_t<N == 32,
-                cute::SM100_TMEM_LOAD_32dp32b32x,
-                cute::SM100_TMEM_LOAD_32dp32b64x>;
+            DG_STATIC_ASSERT(N == 8 or N == 16 or N == 32 or N == 64, "Unsupported TMEM load size");
+            using Loader = cute::conditional_t<N == 8,  cute::SM100_TMEM_LOAD_32dp32b8x,
+                           cute::conditional_t<N == 16, cute::SM100_TMEM_LOAD_32dp32b16x,
+                           cute::conditional_t<N == 32, cute::SM100_TMEM_LOAD_32dp32b32x,
+                                                        cute::SM100_TMEM_LOAD_32dp32b64x>>>;
             [&]<size_t... Is>(cute::index_sequence<Is...>) {
                 Loader::copy(tmem_addr, reinterpret_cast<uint32_t*>(accum)[Is]...);
             }(cute::make_index_sequence<N>{});


### PR DESCRIPTION
Add host-side assertions and fix SM100 FP8/FP4 (paged) MQA logits kernels for num_heads == 16.