### PR TITLE
[SM90] Use continuous FP32 activation scale in MegaMoE (drop UE8M0)

### DIFF
--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_mega_moe.cuh
@@ -55,14 +55,17 @@ __forceinline__ __device__ float sm90_fp8_mega_moe_swiglu(float g, float u) {
     return sm90_fp8_mega_moe_silu<kFastMath>(g) * u;
 }
 
+// Continuous FP32 activation scale. SM90 WGMMA has no hardware block-scale operand (the SF
+// is a plain FFMA in the epilogue), so the previous UE8M0 (power-of-two) scale bought nothing
+// on SM90 and only cost precision; the SF pool is already fp32, so this is byte/layout neutral.
+// clamp amax before the reciprocal: padded rows have amax==0, and 448/0=inf -> 0*inf=NaN.
 __forceinline__ __device__ void sm90_fp8_mega_moe_get_e4m3_sf_and_sf_inv(
     const float2& amax, float2& sf, float2& sf_inv) {
     constexpr float kScale = 1.0f / 448.0f;
-    const auto scaled = make_float2(__fmul_rn(amax.x, kScale), __fmul_rn(amax.y, kScale));
-    const auto exp_x = math::fast_log2_ceil(scaled.x);
-    const auto exp_y = math::fast_log2_ceil(scaled.y);
-    sf.x = math::fast_pow2(exp_x), sf_inv.x = math::fast_pow2(-exp_x);
-    sf.y = math::fast_pow2(exp_y), sf_inv.y = math::fast_pow2(-exp_y);
+    const auto ax = fmaxf(amax.x, 1e-10f);
+    const auto ay = fmaxf(amax.y, 1e-10f);
+    sf.x = __fmul_rn(ax, kScale), sf_inv.x = 1.0f / sf.x;
+    sf.y = __fmul_rn(ay, kScale), sf_inv.y = 1.0f / sf.y;
 }
 
 template <uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,


### PR DESCRIPTION
The SM90 MegaMoE L1 epilogue quantized the L2-GEMM input activation with a power-of-two (UE8M0) scale factor. SM90 WGMMA has no hardware block-scale operand -- the SF is applied as a plain FFMA in the epilogue -- so the power-of-two constraint bought nothing on SM90 (unlike SM100 tcgen05, whose block-scaled MMA encodes UE8M0 into the instruction descriptor). It only cost precision, and it turned a ~1e-4 perturbation in the folded topk_weight into an O(1) error whenever amax crossed a power-of-two boundary (the whole row's e4m3 grid shifted by 2x).

Switch to a continuous fp32 scale. The activation SF pool is already fp32, so this is byte/layout/stride-neutral and needs no retuning; it also matches the input quantizer in sm90_mega_moe_pre_dispatch.cuh, which is already continuous. Clamp amax before the reciprocal (padded rows have amax==0; 448/0=inf -> 0*inf=NaN).

Validated on DeepSeek-V4-Flash-FP8 (H20, SM90 FP8 MegaMoE), GPQA-diamond n-repeats=16 (3168 samples): with the Triton fused gate and no env workaround, no_answer dropped from 6.6% to 0.03% and pass@1 rose from 81.3% to 87.5%, matching the torch-reference-gate baseline.