### PR TITLE
tests: keep tests/ aligned with upstream; move SM120 decode coverage to sgl_deep_gemm/tests

### DIFF
--- a/sgl_deep_gemm/tests/generators.py
+++ b/sgl_deep_gemm/tests/generators.py
@@ -156,7 +156,8 @@ def enumerate_normal(dtype: torch.dtype) -> Generator:
 
 def enumerate_m_grouped_contiguous(dtype: torch.dtype) -> Generator:
     quant_config_list = QuantConfig.get_list_from_dtype(dtype)
-    m_group_list = [(4, 8192), (8, 4096)]
+    # (128, 2): MoE decode regime — tiny per-expert m exercises the minimum alignment
+    m_group_list = [(4, 8192), (8, 4096), (128, 2)]
     n_k_list = [(6144, 7168), (7168, 3072), (4096, 4096), (4096, 2048)]
     for kernel_type in get_kernel_types(dtype):
         for quant_config in quant_config_list:

--- a/sgl_deep_gemm/tests/test_fp8_fp4.py
+++ b/sgl_deep_gemm/tests/test_fp8_fp4.py
@@ -80,8 +80,8 @@ def test_m_grouped_gemm_contiguous() -> None:
         disable_ue8m0_cast = not use_ue8m0
         recipe, recipe_a, recipe_b = quant_config.get_recipes()
 
-        # Select best alignment
-        alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout()
+        # Select best alignment for the per-group expected m (decode cases -> minimum alignment)
+        alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout(int(expected_m_per_group * 1.2))
         deep_gemm.set_mk_alignment_for_contiguous_layout(alignment)
 
         for test_alias in (False, True):

--- a/tests/test_fp8_fp4.py
+++ b/tests/test_fp8_fp4.py
@@ -105,9 +105,7 @@ def test_m_grouped_gemm_contiguous() -> None:
                 if ensure_zero_padding:
                     check_fp8_fp4_psum_zero_padding(a, d, grouped_layout)
             else:
-                # M-padding rows of `d` are unspecified; compare valid rows only
-                valid = grouped_layout >= 0
-                diff = calc_diff(d[valid], ref_d[valid])
+                diff = calc_diff(d, ref_d)
                 assert diff < quant_config.max_diff(), f'{m=}, {n=}, {k=}, {major_opt}, {kernel_opt}, {diff:.5f}, alias={test_alias}'
         m, a, b, grouped_layout, d, ref_d = generate_m_grouped_contiguous(num_groups, expected_m_per_group, n, k, major_a, major_b,
                                                                           use_ue8m0=use_ue8m0, use_psum_layout=use_psum_layout,


### PR DESCRIPTION
Follow-up to the #59 review (@Fridge003).

## Changes

1. Revert `tests/test_fp8_fp4.py` to its `pre-#59` state. Move tests to `sgl_deep_gemm/tests/test_fp8_fp4.py`

2. Add MoE-decode coverage to `sgl_deep_gemm/tests/`.