### PR TITLE
chore: bump apache-tvm-ffi 0.1.9 -> 0.1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,6 @@ if __name__ == '__main__':
             'build_py': CustomBuildPy,
         },
         install_requires=[
-            'apache-tvm-ffi==0.1.9',
+            'apache-tvm-ffi==0.1.11',
         ],
     )

--- a/sgl_deep_gemm/pyproject.toml
+++ b/sgl_deep_gemm/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "apache-tvm-ffi==0.1.9",
+    "apache-tvm-ffi==0.1.11",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What

Bump the `apache-tvm-ffi` pin `0.1.9` → `0.1.11` in the two (only) places it appears in this repo:

- `sgl_deep_gemm/pyproject.toml` — runtime dependency of the published `sgl-deep-gemm` wheel
- `setup.py` — `install_requires` of the legacy `deep_gemm` source build

## Why 0.1.11 (and not the latest 0.1.12)

`0.1.12` has a duplicate `__ffi_repr__` import-abort regression (tile-ai/tilelang#2367). `0.1.11` is the known-good target. Both are on PyPI.

## Verification

Built the wheel against tvm-ffi `0.1.11` and validated on both architectures.

**Hopper (H100):**
- `_C.so` compiles clean (sm90); `sgl_deep_gemm/run_tests.sh` single-GPU suite passes (`test_bf16`, `test_einsum`, `test_fp8_fp4`, `test_hyperconnection`, `test_layout`, `test_attention`).
- `test_mega_moe_hopper.py --num-processes 8` passes on an 8×H100 SXM (NVLink) node (~805 TFLOPS).
- `test_mega_moe_hopper.py --accuracy`: **28/28 scenarios, diff=0.0006 (tol 0.07)**.

**Blackwell (B300, sm103):**
- `_C.so` compiles clean (sm103, auto-detected — no arch override needed).
- Built into SGLang and served `deepseek-ai/DeepSeek-V4-Flash` (TP=4, fp4 MoE); **GSM8K accuracy 0.93–0.96, 0 invalid** across two runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)