### PR TITLE
Raise MegaMoE barrier timeout to 300 seconds

### DIFF
--- a/deep_gemm/include/deep_gemm/comm/barrier.cuh
+++ b/deep_gemm/include/deep_gemm/comm/barrier.cuh
@@ -8,8 +8,8 @@
 
 namespace deep_gemm::comm {
 
-// 60s timeout, at 2 GHz
-constexpr int64_t kNumTimeoutCycles = 60ll * 2000000000ll;
+// 300s timeout, at 2 GHz
+constexpr int64_t kNumTimeoutCycles = 300ll * 2000000000ll;
 
 CUTLASS_DEVICE void cluster_sync_with_relaxed_arrive() {
     // Perform cluster_sync with `barrier.cluster.arrive.relaxed`


### PR DESCRIPTION
## Summary

- raise the shared grid and NVLink barrier timeout from 60 seconds to 300 seconds
- tolerate bounded cross-rank launch skew caused by first-use host-side JIT compilation

## Root cause

MegaMoE ranks can enter a cross-rank device barrier while peer ranks are still synchronously compiling first-use kernels before launching the corresponding work. The 60-second watchdog can therefore abort a healthy collective before the delayed rank arrives. The subsequent grid-sync failures are cascading errors from the same missing rank.

This restores the 300-second timeout used before the timeout refactor while retaining the watchdog added to grid synchronization.

## Impact

Healthy executions are unaffected because their barriers complete before the threshold. A genuine barrier deadlock will take longer to report.

## Validation

- On GB300 with EP8 prefill, EP16 decode, and concurrency 256, diagnostic validation observed about 135 seconds of launch skew before the final rank joined. After allowing the wait beyond 60 seconds, 164 warmup requests completed with zero errors and no grid-sync, NVLink-barrier, or CUDA failures. The observed skew is below the new 300-second threshold.
- `git diff --check`
