### PR TITLE
build: require tvm-ffi 0.1.12 or newer

### DIFF
--- a/sgl_deep_gemm/pyproject.toml
+++ b/sgl_deep_gemm/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "apache-tvm-ffi==0.1.11",
+    "apache-tvm-ffi>=0.1.12",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- raise the `apache-tvm-ffi` minimum version from `0.1.11` to `0.1.12`
- allow newer compatible releases instead of pinning one exact version

## Why

The SGL DeepGEMM package now requires functionality available in TVM FFI 0.1.12 while remaining compatible with newer releases.

## Validation

- parsed `sgl_deep_gemm/pyproject.toml` with Python `tomllib`
- parsed `apache-tvm-ffi>=0.1.12` as a PEP 508 requirement
- verified the PR diff contains only `sgl_deep_gemm/pyproject.toml`
- `git diff --check origin/dev..HEAD`
