### PR TITLE
ci: build release wheels against PyTorch 2.13

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -109,8 +109,8 @@ jobs:
           # see https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
           # This code is ugly, maybe there's a better way to do this.
           export TORCH_CUDA_VERSION=$(python -c "from os import environ as env; \
-            minv = {'2.4': 118, '2.5': 118, '2.6': 118, '2.7': 118, '2.8': 126}[env['MATRIX_TORCH_VERSION']]; \
-            maxv = {'2.4': 124, '2.5': 124, '2.6': 126, '2.7': 128, '2.8': 129}[env['MATRIX_TORCH_VERSION']]; \
+            minv = {'2.4': 118, '2.5': 118, '2.6': 118, '2.7': 118, '2.8': 126, '2.13': 126}[env['MATRIX_TORCH_VERSION']]; \
+            maxv = {'2.4': 124, '2.5': 124, '2.6': 126, '2.7': 128, '2.8': 129, '2.13': 129}[env['MATRIX_TORCH_VERSION']]; \
             print(minv if int(env['MATRIX_CUDA_VERSION']) < 120 else maxv)" \
           )
           if [[ ${{ inputs.torch-version }} == *"dev"* ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,19 +41,16 @@ jobs:
         # Using ubuntu-22.04 instead of 24.04 for more compatibility (glibc). Ideally we'd use the
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.4.0", "2.5.1", "2.6.0", "2.7.1", "2.8.0"]
+        # see https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
+        # Pytorch 2.13 requires Python >= 3.10
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        torch-version: ["2.13.0"]
         cuda-version: ["12.9.1"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
         # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)
         # when building without C++11 ABI and using it on nvcr images.
         cxx11_abi: ["FALSE", "TRUE"]
-        exclude:
-          # see https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
-          # Pytorch < 2.5 does not support Python 3.13
-          - torch-version: "2.4.0"
-            python-version: "3.13"
     uses: ./.github/workflows/_build.yml
     with:
       runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Builds the release wheels against PyTorch 2.13 (current latest) instead of the 2.4–2.8 matrix.

### Changes
- `publish.yml`: `torch-version` matrix → `["2.13.0"]`.
- `publish.yml`: drop Python 3.8/3.9 — torch 2.13 is `requires-python >= 3.10`. The `torch 2.4.0 x py3.13` exclude is dropped with it, since 2.4.0 is no longer in the matrix.
- `_build.yml`: add a `2.13` entry to the min/max CUDA lookup (`126` / `129`). Without it the step raises `KeyError: '2.13'`. With `cuda-version: 12.9.1` the build resolves to the `cu129` wheels, which exist for 2.13.0 (available variants: cu126 / cu129 / cu130 / cu132).

### Notes
- Not built or otherwise verified — the wheel job only fires on `v*` tag creation, so nothing runs from this PR.
- Pre-existing and untouched: the build step pins `setuptools==75.8.0`, while torch 2.13 declares `setuptools>=77.0.3`. pip will flag the conflict. Happy to bump the pin here if you'd prefer.
