### PR TITLE
Add minimal SM120 FP4 paged MQA support

### DIFF
--- a/csrc/apis/attention.hpp
+++ b/csrc/apis/attention.hpp
@@ -7,6 +7,7 @@
 #include "../jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp"
 #include "../jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp"
 #include "../jit_kernels/impls/sm100_mqa_logits.hpp"
+#include "../jit_kernels/impls/sm120_fp4_paged_mqa_logits.hpp"
 #include "../jit_kernels/impls/sm90_fp8_mqa_logits.hpp"
 #include "../jit_kernels/impls/smxx_clean_logits.hpp"
 #endif
@@ -220,6 +221,10 @@ static torch::Tensor get_paged_mqa_logits_metadata(const torch::Tensor& context_
     } else if (arch_major == 10) {
         DG_HOST_ASSERT(block_kv == 64 or block_kv == 32);
         sm100_paged_mqa_logits_metadata(context_lens, schedule_metadata, batch_size, batch_size * next_n, next_n, num_sms, is_context_lens_2d, false, nullptr);
+    } else if (arch_major == 12) {
+        DG_HOST_ASSERT(next_n == 1 and block_kv == 64);
+        sm120_fp4_paged_mqa_logits_metadata(
+            context_lens, schedule_metadata, batch_size, num_sms);
     } else if (arch_major == 9) {
         DG_HOST_ASSERT(block_kv == 64);
         sm90_paged_mqa_logits_metadata(context_lens, schedule_metadata, batch_size, next_n, block_kv, num_sms, is_context_lens_2d, false, nullptr);
@@ -255,10 +260,16 @@ static torch::Tensor fp8_fp4_paged_mqa_logits(const std::tuple<torch::Tensor, st
         // Check FP4 Q
         std::tie(batch_size, next_n, num_heads, head_dim) = get_shape<4>(q_fp);
         head_dim *= 2;
-        DG_HOST_ASSERT(next_n >= 1);
-        DG_HOST_ASSERT(arch_major == 10);
-        DG_HOST_ASSERT(num_heads == 8 or num_heads == 16 or num_heads == 32 or num_heads == 64);
-        DG_HOST_ASSERT(head_dim == 64 or head_dim == 128);
+        DG_HOST_ASSERT(arch_major == 10 or arch_major == 12);
+        DG_HOST_ASSERT(next_n >= 1 and (arch_major != 12 or next_n == 1));
+        DG_HOST_ASSERT(
+            (arch_major == 10 and
+             (num_heads == 8 or num_heads == 16 or
+              num_heads == 32 or num_heads == 64)) or
+            (arch_major == 12 and num_heads == 64));
+        DG_HOST_ASSERT(
+            (arch_major == 10 and (head_dim == 64 or head_dim == 128)) or
+            (arch_major == 12 and head_dim == 128));
         DG_HOST_ASSERT(q_fp.is_contiguous());
         DG_HOST_ASSERT(q_fp.scalar_type() == kPackedFP4);
 
@@ -271,8 +282,9 @@ static torch::Tensor fp8_fp4_paged_mqa_logits(const std::tuple<torch::Tensor, st
         // Check fused KV cache
         int num_heads_kv, fp4_with_sf_bytes;
         std::tie(num_kv_blocks, block_kv, num_heads_kv, fp4_with_sf_bytes) = get_shape<4>(fused_kv_cache);
-        DG_HOST_ASSERT((arch_major == 10 and (block_kv == 32 or block_kv == 64)) or
-                       (arch_major == 9 and block_kv == 64));
+        DG_HOST_ASSERT(
+            (arch_major == 10 and (block_kv == 32 or block_kv == 64)) or
+            (arch_major == 12 and block_kv == 64));
         DG_HOST_ASSERT(num_heads_kv == 1 and fp4_with_sf_bytes == head_dim / 2 + static_cast<int>(sizeof(int)));
         DG_HOST_ASSERT(fused_kv_cache.stride(1) == fp4_with_sf_bytes and fused_kv_cache.stride(3) == 1);
         DG_HOST_ASSERT(fused_kv_cache.scalar_type() == torch::kByte);
@@ -371,7 +383,7 @@ static torch::Tensor fp8_fp4_paged_mqa_logits(const std::tuple<torch::Tensor, st
 
     // Allocate output
     DG_HOST_ASSERT(logits_dtype == torch::kFloat32 or logits_dtype == torch::kBFloat16);
-    constexpr int split_kv = 256;
+    const int split_kv = arch_major == 12 ? 128 : 256;
     // Logits row stride must be 1024-byte aligned
     const int stride_logits_alignment = 1024 / static_cast<int>(c10::elementSize(logits_dtype));
     const auto aligned_max_context_len = align(align(max_context_len, split_kv), stride_logits_alignment);
@@ -384,6 +396,13 @@ static torch::Tensor fp8_fp4_paged_mqa_logits(const std::tuple<torch::Tensor, st
         sm100_paged_mqa_logits(is_fp4, q_fp, q_sf, kv_cache, kv_cache_sf, weights, context_lens, logits, block_table, indices_tensor, schedule_meta,
                                logits_dtype, batch_size, batch_size * next_n, next_n, num_heads, head_dim, num_kv_blocks, block_kv, is_context_lens_2d,
                                is_varlen, aligned_max_context_len, block_table_stride, num_sms, split_kv, splits_per_chunk);
+    } else if (arch_major == 12 and is_fp4) {
+        DG_HOST_ASSERT(not is_varlen and logits_dtype == torch::kFloat32);
+        sm120_fp4_paged_mqa_logits(
+            q_fp, q_sf.value(), kv_cache, kv_cache_sf, weights,
+            context_lens, logits, block_table, schedule_meta,
+            batch_size, num_heads, head_dim, num_kv_blocks, block_kv,
+            aligned_max_context_len, block_table_stride, num_sms, split_kv);
     } else if (arch_major == 9 and not is_fp4) {
         DG_HOST_ASSERT(weights.scalar_type() == torch::kFloat);
         sm90_fp8_paged_mqa_logits(q_fp, kv_cache, kv_cache_sf, weights, context_lens, logits, block_table, indices_tensor, schedule_meta,

--- a/csrc/jit/compiler.hpp
+++ b/csrc/jit/compiler.hpp
@@ -202,10 +202,15 @@ public:
         // The override the compiler flags
         // Only NVCC >= 12.9 supports arch-specific family suffix
         const auto arch = device_runtime->get_arch(false, nvcc_major > 12 or nvcc_minor >= 9);
-        flags = fmt::format("{} -I{} --gpu-architecture=sm_{} "
+        // SM120a must use -gencode. With --gpu-architecture, ptxas may fall
+        // back to sm_120 and reject architecture-specific block-scale MMA.
+        const auto arch_flag = device_runtime->get_arch_major() == 12
+            ? fmt::format("-gencode=arch=compute_{},code=sm_{}", arch, arch)
+            : fmt::format("--gpu-architecture=sm_{}", arch);
+        flags = fmt::format("{} -I{} {} "
                             "--compiler-options=-fPIC,-O3,-fconcepts,-Wno-deprecated-declarations,-Wno-abi "
                             "-O3 --expt-relaxed-constexpr --expt-extended-lambda",
-                            flags, library_include_path.c_str(), arch);
+                            flags, library_include_path.c_str(), arch_flag);
     }
 
     void compile(const std::string &code, const std::filesystem::path& dir_path,

--- a/csrc/jit_kernels/impls/sm120_fp4_paged_mqa_logits.hpp
+++ b/csrc/jit_kernels/impls/sm120_fp4_paged_mqa_logits.hpp
@@ -1,0 +1,175 @@
+#pragma once
+
+#include "sm100_mqa_logits.hpp"
+
+namespace deep_gemm {
+
+static constexpr int kSM120SmemCapacity = 101376;
+
+static void sm120_fp4_paged_mqa_logits_metadata(
+        const torch::Tensor& context_lens,
+        const torch::Tensor& schedule_meta,
+        const int batch_size, const int num_sms) {
+    constexpr int next_n = 1;
+    constexpr int split_kv = 128;
+    constexpr int num_threads = 256;
+    const int smem_size = 2 * batch_size * static_cast<int>(sizeof(int));
+    DG_HOST_ASSERT(smem_size <= kSM120SmemCapacity);
+
+    const SM100PagedMQALogitsMetadataRuntime::Args args = {
+        .next_n = next_n,
+        .is_context_lens_2d = true,
+        .is_varlen = false,
+        .split_kv = split_kv,
+        .num_sms = num_sms,
+        .num_requests = batch_size,
+        .num_q_tokens_total = batch_size,
+        .context_lens = context_lens.data_ptr<int>(),
+        .indices = nullptr,
+        .schedule_meta = schedule_meta.data_ptr<int>(),
+        .launch_args = LaunchArgs(1, num_threads, smem_size)
+    };
+    const auto code = SM100PagedMQALogitsMetadataRuntime::generate(args);
+    const auto runtime =
+        compiler->build("sm120_fp4_paged_mqa_logits_metadata", code);
+    SM100PagedMQALogitsMetadataRuntime::launch(runtime, args);
+}
+
+class SM120FP4PagedMQALogitsRuntime final
+        : public LaunchRuntime<SM120FP4PagedMQALogitsRuntime> {
+public:
+    struct Args {
+        int batch_size;
+        int block_table_stride;
+        int logits_stride;
+
+        int* context_lens;
+        float* logits;
+        int* block_table;
+        int* schedule_meta;
+
+        CUtensorMap tensor_map_q;
+        CUtensorMap tensor_map_sf_q;
+        CUtensorMap tensor_map_kv;
+        CUtensorMap tensor_map_sf_kv;
+        CUtensorMap tensor_map_weights;
+
+        LaunchArgs launch_args;
+    };
+
+    static std::string generate_impl(const Args&) {
+        return R"(
+#include <deep_gemm/impls/sm120_fp4_paged_mqa_logits.cuh>
+
+using namespace deep_gemm;
+
+static void __instantiate_kernel() {
+    auto ptr = reinterpret_cast<void*>(&sm120_fp4_paged_mqa_logits);
+}
+)";
+    }
+
+    static void launch_impl(
+            const KernelHandle& kernel, const LaunchConfigHandle& config,
+            Args args) {
+        DG_CUDA_UNIFIED_CHECK(launch_kernel(
+            kernel, config,
+            args.batch_size, args.logits_stride, args.block_table_stride,
+            args.context_lens, args.logits, args.block_table,
+            args.schedule_meta, args.tensor_map_q, args.tensor_map_sf_q,
+            args.tensor_map_kv, args.tensor_map_sf_kv,
+            args.tensor_map_weights
+        ));
+    }
+};
+
+static void sm120_fp4_paged_mqa_logits(
+        const torch::Tensor& q, const torch::Tensor& sf_q,
+        const torch::Tensor& kv_cache, const torch::Tensor& kv_cache_sf,
+        const torch::Tensor& weights, const torch::Tensor& context_lens,
+        const torch::Tensor& logits, const torch::Tensor& block_table,
+        const torch::Tensor& schedule_meta, const int batch_size,
+        const int num_heads, const int head_dim, const int num_kv_blocks,
+        const int block_kv, const int logits_stride,
+        const int block_table_stride, const int num_sms,
+        const int split_kv) {
+    constexpr int num_tma_threads = 128;
+    constexpr int num_math_threads = 256;
+    constexpr int num_q_stages = 2;
+    constexpr int num_kv_stages = 3;
+
+    DG_HOST_ASSERT(num_heads == 64 and head_dim == 128);
+    DG_HOST_ASSERT(block_kv == 64 and split_kv == 128);
+    DG_HOST_ASSERT(logits_stride % split_kv == 0);
+    DG_HOST_ASSERT(logits.scalar_type() == torch::kFloat32);
+
+    const auto tensor_map_q = make_tma_2d_desc(
+        q, head_dim, batch_size * num_heads,
+        head_dim, num_heads, static_cast<int>(q.stride(2)),
+        head_dim / 2, 0, false, false);
+    const auto tensor_map_sf_q = make_tma_2d_desc(
+        sf_q, num_heads, batch_size, num_heads, 1,
+        static_cast<int>(sf_q.stride(1)), 0);
+    const auto tensor_map_weights = make_tma_2d_desc(
+        weights, num_heads, batch_size, num_heads, 1,
+        static_cast<int>(weights.stride(0)), 0);
+    const auto tensor_map_kv = make_tma_3d_desc(
+        kv_cache, head_dim, block_kv, num_kv_blocks,
+        head_dim, block_kv, 1,
+        static_cast<int>(kv_cache.stride(1)),
+        static_cast<int>(kv_cache.stride(0)),
+        head_dim / 2, 0, false, false);
+    const auto tensor_map_sf_kv = make_tma_2d_desc(
+        kv_cache_sf, block_kv, num_kv_blocks, block_kv, 1,
+        static_cast<int>(kv_cache_sf.stride(0)), 0);
+
+    const int swizzle_alignment = head_dim / 2 * 8;
+    const int smem_q_size_per_stage = num_heads * head_dim / 2;
+    const int aligned_smem_sf_q_size_per_stage = align(
+        num_heads * static_cast<int>(sizeof(int)), swizzle_alignment);
+    const int aligned_smem_weight_size_per_stage = align(
+        num_heads * static_cast<int>(sizeof(float)), swizzle_alignment);
+    const int smem_q_pipe_size =
+        num_q_stages *
+            (smem_q_size_per_stage +
+             aligned_smem_sf_q_size_per_stage +
+             aligned_smem_weight_size_per_stage) +
+        align(num_q_stages * 8 * 2, swizzle_alignment);
+
+    const int smem_kv_size_per_stage = block_kv * head_dim / 2;
+    const int aligned_smem_sf_kv_size_per_stage = align(
+        block_kv * static_cast<int>(sizeof(int)), swizzle_alignment);
+    const int smem_kv_pipe_size =
+        num_kv_stages *
+            (smem_kv_size_per_stage +
+             aligned_smem_sf_kv_size_per_stage) +
+        align(num_kv_stages * 8 * 2, swizzle_alignment);
+
+    const int num_groups = split_kv / block_kv;
+    const int smem_size =
+        smem_q_pipe_size + num_groups * smem_kv_pipe_size + 4;
+    DG_HOST_ASSERT(smem_size <= kSM120SmemCapacity);
+
+    const SM120FP4PagedMQALogitsRuntime::Args args = {
+        .batch_size = batch_size,
+        .block_table_stride = block_table_stride,
+        .logits_stride = logits_stride,
+        .context_lens = context_lens.data_ptr<int>(),
+        .logits = logits.data_ptr<float>(),
+        .block_table = block_table.data_ptr<int>(),
+        .schedule_meta = schedule_meta.data_ptr<int>(),
+        .tensor_map_q = tensor_map_q,
+        .tensor_map_sf_q = tensor_map_sf_q,
+        .tensor_map_kv = tensor_map_kv,
+        .tensor_map_sf_kv = tensor_map_sf_kv,
+        .tensor_map_weights = tensor_map_weights,
+        .launch_args = LaunchArgs(
+            num_sms, num_tma_threads + num_math_threads, smem_size)
+    };
+    const auto code = SM120FP4PagedMQALogitsRuntime::generate(args);
+    const auto runtime =
+        compiler->build("sm120_fp4_paged_mqa_logits", code);
+    SM120FP4PagedMQALogitsRuntime::launch(runtime, args);
+}
+
+}  // namespace deep_gemm

--- a/deep_gemm/include/deep_gemm/common/sm120_utils.cuh
+++ b/deep_gemm/include/deep_gemm/common/sm120_utils.cuh
@@ -1,0 +1,56 @@
+#pragma once
+
+#if (defined(__CUDA_ARCH__) and (__CUDA_ARCH__ >= 1200)) || defined(__CLION_IDE__)
+
+#include <cute/swizzle.hpp>
+
+#include <deep_gemm/ptx/ld_st.cuh>
+
+namespace deep_gemm::sm120 {
+
+template <int kSwizzleBytes>
+using CuTeSwizzle = cute::Swizzle<__builtin_ctz(kSwizzleBytes) - 4, 4, 3>;
+
+template <int kSwizzleBytes>
+struct SwizzleContext {
+    int row_base_addr;
+    int row_xor_bits;
+
+    CUTLASS_DEVICE void init(const int row, const int row_stride) {
+        row_base_addr = row * row_stride;
+        row_xor_bits =
+            CuTeSwizzle<kSwizzleBytes>::apply(row_base_addr) ^ row_base_addr;
+    }
+
+    CUTLASS_DEVICE void* addr(char* smem_tile, const int col_byte) const {
+        return smem_tile + row_base_addr + (col_byte ^ row_xor_bits);
+    }
+};
+
+template <int kSwizzleBytes>
+CUTLASS_DEVICE void load_a_fragment(
+        uint32_t (&frag)[4], char* smem_a,
+        const SwizzleContext<kSwizzleBytes>& ctx, const int lane,
+        const int k_step, const int mma_k) {
+    const int col = (lane >> 4) * 16 + k_step * mma_k;
+    ptx::SM90_U32x4_LDSM_N::copy(
+        frag[0], frag[1], frag[2], frag[3], ctx.addr(smem_a, col));
+}
+
+template <int kSwizzleBytes>
+CUTLASS_DEVICE void load_b_fragment_x2(
+        uint32_t (&frag)[2], char* smem_b,
+        const SwizzleContext<kSwizzleBytes>& ctx, const int lane,
+        const int k_step, const int mma_k) {
+    const int col = ((lane >> 3) & 1) * 16 + k_step * mma_k;
+    ptx::SM90_U32x2_LDSM_N::copy(frag[0], frag[1], ctx.addr(smem_b, col));
+}
+
+CUTLASS_DEVICE uint32_t load_sf(const char* smem_sf, const int idx) {
+    return *reinterpret_cast<const uint32_t*>(
+        smem_sf + idx * static_cast<int>(sizeof(int32_t)));
+}
+
+}  // namespace deep_gemm::sm120
+
+#endif

--- a/deep_gemm/include/deep_gemm/impls/sm120_fp4_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm120_fp4_paged_mqa_logits.cuh
@@ -1,0 +1,387 @@
+#pragma once
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-attributes"
+
+#include <cutlass/arch/barrier.h>
+#include <cutlass/arch/reg_reconfig.h>
+
+#include <cute/arch/cluster_sm90.hpp>
+#include <cute/arch/copy_sm90_desc.hpp>
+
+#include <deep_gemm/common/cute_tie.cuh>
+#include <deep_gemm/common/math.cuh>
+#include <deep_gemm/common/sm120_utils.cuh>
+#include <deep_gemm/common/tma_copy.cuh>
+#include <deep_gemm/common/types.cuh>
+#include <deep_gemm/common/utils.cuh>
+#include <deep_gemm/mma/sm120.cuh>
+#include <deep_gemm/ptx/ld_st.cuh>
+#include <deep_gemm/ptx/utils.cuh>
+#include <deep_gemm/scheduler/sm120_fp4_paged_mqa_logits.cuh>
+
+namespace deep_gemm {
+
+CUTLASS_GLOBAL __launch_bounds__(384, 1)
+void sm120_fp4_paged_mqa_logits(
+        const uint32_t batch_size, const uint32_t logits_stride,
+        const uint32_t block_table_stride, const uint32_t* context_lens,
+        float* logits, const uint32_t* block_table,
+        const uint32_t* schedule_meta,
+        const __grid_constant__ cute::TmaDescriptor tensor_map_q,
+        const __grid_constant__ cute::TmaDescriptor tensor_map_sf_q,
+        const __grid_constant__ cute::TmaDescriptor tensor_map_kv,
+        const __grid_constant__ cute::TmaDescriptor tensor_map_sf_kv,
+        const __grid_constant__ cute::TmaDescriptor tensor_map_weights) {
+#if (defined(__CUDA_ARCH__) and (__CUDA_ARCH__ >= 1200)) || defined(__CLION_IDE__)
+    using namespace mma::sm120;
+    using Barrier = cutlass::arch::ClusterTransactionBarrier;
+
+    static constexpr uint32_t kNumHeads = 64;
+    static constexpr uint32_t kHeadDim = 128;
+    static constexpr uint32_t kBlockKV = 64;
+    static constexpr uint32_t kSplitKV = 128;
+    static constexpr uint32_t kNumQStages = 2;
+    static constexpr uint32_t kNumKVStages = 3;
+    static constexpr uint32_t kNumTMAThreads = 128;
+    static constexpr uint32_t kNumMathThreads = 256;
+
+    static constexpr uint32_t kMMAM = FP4_MMA_M;
+    static constexpr uint32_t kMMAN = FP4_MMA_N;
+    static constexpr uint32_t kMMAK = FP4_MMA_K;
+    static constexpr uint32_t kKSteps = kHeadDim / kMMAK;
+    static constexpr uint32_t kNTilesPerQ = kNumHeads / kMMAN;
+    static constexpr uint32_t kLdmK = kMMAK / 2;
+
+    static constexpr uint32_t kNumMathWarps = kNumMathThreads / 32;
+    static constexpr uint32_t kWarpsPerGroup = kBlockKV / kMMAM;
+    static constexpr uint32_t kNumGroups = kNumMathWarps / kWarpsPerGroup;
+    static constexpr uint32_t kSwizzleMode = 64;
+    static constexpr uint32_t kSMEMKBytes = kHeadDim / 2;
+    static_assert(kSplitKV == kBlockKV * kNumGroups);
+
+    static constexpr uint32_t kSMEMQSizePerStage =
+        kNumHeads * (kHeadDim / 2);
+    static constexpr uint32_t kSMEMSFQSizePerStage =
+        kNumHeads * sizeof(uint32_t);
+    static constexpr uint32_t kSMEMWeightSizePerStage =
+        kNumHeads * sizeof(float);
+    static constexpr uint32_t kSMEMKVSizePerStage =
+        kBlockKV * (kHeadDim / 2);
+    static constexpr uint32_t kSMEMSFKVSizePerStage =
+        kBlockKV * sizeof(uint32_t);
+    static constexpr uint32_t kSwizzleAlignment = (kHeadDim / 2) * 8;
+
+    static constexpr uint32_t kAlignedSMEMSFQSizePerStage =
+        math::constexpr_align(kSMEMSFQSizePerStage, kSwizzleAlignment);
+    static constexpr uint32_t kAlignedSMEMWeightSizePerStage =
+        math::constexpr_align(kSMEMWeightSizePerStage, kSwizzleAlignment);
+    static constexpr uint32_t kSMEMQPipeSize =
+        kNumQStages *
+            (kSMEMQSizePerStage + kAlignedSMEMSFQSizePerStage +
+             kAlignedSMEMWeightSizePerStage) +
+        math::constexpr_align(kNumQStages * 8 * 2, kSwizzleAlignment);
+    static constexpr uint32_t kAlignedSMEMSFKVSizePerStage =
+        math::constexpr_align(kSMEMSFKVSizePerStage, kSwizzleAlignment);
+    static constexpr uint32_t kSMEMKVPipeSize =
+        kNumKVStages *
+            (kSMEMKVSizePerStage + kAlignedSMEMSFKVSizePerStage) +
+        math::constexpr_align(kNumKVStages * 8 * 2, kSwizzleAlignment);
+
+    const auto warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    const auto lane_idx = ptx::get_lane_idx();
+
+    if (warp_idx == kNumMathWarps and cute::elect_one_sync()) {
+        cute::prefetch_tma_descriptor(&tensor_map_q);
+        cute::prefetch_tma_descriptor(&tensor_map_sf_q);
+        cute::prefetch_tma_descriptor(&tensor_map_kv);
+        cute::prefetch_tma_descriptor(&tensor_map_sf_kv);
+        cute::prefetch_tma_descriptor(&tensor_map_weights);
+    }
+    __syncwarp();
+
+    extern __shared__ __align__(kSwizzleAlignment) uint8_t smem_buffer[];
+
+    auto smem_q = utils::PatternVisitor([&](const uint32_t i) {
+        return smem_buffer + kSMEMQSizePerStage * i;
+    });
+    auto smem_sf_q = utils::PatternVisitor([&](const uint32_t i) {
+        return reinterpret_cast<uint32_t*>(
+            smem_buffer + kSMEMQSizePerStage * kNumQStages +
+            kAlignedSMEMSFQSizePerStage * i);
+    });
+    auto smem_weights = utils::PatternVisitor([&](const uint32_t i) {
+        return reinterpret_cast<float*>(
+            smem_buffer + kSMEMQSizePerStage * kNumQStages +
+            kAlignedSMEMSFQSizePerStage * kNumQStages +
+            kAlignedSMEMWeightSizePerStage * i);
+    });
+    auto q_barrier_ptr =
+        reinterpret_cast<Barrier*>(smem_weights[kNumQStages]);
+    auto full_q_barriers = utils::PatternVisitor(
+        [&](const uint32_t i) { return q_barrier_ptr + i; });
+    auto empty_q_barriers = utils::PatternVisitor(
+        [&](const uint32_t i) { return q_barrier_ptr + kNumQStages + i; });
+
+    const auto kv_group_idx = __shfl_sync(
+        0xffffffff,
+        threadIdx.x >= kNumMathThreads
+            ? (threadIdx.x - kNumMathThreads) / 32
+            : warp_idx / kWarpsPerGroup,
+        0);
+    const auto smem_offset =
+        kSMEMQPipeSize + kSMEMKVPipeSize * kv_group_idx;
+    auto smem_kv = utils::PatternVisitor([&](const uint32_t i) {
+        return smem_buffer + smem_offset + kSMEMKVSizePerStage * i;
+    });
+    auto smem_sf_kv = utils::PatternVisitor([&](const uint32_t i) {
+        return reinterpret_cast<uint32_t*>(
+            smem_buffer + smem_offset +
+            kSMEMKVSizePerStage * kNumKVStages +
+            kAlignedSMEMSFKVSizePerStage * i);
+    });
+    auto kv_barrier_ptr =
+        reinterpret_cast<Barrier*>(smem_sf_kv[kNumKVStages]);
+    auto full_kv_barriers = utils::PatternVisitor(
+        [&](const uint32_t i) { return kv_barrier_ptr + i; });
+    auto empty_kv_barriers = utils::PatternVisitor(
+        [&](const uint32_t i) { return kv_barrier_ptr + kNumKVStages + i; });
+
+    if (warp_idx >= kNumMathWarps and cute::elect_one_sync()) {
+        if (kv_group_idx == 0) {
+#pragma unroll
+            for (uint32_t i = 0; i < kNumQStages; ++i) {
+                full_q_barriers[i]->init(1);
+                empty_q_barriers[i]->init(kNumMathThreads);
+            }
+        }
+        if (kv_group_idx < kNumGroups) {
+#pragma unroll
+            for (uint32_t i = 0; i < kNumKVStages; ++i) {
+                full_kv_barriers[i]->init(1);
+                empty_kv_barriers[i]->init(kWarpsPerGroup * 32);
+            }
+        }
+        cutlass::arch::fence_barrier_init();
+    }
+    __syncthreads();
+
+    cudaGridDependencySynchronize();
+
+    auto scheduler =
+        sched::SM120FP4PagedMQALogitsScheduler<kBlockKV, kNumGroups>(
+            blockIdx.x, batch_size, context_lens, schedule_meta);
+
+    const auto get_q_pipeline =
+        [](const uint32_t iter) -> cute::tuple<uint32_t, uint32_t> {
+        return {iter % kNumQStages, (iter / kNumQStages) & 1};
+    };
+    const auto get_kv_pipeline =
+        [](const uint32_t iter) -> cute::tuple<uint32_t, uint32_t> {
+        return {iter % kNumKVStages, (iter / kNumKVStages) & 1};
+    };
+    uint32_t q_iter_idx = 0;
+    uint32_t kv_iter_idx = 0;
+
+    if (warp_idx >= kNumMathWarps) {
+        cutlass::arch::warpgroup_reg_dealloc<40>();
+        if (kv_group_idx >= kNumGroups)
+            return;
+
+        using Scheduler = decltype(scheduler);
+        const auto issue_tma_q =
+            [&](const uint32_t stage_idx, const uint32_t q_idx) {
+            if (kv_group_idx == 0 and cute::elect_one_sync()) {
+                const auto q_token_idx = Scheduler::atom_to_token_idx(q_idx);
+                tma::copy<kHeadDim, kNumHeads, 0>(
+                    &tensor_map_q, full_q_barriers[stage_idx],
+                    smem_q[stage_idx], 0, q_token_idx * kNumHeads);
+                tma::copy<kNumHeads, 1, 0>(
+                    &tensor_map_sf_q, full_q_barriers[stage_idx],
+                    smem_sf_q[stage_idx], 0, q_token_idx);
+                tma::copy<kNumHeads, 1, 0>(
+                    &tensor_map_weights, full_q_barriers[stage_idx],
+                    smem_weights[stage_idx], 0, q_token_idx);
+                full_q_barriers[stage_idx]->arrive_and_expect_tx(
+                    kSMEMQSizePerStage + kSMEMSFQSizePerStage +
+                    kSMEMWeightSizePerStage);
+            }
+        };
+
+        uint32_t q_idx = batch_size;
+        uint32_t kv_idx;
+        uint32_t num_kv;
+        uint32_t next_q_idx;
+        uint32_t next_kv_idx;
+        uint32_t next_num_kv;
+        bool fetched_next_task =
+            scheduler.fetch_next_task(next_q_idx, next_kv_idx, next_num_kv);
+        if (fetched_next_task) {
+            issue_tma_q(0, next_q_idx);
+            q_iter_idx = 1;
+        }
+
+        int kv_block_idx_ptr = 32;
+        uint32_t kv_block_idx_storage;
+
+        while (fetched_next_task) {
+            const bool prefetch_q =
+                q_idx != next_q_idx &&
+                scheduler.exist_q_atom_idx(next_q_idx + 1);
+
+            if (q_idx != next_q_idx)
+                kv_block_idx_ptr = 32;
+            q_idx = next_q_idx;
+            kv_idx = next_kv_idx;
+            num_kv = next_num_kv;
+
+            if (prefetch_q) {
+                CUTE_TIE_DECL(
+                    get_q_pipeline(q_iter_idx++), q_stage_idx, q_phase);
+                empty_q_barriers[q_stage_idx]->wait(q_phase ^ 1);
+                issue_tma_q(q_stage_idx, q_idx + 1);
+            }
+
+            if (kv_block_idx_ptr == 32) {
+                kv_block_idx_ptr = 0;
+                const auto page_idx =
+                    kv_idx + kv_group_idx + lane_idx * kNumGroups;
+                kv_block_idx_storage = page_idx < num_kv
+                    ? block_table[
+                          Scheduler::atom_to_block_table_row(q_idx) *
+                              static_cast<uint64_t>(block_table_stride) +
+                          page_idx]
+                    : 0;
+            }
+            const auto kv_block_idx = __shfl_sync(
+                0xffffffff, kv_block_idx_storage, kv_block_idx_ptr++);
+
+            CUTE_TIE_DECL(
+                get_kv_pipeline(kv_iter_idx++), kv_stage_idx, kv_phase);
+            empty_kv_barriers[kv_stage_idx]->wait(kv_phase ^ 1);
+
+            if (cute::elect_one_sync()) {
+                tma::copy<kHeadDim, kBlockKV, 0, uint8_t, true>(
+                    &tensor_map_kv, full_kv_barriers[kv_stage_idx],
+                    smem_kv[kv_stage_idx], 0, 0, 1, kv_block_idx);
+                tma::copy<kBlockKV, 1, 0>(
+                    &tensor_map_sf_kv, full_kv_barriers[kv_stage_idx],
+                    smem_sf_kv[kv_stage_idx], 0, kv_block_idx);
+                full_kv_barriers[kv_stage_idx]->arrive_and_expect_tx(
+                    kSMEMKVSizePerStage + kSMEMSFKVSizePerStage);
+            }
+
+            fetched_next_task =
+                scheduler.fetch_next_task(
+                    next_q_idx, next_kv_idx, next_num_kv);
+        }
+    } else {
+        cutlass::arch::warpgroup_reg_alloc<232>();
+
+        const uint32_t warp_in_group = warp_idx % kWarpsPerGroup;
+        const uint32_t g = lane_idx / 4;
+        const uint32_t t = lane_idx % 4;
+        const uint32_t a_row =
+            (lane_idx & 7) + ((lane_idx >> 3) & 1) * 8;
+
+        uint32_t q_idx = batch_size;
+        uint32_t kv_idx;
+        uint32_t next_q_idx;
+        uint32_t next_kv_idx;
+        uint32_t next_num_kv;
+        uint32_t q_stage_idx = 0;
+        uint32_t q_phase = 0;
+
+        while (scheduler.fetch_next_task(
+                next_q_idx, next_kv_idx, next_num_kv)) {
+            if (q_idx != next_q_idx) {
+                if (q_iter_idx > 0)
+                    empty_q_barriers[
+                        (q_iter_idx - 1) % kNumQStages]->arrive();
+                CUTE_TIE(
+                    get_q_pipeline(q_iter_idx++), q_stage_idx, q_phase);
+                full_q_barriers[q_stage_idx]->wait(q_phase);
+            }
+            q_idx = next_q_idx;
+            kv_idx = next_kv_idx;
+
+            const auto kv_offset =
+                q_idx * static_cast<uint64_t>(logits_stride) +
+                (kv_idx + kv_group_idx) * kBlockKV +
+                warp_in_group * kMMAM;
+
+            CUTE_TIE_DECL(
+                get_kv_pipeline(kv_iter_idx++), kv_stage_idx, kv_phase);
+            full_kv_barriers[kv_stage_idx]->wait(kv_phase);
+
+            const uint32_t sf_kv_packed = sm120::load_sf(
+                reinterpret_cast<const char*>(smem_sf_kv[kv_stage_idx]),
+                warp_in_group * kMMAM + g + (t & 1) * 8);
+
+            sm120::SwizzleContext<kSwizzleMode> a_ctx;
+            a_ctx.init(a_row + warp_in_group * kMMAM, kSMEMKBytes);
+
+            float partial_0 = 0.0f;
+            float partial_1 = 0.0f;
+#pragma unroll
+            for (uint32_t nt = 0; nt < kNTilesPerQ; ++nt) {
+                float d[4] = {0, 0, 0, 0};
+                sm120::SwizzleContext<kSwizzleMode> b_ctx;
+                b_ctx.init((lane_idx & 7) + nt * kMMAN, kSMEMKBytes);
+
+                const uint32_t sf_q_packed = sm120::load_sf(
+                    reinterpret_cast<const char*>(smem_sf_q[q_stage_idx]),
+                    nt * kMMAN + g);
+
+#pragma unroll
+                for (uint32_t k = 0; k < kKSteps; ++k) {
+                    uint32_t a_frag[4];
+                    sm120::load_a_fragment<kSwizzleMode>(
+                        a_frag,
+                        reinterpret_cast<char*>(smem_kv[kv_stage_idx]),
+                        a_ctx, lane_idx, k, kLdmK);
+                    uint32_t b_frag[2];
+                    sm120::load_b_fragment_x2<kSwizzleMode>(
+                        b_frag,
+                        reinterpret_cast<char*>(smem_q[q_stage_idx]),
+                        b_ctx, lane_idx, k, kLdmK);
+                    fp4_mma_block_scaled(
+                        d, a_frag, b_frag,
+                        extract_sf_pair(sf_kv_packed, k * 2),
+                        extract_sf_pair(sf_q_packed, k * 2));
+                }
+
+                const uint32_t h0 = nt * kMMAN + t * 2;
+                const float w0 =
+                    ptx::ld_shared(smem_weights[q_stage_idx] + h0);
+                const float w1 =
+                    ptx::ld_shared(smem_weights[q_stage_idx] + h0 + 1);
+                partial_0 +=
+                    fmaxf(d[0], 0.0f) * w0 + fmaxf(d[1], 0.0f) * w1;
+                partial_1 +=
+                    fmaxf(d[2], 0.0f) * w0 + fmaxf(d[3], 0.0f) * w1;
+            }
+
+#pragma unroll
+            for (uint32_t j = 0; j < 2; ++j) {
+                const auto offset = static_cast<int>(1u << j);
+                partial_0 +=
+                    __shfl_xor_sync(0xffffffffu, partial_0, offset);
+                partial_1 +=
+                    __shfl_xor_sync(0xffffffffu, partial_1, offset);
+            }
+
+            logits[kv_offset + g] = partial_0;
+            logits[kv_offset + g + 8] = partial_1;
+            empty_kv_barriers[kv_stage_idx]->arrive();
+        }
+    }
+#else
+    if (blockIdx.x == 0 and threadIdx.x == 0)
+        DG_DEVICE_ASSERT(false and "This kernel only supports sm_120a");
+#endif
+}
+
+}  // namespace deep_gemm
+
+#pragma clang diagnostic pop

--- a/deep_gemm/include/deep_gemm/mma/sm120.cuh
+++ b/deep_gemm/include/deep_gemm/mma/sm120.cuh
@@ -1,0 +1,38 @@
+#pragma once
+
+#if (defined(__CUDA_ARCH__) and (__CUDA_ARCH__ >= 1200)) || defined(__CLION_IDE__)
+
+#include <cuda/std/cstdint>
+
+namespace deep_gemm::mma::sm120 {
+
+static constexpr int FP4_MMA_M = 16;
+static constexpr int FP4_MMA_N = 8;
+static constexpr int FP4_MMA_K = 64;
+
+__device__ __forceinline__ uint16_t extract_sf_pair(
+        const uint32_t packed, const uint32_t first_byte_idx) {
+    return static_cast<uint16_t>(
+        (packed >> (first_byte_idx * 8)) & 0xffff);
+}
+
+__device__ __forceinline__ void fp4_mma_block_scaled(
+        float (&d)[4], const uint32_t (&a)[4], const uint32_t (&b)[2],
+        const uint16_t sfa, const uint16_t sfb) {
+    asm volatile(
+        "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X."
+        "m16n8k64.row.col.f32.e2m1.e2m1.f32.ue8m0 "
+        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3}, "
+        "{%10}, {%11, %12}, {%13}, {%14, %15};\n"
+        : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+          "r"(b[0]), "r"(b[1]),
+          "r"(static_cast<uint32_t>(sfa)),
+          "n"(static_cast<uint16_t>(0)), "n"(static_cast<uint16_t>(0)),
+          "r"(static_cast<uint32_t>(sfb)),
+          "n"(static_cast<uint16_t>(0)), "n"(static_cast<uint16_t>(0)));
+}
+
+}  // namespace deep_gemm::mma::sm120
+
+#endif

--- a/deep_gemm/include/deep_gemm/scheduler/sm120_fp4_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/sm120_fp4_paged_mqa_logits.cuh
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <deep_gemm/common/math.cuh>
+
+namespace deep_gemm::sched {
+
+// Minimal scheduler for SGLang's DeepSeek-V4 indexer contract:
+// one query token per request, 2-D context lengths, and no varlen indices.
+template <uint32_t kBlockKV, uint32_t kNumBlocksPerSplit>
+struct SM120FP4PagedMQALogitsScheduler {
+    const uint32_t* context_lens;
+    uint32_t batch_size;
+
+    uint32_t current_q_idx;
+    uint32_t current_kv_idx;
+    uint32_t end_q_idx;
+    uint32_t end_kv_idx;
+    uint32_t current_num_kv;
+
+    CUTLASS_DEVICE SM120FP4PagedMQALogitsScheduler(
+            const uint32_t sm_idx, const uint32_t batch_size,
+            const uint32_t* context_lens, const uint32_t* schedule_meta) {
+        this->context_lens = context_lens;
+        this->batch_size = batch_size;
+
+        const auto current =
+            reinterpret_cast<const uint2*>(schedule_meta)[sm_idx];
+        const auto end =
+            reinterpret_cast<const uint2*>(schedule_meta)[sm_idx + 1];
+        current_q_idx = current.x;
+        current_kv_idx = current.y * kNumBlocksPerSplit;
+        end_q_idx = end.x;
+        end_kv_idx = end.y * kNumBlocksPerSplit;
+        refresh_num_kv();
+    }
+
+    CUTLASS_DEVICE void refresh_num_kv() {
+        current_num_kv = current_q_idx < batch_size
+            ? math::ceil_div(context_lens[current_q_idx], kBlockKV)
+            : 0;
+    }
+
+    CUTLASS_DEVICE static uint32_t atom_to_token_idx(
+            const uint32_t q_idx) {
+        return q_idx;
+    }
+
+    CUTLASS_DEVICE static uint32_t atom_to_block_table_row(
+            const uint32_t q_idx) {
+        return q_idx;
+    }
+
+    CUTLASS_DEVICE static uint32_t get_last_advance() {
+        return 1;
+    }
+
+    CUTLASS_DEVICE bool exist_q_atom_idx(const uint32_t q_idx) const {
+        return q_idx < end_q_idx or
+               (q_idx == end_q_idx and end_kv_idx > 0);
+    }
+
+    CUTLASS_DEVICE bool fetch_next_task(
+            uint32_t& q_idx, uint32_t& kv_idx, uint32_t& num_kv) {
+        q_idx = current_q_idx;
+        kv_idx = current_kv_idx;
+        num_kv = current_num_kv;
+
+        if (current_q_idx == end_q_idx and current_kv_idx == end_kv_idx)
+            return false;
+
+        current_kv_idx += kNumBlocksPerSplit;
+        if (current_kv_idx >= current_num_kv) {
+            current_kv_idx = 0;
+            ++current_q_idx;
+            refresh_num_kv();
+        }
+        return true;
+    }
+};
+
+}  // namespace deep_gemm::sched

--- a/sgl_deep_gemm/tests/test_attention.py
+++ b/sgl_deep_gemm/tests/test_attention.py
@@ -32,6 +32,9 @@ def apply_skip_head_mid(d: torch.Tensor, head_splits: Tuple[int, int, int]):
 
 
 def test_gemm_skip_head_mid() -> None:
+    if get_arch_major() == 12:
+        print('Skipping GEMM skip-head-mid on SM120 (not part of this port).')
+        return
     print('Testing GEMM skip head mid:')
     head_splits = (128, 64, 128)
 
@@ -114,6 +117,9 @@ def ref_fp8_mqa_logits(q: torch.Tensor, kv: torch.Tensor, weights: torch.Tensor,
 
 
 def test_mqa_logits():
+    if get_arch_major() == 12:
+        print('Skipping dense MQA logits on SM120 (not part of this port).')
+        return
 
     # Helper functions
     def generate_ks_ke_tests(seq_len: int, seq_len_kv: int, disable_cp: bool):
@@ -320,21 +326,21 @@ def test_paged_mqa_logits():
         max_kv_pool_tokens = 32 * 1024 * 1024
         max_varlen_tokens = 16 * 1024
         for is_varlen in ((False, True) if arch_major == 10 else (False, )):
-            for is_fp4 in ((True, False) if arch_major == 10 else (False, )):
-                for logits_dtype in (torch.bfloat16, torch.float):
+            for is_fp4 in ((True, False) if arch_major == 10 else ((True, ) if arch_major == 12 else (False, ))):
+                for logits_dtype in ((torch.float, ) if arch_major == 12 else (torch.bfloat16, torch.float)):
                     for weights_dtype in ((torch.float, torch.bfloat16) if arch_major == 10 else (torch.float, )):
                         if weights_dtype == torch.bfloat16 and logits_dtype == torch.float:
                             continue
                         for block_kv in ((32, 64) if arch_major == 10 else (64, )):
                             for use_2d_context_lens, clean_logits in [(True, False)]:
-                                for batch_size in (256, 4096):
-                                    for next_n in ((1, ) if is_varlen else ((1, 6) if arch_major == 10 else (1, 2))):
+                                for batch_size in ((16, ) if arch_major == 12 else (256, 4096)):
+                                    for next_n in ((1, ) if (is_varlen or arch_major == 12) else ((1, 6) if arch_major == 10 else (1, 2))):
                                         for max_tokens_per_batch in ((6, 10) if is_varlen else (1, )):
-                                            heads = (8, 16, 32, 64) if arch_major == 10 else (32, 64)
+                                            heads = (8, 16, 32, 64) if arch_major == 10 else ((64, ) if arch_major == 12 else (32, 64))
                                             head_dims = (64, 128) if (is_fp4 and arch_major == 10) else ((32, 64, 128) if arch_major == 10 else (128, ))
                                             for num_heads in heads:
                                                 for head_dim in head_dims:
-                                                    for avg_kv in (8192, 65536):
+                                                    for avg_kv in ((4096, ) if arch_major == 12 else (8192, 65536)):
                                                         if batch_size * avg_kv > max_kv_pool_tokens:
                                                             continue
                                                         if is_varlen and batch_size * max_tokens_per_batch > max_varlen_tokens:

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -32,6 +32,9 @@ def apply_skip_head_mid(d: torch.Tensor, head_splits: Tuple[int, int, int]):
 
 
 def test_gemm_skip_head_mid() -> None:
+    if get_arch_major() == 12:
+        print('Skipping GEMM skip-head-mid on SM120 (not part of this port).')
+        return
     print('Testing GEMM skip head mid:')
     head_splits = (128, 64, 128)
 
@@ -114,6 +117,9 @@ def ref_fp8_mqa_logits(q: torch.Tensor, kv: torch.Tensor, weights: torch.Tensor,
 
 
 def test_mqa_logits():
+    if get_arch_major() == 12:
+        print('Skipping dense MQA logits on SM120 (not part of this port).')
+        return
 
     # Helper functions
     def generate_ks_ke_tests(seq_len: int, seq_len_kv: int, disable_cp: bool):
@@ -320,21 +326,21 @@ def test_paged_mqa_logits():
         max_kv_pool_tokens = 32 * 1024 * 1024
         max_varlen_tokens = 16 * 1024
         for is_varlen in ((False, True) if arch_major == 10 else (False, )):
-            for is_fp4 in ((True, False) if arch_major == 10 else (False, )):
-                for logits_dtype in (torch.bfloat16, torch.float):
+            for is_fp4 in ((True, False) if arch_major == 10 else ((True, ) if arch_major == 12 else (False, ))):
+                for logits_dtype in ((torch.float, ) if arch_major == 12 else (torch.bfloat16, torch.float)):
                     for weights_dtype in ((torch.float, torch.bfloat16) if arch_major == 10 else (torch.float, )):
                         if weights_dtype == torch.bfloat16 and logits_dtype == torch.float:
                             continue
                         for block_kv in ((32, 64) if arch_major == 10 else (64, )):
                             for use_2d_context_lens, clean_logits in [(True, False)]:
-                                for batch_size in (256, 4096):
-                                    for next_n in ((1, ) if is_varlen else ((1, 6) if arch_major == 10 else (1, 2))):
+                                for batch_size in ((16, ) if arch_major == 12 else (256, 4096)):
+                                    for next_n in ((1, ) if (is_varlen or arch_major == 12) else ((1, 6) if arch_major == 10 else (1, 2))):
                                         for max_tokens_per_batch in ((6, 10) if is_varlen else (1, )):
-                                            heads = (8, 16, 32, 64) if arch_major == 10 else (32, 64)
+                                            heads = (8, 16, 32, 64) if arch_major == 10 else ((64, ) if arch_major == 12 else (32, 64))
                                             head_dims = (64, 128) if (is_fp4 and arch_major == 10) else ((32, 64, 128) if arch_major == 10 else (128, ))
                                             for num_heads in heads:
                                                 for head_dim in head_dims:
-                                                    for avg_kv in (8192, 65536):
+                                                    for avg_kv in ((4096, ) if arch_major == 12 else (8192, 65536)):
                                                         if batch_size * avg_kv > max_kv_pool_tokens:
                                                             continue
                                                         if is_varlen and batch_size * max_tokens_per_batch > max_varlen_tokens:


### PR DESCRIPTION
This PR simply cherry-picks the minimal subset of the original DeepGEMM PR https://github.com/deepseek-ai/DeepGEMM/pull/324 required to enable the DeepSeek-V4 FP4 indexer on SM120. PR https://github.com/sgl-project/sglang/pull/27059 builds on top of this change.

- Includes only the necessary SM120 FP4 paged-MQA code and the associated integration changes.
- Validated together with https://github.com/sgl-project/sglang/pull/27059, covering both the DeepGEMM kernel and SGLang E2E inference (see https://github.com/sgl-project/sglang/pull/27059#issue-4571252295).