### PR TITLE
build: allow tvm-ffi 0.1.11

### DIFF
--- a/sgl_deep_gemm/pyproject.toml
+++ b/sgl_deep_gemm/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "apache-tvm-ffi>=0.1.12",
+    "apache-tvm-ffi>=0.1.11",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- lower the `apache-tvm-ffi` minimum version from `0.1.12` to `0.1.11`
- keep the dependency open to newer compatible releases

## Why

TVM FFI 0.1.11 remains compatible with the SGL DeepGEMM package, so users do not need to upgrade to 0.1.12 when installing it.

## Validation

- parsed `sgl_deep_gemm/pyproject.toml` with Python `tomllib`
- parsed `apache-tvm-ffi>=0.1.11` as a PEP 508 requirement
- verified the PR diff contains only `sgl_deep_gemm/pyproject.toml`
- `git diff --check origin/dev..HEAD`
