### PR TITLE
Add NVFP4 mega MoE support

### DIFF
--- a/csrc/apis/layout.hpp
+++ b/csrc/apis/layout.hpp
@@ -54,7 +54,7 @@ static torch::Tensor transform_sf_into_required_layout(const torch::Tensor& sf,
     }
 
     // (INT, 1, gran_k) on SM100/SM120: transform to TMA-aligned and MN-major
-    if (sf.scalar_type() == torch::kInt and gran_mn == 1 and (gran_k == 32 or gran_k == 128) and (arch_major == 10 or arch_major == 12))
+    if (sf.scalar_type() == torch::kInt and gran_mn == 1 and (gran_k == 16 or gran_k == 32 or gran_k == 128) and (arch_major == 10 or arch_major == 12))
         return check_sf_layout(sf, mn, k, gran_mn, gran_k, num_groups, true, false, torch::kInt);
 
     DG_HOST_UNREACHABLE("Unknown SF transformation");

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -2,7 +2,7 @@
 
 #include <functional>
 #include <string>
-// #include <pybind11/functional.h>
+#include <torch/torch.h>
 
 #include <deep_gemm/common/types.cuh>
 #include <deep_gemm/scheduler/mega_moe.cuh>
@@ -14,8 +14,6 @@
 #include "../jit_kernels/impls/sm100_bf16_mega_moe.hpp"
 #include "../jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp"
 #include "../jit_kernels/impls/sm100_mega_moe_pre_dispatch.hpp"
-#include "../utils/math.hpp"
-#include "../utils/system.hpp"
 
 namespace deep_gemm::mega {
 
@@ -36,7 +34,8 @@ static int get_block_m_for_mega_moe(
 
 static std::tuple<int64_t, std::function<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
                                                     torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
-                                                    torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>(const torch::Tensor&)>>
+                                                    torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
+                                                    torch::Tensor>(const torch::Tensor&)>>
 get_symm_buffer_size_for_mega_moe(
     const int& num_ranks, const int& num_experts,
     const int& num_max_tokens_per_rank, const int& num_topk,
@@ -48,8 +47,9 @@ get_symm_buffer_size_for_mega_moe(
 
     // SiTU is implemented only by the SM100 FP8xFP4 MegaMoE kernel.
     const auto mma_kind = parse_mma_kind(mma_type);
-    DG_HOST_ASSERT(activation == "swiglu" or
+    DG_HOST_ASSERT(activation == "swiglu" or activation == "swigluoai" or
                    (mma_kind == MmaKind::MXFP8FP4 and activation == "situ"));
+    DG_HOST_ASSERT(num_shared_experts >= 0);
 
     // Ring capacity: worst-case live pool blocks over all candidate BLOCK_M; mirrors the kernel assert.
     // TODO: we temporarily assume the SM count is consistent with the runtime value
@@ -80,18 +80,10 @@ get_symm_buffer_size_for_mega_moe(
 
     // Parse MMA type
     const auto with_sf = is_mma_with_sf(mma_kind);
-    // FP4 activations are currently a routed-expert-only optimization. Keep
-    // the upstream shared-expert path on its original FP8 representation.
-    const bool host_use_fp4_acts = with_sf and num_shared_experts == 0 and
-                                   get_env<int>("DG_USE_FP4_ACTS") != 0;
 
-    // Stream B (combine path): when `DG_USE_FP8_COMBINE=1`, the combine slot
-    // holds FP8 E4M3 (kHidden bytes/token) + a separate combine_sf slot
-    // holding UE8M0 SF bytes (kHidden/128 bytes/token, gran_k=128). When off,
-    // the combine slot holds BF16 (kHidden*2 bytes/token) and combine_sf is
-    // unused (zero-sized).
     const bool host_use_fp8_combine = with_sf and get_env<int>("DG_USE_FP8_COMBINE") != 0;
-    // Padded SF pool tokens
+
+    // Compute num_sf_ring_tokens (max across all candidate block sizes)
     int num_sf_ring_tokens = 0;
     if (with_sf) {
         for (auto block_m: layout::kCandidateBlockM) {
@@ -105,9 +97,20 @@ get_symm_buffer_size_for_mega_moe(
     const auto mega_buffer = layout::MegaMoEBuffer(
         nullptr, hidden, intermediate_hidden,
         num_ranks, num_experts, num_max_tokens_per_rank,
-        num_topk, num_ring_tokens, num_sf_ring_tokens, with_sf,
-        num_shared_experts, host_use_fp4_acts, host_use_fp8_combine
+        num_topk, num_ring_tokens, num_sf_ring_tokens, mma_kind,
+        num_shared_experts, host_use_fp8_combine
     );
+
+    // Activation layout: FP8 for MXFP8FP4, raw bytes holding 2 packed FP4 values for NVFP4/MXFP4
+    const auto acts_dtype = with_sf ?
+        (get_element_bits(mma_kind) == 4 ? torch::kUInt8 : torch::kFloat8_e4m3fn) : torch::kBFloat16;
+    const int acts_storage_bits = static_cast<int>(c10::elementSize(acts_dtype)) * 8;
+    const auto num_acts_cols = [=](const int& num_elems) {
+        return num_elems * get_element_bits(mma_kind) / acts_storage_bits;
+    };
+    const auto num_sf_cols = [=](const int& num_elems) {
+        return num_elems / (get_sf_gran_k(mma_kind) * 4);
+    };
 
     // Check SF buffer requirements
     if (with_sf) {
@@ -118,20 +121,14 @@ get_symm_buffer_size_for_mega_moe(
 
     // Slice function: creates tensor views from the raw buffer.
     // NOTES: `x_sf` is K-major, while `l1_acts_sf` and `l2_acts_sf` are M-major
-    // Stream A0.0b: under `host_use_fp4_acts`, the `x` and `l1_acts` views
-    // expose packed E2M1 (`kPackedFP4` = `torch::kInt8`, 2 elements/byte) of
-    // shape `[..., hidden / 2]`. Underlying buffer bytes are the same as the
-    // sized `fp8_token_layout` slot, just half the row width.
-    const auto x_dtype = with_sf ? (host_use_fp4_acts ? kPackedFP4 : torch::kFloat8_e4m3fn) : torch::kBFloat16;
-    const int x_inner_cols = host_use_fp4_acts ? (hidden / 2) : hidden;
     auto slice_input_buffers = [=](const torch::Tensor& buffer) {
         auto x = torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.input_token_buffer.base)),
-            {num_max_tokens_per_rank, x_inner_cols},
-            torch::TensorOptions().dtype(x_dtype).device(buffer.device()));
+            {num_max_tokens_per_rank, num_acts_cols(hidden)},
+            torch::TensorOptions().dtype(acts_dtype).device(buffer.device()));
         auto x_sf = with_sf ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.input_sf_buffer.base)),
-            {num_max_tokens_per_rank, hidden / 128},
+            {num_max_tokens_per_rank, num_sf_cols(hidden)},
             torch::TensorOptions().dtype(torch::kInt).device(buffer.device())) : torch::Tensor();
         auto topk_idx = torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.input_topk_idx_buffer.base)),
@@ -145,40 +142,44 @@ get_symm_buffer_size_for_mega_moe(
         auto shared_l1_acts = x;
         auto shared_l1_acts_sf = (with_sf and num_shared_experts > 0) ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.shared_l1_sf_buffer.base)),
-            {layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank), hidden / 128},
+            {layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank), num_sf_cols(hidden)},
             {1, layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank)},
             torch::TensorOptions().dtype(torch::kInt).device(buffer.device())) : torch::Tensor();
         auto shared_l2_acts = num_shared_experts > 0 ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.shared_l2_token_buffer.base)),
-            {num_max_tokens_per_rank, shared_intermediate_hidden},
-            torch::TensorOptions().dtype(with_sf ? torch::kFloat8_e4m3fn : torch::kBFloat16).device(buffer.device())) : torch::Tensor();
+            {num_max_tokens_per_rank, num_acts_cols(shared_intermediate_hidden)},
+            torch::TensorOptions().dtype(acts_dtype).device(buffer.device())) : torch::Tensor();
         auto shared_l2_acts_sf = (with_sf and num_shared_experts > 0) ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.shared_l2_sf_buffer.base)),
-            {layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank), shared_intermediate_hidden / 128},
+            {layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank), num_sf_cols(shared_intermediate_hidden)},
             {1, layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank)},
             torch::TensorOptions().dtype(torch::kInt).device(buffer.device())) : torch::Tensor();
 
         auto l1_acts = torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.l1_token_buffer.base)),
-            {num_ring_tokens, x_inner_cols},
-            torch::TensorOptions().dtype(x_dtype).device(buffer.device()));
+            {num_ring_tokens, num_acts_cols(hidden)},
+            torch::TensorOptions().dtype(acts_dtype).device(buffer.device()));
         auto l1_acts_sf = with_sf ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.l1_sf_buffer.base)),
-            {num_sf_ring_tokens, hidden / 128},
+            {num_sf_ring_tokens, num_sf_cols(hidden)},
             {1, num_sf_ring_tokens},
             torch::TensorOptions().dtype(torch::kInt).device(buffer.device())) : torch::Tensor();
         auto l2_acts = torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.l2_token_buffer.base)),
-            {num_ring_tokens, intermediate_hidden},
-            torch::TensorOptions().dtype(with_sf ? torch::kFloat8_e4m3fn : torch::kBFloat16).device(buffer.device()));
+            {num_ring_tokens, num_acts_cols(intermediate_hidden)},
+            torch::TensorOptions().dtype(acts_dtype).device(buffer.device()));
         auto l2_acts_sf = with_sf ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.l2_sf_buffer.base)),
-            {num_sf_ring_tokens, intermediate_hidden / 128},
+            {num_sf_ring_tokens, num_sf_cols(intermediate_hidden)},
             {1, num_sf_ring_tokens},
             torch::TensorOptions().dtype(torch::kInt).device(buffer.device())) : torch::Tensor();
+        auto x_scales = torch::from_blob(
+            math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.input_x_scales_buffer.base)),
+            {num_max_tokens_per_rank},
+            torch::TensorOptions().dtype(torch::kFloat32).device(buffer.device()));
         return std::make_tuple(x, x_sf, topk_idx, topk_weights,
                                shared_l1_acts, shared_l1_acts_sf, shared_l2_acts, shared_l2_acts_sf,
-                               l1_acts, l1_acts_sf, l2_acts, l2_acts_sf);
+                               l1_acts, l1_acts_sf, l2_acts, l2_acts_sf, x_scales);
     };
     return {mega_buffer.get_num_bytes(), slice_input_buffers};
 }
@@ -195,9 +196,14 @@ static void fp8_fp4_mega_moe(
     const int& num_max_tokens_per_rank,
     const int& num_experts, const int& num_topk,
     const std::tuple<int, int, int>& recipe,
+    const std::string& mma_type,
     const std::string& activation,
     const std::optional<float>& activation_clamp_opt,
-    const bool& fast_math
+    const bool& fast_math,
+    const bool& use_x_scales,
+    const std::optional<torch::Tensor>& l1_alphas,
+    const std::optional<torch::Tensor>& l2_alphas,
+    const std::optional<torch::Tensor>& l2_act_scales
 ) {
     const auto [l1_weights, l1_weights_sf] = l1_weights_tuple;
     const auto [l2_weights, l2_weights_sf] = l2_weights_tuple;
@@ -205,11 +211,23 @@ static void fp8_fp4_mega_moe(
     // Config checks
     const auto num_tokens = static_cast<int>(y.size(0));
     const auto [rm, rn, rk] = recipe;
-    DG_HOST_ASSERT(rm == 1 and rn == 1 and rk == 32);
-    DG_HOST_ASSERT(shared_l1_weights_tuple_opt.has_value() == shared_l2_weights_tuple_opt.has_value());
-    DG_HOST_ASSERT(activation == "swiglu" or activation == "situ");
+    DG_HOST_ASSERT(rm == 1 and rn == 1 and (rk == 32 or rk == 16));
+    const auto mma_kind = parse_mma_kind(mma_type);
+    if (mma_kind != MmaKind::MXFP8FP4 and mma_kind != MmaKind::MXFP4 and mma_kind != MmaKind::NVFP4)
+        DG_HOST_UNREACHABLE("`" + mma_type + "` activations are not implemented by the SM100 "
+                            "mega-MoE kernel (only `fp8xfp4`, `mxf4xmxf4` and `nvfp4xnvfp4` are); "
+                            "allocate the symmetric buffer with one of those");
+    if (rk != get_sf_gran_k(mma_kind))
+        DG_HOST_UNREACHABLE("recipe K granularity " + std::to_string(rk) + " does not match `" +
+                            mma_type + "` (expected " +
+                            std::to_string(get_sf_gran_k(mma_kind)) + ")");
+    DG_HOST_ASSERT(use_x_scales == (mma_kind == MmaKind::NVFP4));
+    DG_HOST_ASSERT(activation == "swiglu" or activation == "swigluoai" or
+                   (mma_kind == MmaKind::MXFP8FP4 and activation == "situ"));
     DG_HOST_ASSERT(activation != "situ" or not activation_clamp_opt.has_value());
     const bool use_situ = activation == "situ";
+    const float swiglu_alpha = activation == "swigluoai" ? 1.702f : 0.0f;
+    DG_HOST_ASSERT(shared_l1_weights_tuple_opt.has_value() == shared_l2_weights_tuple_opt.has_value());
 
     // Activation checks
     const auto activation_clamp =
@@ -232,8 +250,9 @@ static void fp8_fp4_mega_moe(
     DG_HOST_ASSERT(intermediate_hidden_2 == 2 * intermediate_hidden);
     DG_HOST_ASSERT(l1_weights.is_contiguous() and l2_weights.is_contiguous());
 
-    // Check weight SF layout for UE8M0 packing, MN-major, and TMA alignment
-    constexpr int kGranMN = 1, kGranK = 32;
+    // Check weight SF layout for byte-packing, MN-major, and TMA alignment
+    constexpr int kGranMN = 1;
+    const int kGranK = rk;
     check_sf_layout(l1_weights_sf, intermediate_hidden * 2, hidden, kGranMN, kGranK,
                     num_experts_per_rank, true, false, torch::kInt);
     check_sf_layout(l2_weights_sf, hidden, intermediate_hidden, kGranMN, kGranK,
@@ -244,16 +263,19 @@ static void fp8_fp4_mega_moe(
     if (shared_l1_weights_tuple_opt.has_value()) {
         std::tie(shared_l1_weights, shared_l1_weights_sf) = shared_l1_weights_tuple_opt.value();
         std::tie(shared_l2_weights, shared_l2_weights_sf) = shared_l2_weights_tuple_opt.value();
-        shared_intermediate_hidden = static_cast<int>(shared_l2_weights.size(1));
+        const bool is_packed_fp4 = mma_kind == MmaKind::MXFP4 or mma_kind == MmaKind::NVFP4;
+        shared_intermediate_hidden = static_cast<int>(shared_l2_weights.size(1)) *
+                                     (is_packed_fp4 ? 2 : 1);
         num_shared_experts = shared_intermediate_hidden / intermediate_hidden;
 
         DG_HOST_ASSERT(shared_intermediate_hidden % intermediate_hidden == 0);
         DG_HOST_ASSERT(shared_l1_weights.dim() == 2 and shared_l2_weights.dim() == 2);
         DG_HOST_ASSERT(shared_l1_weights.size(0) == shared_intermediate_hidden * 2);
-        DG_HOST_ASSERT(shared_l1_weights.size(1) == hidden);
+        DG_HOST_ASSERT(shared_l1_weights.size(1) == (is_packed_fp4 ? hidden / 2 : hidden));
         DG_HOST_ASSERT(shared_l2_weights.size(0) == hidden);
-        DG_HOST_ASSERT(shared_l1_weights.scalar_type() == torch::kFloat8_e4m3fn);
-        DG_HOST_ASSERT(shared_l2_weights.scalar_type() == torch::kFloat8_e4m3fn);
+        const auto shared_weight_dtype = is_packed_fp4 ? kPackedFP4 : torch::kFloat8_e4m3fn;
+        DG_HOST_ASSERT(shared_l1_weights.scalar_type() == shared_weight_dtype);
+        DG_HOST_ASSERT(shared_l2_weights.scalar_type() == shared_weight_dtype);
         DG_HOST_ASSERT(shared_l1_weights.is_contiguous() and shared_l2_weights.is_contiguous());
         DG_HOST_ASSERT(get_major_type_ab(shared_l1_weights) == cute::UMMA::Major::K);
         DG_HOST_ASSERT(get_major_type_ab(shared_l2_weights) == cute::UMMA::Major::K);
@@ -277,35 +299,45 @@ static void fp8_fp4_mega_moe(
         num_ranks, num_experts,
         num_max_tokens_per_rank, num_topk,
         hidden, intermediate_hidden,
-        "fp8xfp4", activation, num_shared_experts
+        mma_type, activation, num_shared_experts
     );
-    DG_HOST_ASSERT(sym_buffer.nbytes() >= static_cast<size_t>(num_required_bytes));
+    if (sym_buffer.nbytes() < static_cast<size_t>(num_required_bytes))
+        DG_HOST_UNREACHABLE("symmetric buffer is " + std::to_string(sym_buffer.nbytes()) +
+                            " bytes but `" + mma_type + "`/`" + activation + "` with " +
+                            std::to_string(num_shared_experts) + " shared expert(s) needs " +
+                            std::to_string(num_required_bytes));
     DG_HOST_ASSERT(num_experts == num_experts_);
+
+    if (l1_alphas.has_value()) {
+        DG_HOST_ASSERT(mma_kind == MmaKind::NVFP4);
+        DG_HOST_ASSERT(l1_alphas->scalar_type() == torch::kFloat);
+        DG_HOST_ASSERT(l1_alphas->is_contiguous());
+        DG_HOST_ASSERT(l1_alphas->dim() == 2);
+        DG_HOST_ASSERT(l1_alphas->size(0) == num_experts_per_rank);
+        DG_HOST_ASSERT(l1_alphas->size(1) == 2);
+    }
+
+    if (l2_alphas.has_value()) {
+        DG_HOST_ASSERT(mma_kind == MmaKind::NVFP4);
+        DG_HOST_ASSERT(l2_alphas->scalar_type() == torch::kFloat);
+        DG_HOST_ASSERT(l2_alphas->is_contiguous());
+        DG_HOST_ASSERT(l2_alphas->dim() == 1);
+        DG_HOST_ASSERT(l2_alphas->size(0) == num_experts_per_rank);
+    }
+
+    // Per-expert fc2 input global scales, `[num_experts_per_rank]` FP32
+    if (l2_act_scales.has_value()) {
+        DG_HOST_ASSERT(mma_kind == MmaKind::NVFP4);
+        DG_HOST_ASSERT(l2_act_scales->scalar_type() == torch::kFloat);
+        DG_HOST_ASSERT(l2_act_scales->is_contiguous());
+        DG_HOST_ASSERT(l2_act_scales->dim() == 1);
+        DG_HOST_ASSERT(l2_act_scales->size(0) == num_experts_per_rank);
+    }
 
     // Already registered tensors
     const auto [x, x_sf, topk_idx, topk_weights,
                 shared_l1_acts, shared_l1_acts_sf, shared_l2_acts, shared_l2_acts_sf,
-                l1_acts, l1_acts_sf, l2_acts, l2_acts_sf] = slice(sym_buffer);
-
-    // Stream A0.1: pick up FP4-acts flag from `DG_USE_FP4_ACTS` env var.
-    // Default off — preserves byte-identical FP8-acts behavior. Setting
-    // `DG_USE_FP4_ACTS=1` flips L1's epilogue quant to E2M1 + UE8M0 SF.
-    const bool use_fp4_acts = num_shared_experts == 0 and
-                              get_env<int>("DG_USE_FP4_ACTS") != 0;
-    // Stream A0.5: when also `DG_USE_MXF4_KIND=1`, the L1 and L2 mainloops
-    // run `tcgen05.mma.kind::mxf4.block_scale.block32` instead of
-    // `kind::mxf8f6f4` — K=64 dense per call (vs K=32 with-padding), dense
-    // FP4 smem (`_ALIGN8B`, half the byte footprint), scale_vec::2X SF
-    // protocol with HALF-WORD address bits. Only honored when
-    // `DG_USE_FP4_ACTS=1` (kind::mxf4 is FP4-only). See A6 capstone /
-    // B2 standalone GEMM for the +20-22% headline.
-    const bool use_mxf4_kind = use_fp4_acts and get_env<int>("DG_USE_MXF4_KIND") != 0;
-    // Stream B (combine path): when `DG_USE_FP8_COMBINE=1`, the L2 epilogue
-    // ships FP8 E4M3 + per-(token, N=128) UE8M0 SF over NVLink instead of
-    // BF16. The combine reduce dequantizes on the fly. NVLink bytes/token
-    // halve (from kHidden*2 → kHidden + kHidden/128). Independent of the
-    // FP4-acts / MXF4-kind flags above (those control the dispatch a2a +
-    // mainloops; this controls the combine a2a only).
+                l1_acts, l1_acts_sf, l2_acts, l2_acts_sf, x_scales] = slice(sym_buffer);
     const bool use_fp8_combine = get_env<int>("DG_USE_FP8_COMBINE") != 0;
 
     // Dispatch into different architectures
@@ -326,8 +358,16 @@ static void fp8_fp4_mega_moe(
                                num_shared_experts,
                                num_tokens, num_topk,
                                hidden, intermediate_hidden,
-                               activation_clamp, use_situ, fast_math,
-                               use_fp4_acts, use_mxf4_kind, use_fp8_combine);
+                               activation_clamp, swiglu_alpha, use_situ, fast_math,
+                               use_x_scales,
+                               l1_alphas.has_value()
+                                   ? l1_alphas->const_data_ptr<float>() : nullptr,
+                               l2_alphas.has_value()
+                                   ? l2_alphas->const_data_ptr<float>() : nullptr,
+                               l2_act_scales.has_value()
+                                   ? l2_act_scales->const_data_ptr<float>() : nullptr,
+                               mma_kind,
+                               use_fp8_combine);
     } else {
         DG_HOST_UNREACHABLE("Unsupported architecture");
     }
@@ -419,7 +459,7 @@ static void bf16_mega_moe(
     // Already registered tensors
     const auto [x, _x_sf, topk_idx, topk_weights,
                 shared_l1_acts, _shared_l1_acts_sf, shared_l2_acts, _shared_l2_acts_sf,
-                l1_acts, _l1_acts_sf, l2_acts, _l2_acts_sf] = slice(sym_buffer);
+                l1_acts, _l1_acts_sf, l2_acts, _l2_acts_sf, _x_scales] = slice(sym_buffer);
 
     // Dispatch into different architectures
     if (arch_major == 10) {
@@ -464,7 +504,9 @@ static void register_apis(pybind11::module_& m) {
           pybind11::arg("buf_topk_weights"),
           pybind11::arg("num_tokens"),
           pybind11::arg("group_size") = 32,
-          pybind11::arg("use_fp4_acts") = false);
+          pybind11::arg("mma_type") = "fp8xfp4",
+          pybind11::arg("buf_x_scales") = std::nullopt,
+          pybind11::arg("expert_scales") = std::nullopt);
 #endif
 }
 

--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -23,6 +23,8 @@ struct MegaMoEConfig {
 
     // SF block sizes (UTCCP 128-aligned)
     int sf_block_m, sf_block_n;
+    // SF granularity along K
+    int gran_k;
 
     // Ring capacity and SF ring token count
     int num_ring_tokens;
@@ -46,6 +48,7 @@ struct MegaMoEConfig {
            << ", load_block_m=" << config.load_block_m << ", load_block_n=" << config.load_block_n
            << ", store_block_m=" << config.store_block_m
            << ", sf_block_m=" << config.sf_block_m << ", sf_block_n=" << config.sf_block_n
+           << ", gran_k=" << config.gran_k
            << ", num_ring_tokens=" << config.num_ring_tokens
            << ", num_sf_ring_tokens=" << config.num_sf_ring_tokens
            << ", swizzle_acts_mode=" << config.swizzle_acts_mode << ", swizzle_weights_mode=" << config.swizzle_weights_mode
@@ -61,31 +64,56 @@ struct MegaMoEConfig {
 static MmaKind parse_mma_kind(const std::string& mma_type_str) {
     if (mma_type_str == "bf16xbf16")
         return MmaKind::BF16;
-    DG_HOST_ASSERT(mma_type_str == "fp8xfp4");
-    return MmaKind::MXFP8FP4;
+    if (mma_type_str == "fp8xfp4")
+        return MmaKind::MXFP8FP4;
+    if (mma_type_str == "mxf4xmxf4")
+        return MmaKind::MXFP4;
+    DG_HOST_ASSERT(mma_type_str == "nvfp4xnvfp4");
+    return MmaKind::NVFP4;
 }
 
-static int get_num_mma_elem_bytes(const MmaKind& mma_kind) {
-    return mma_kind == MmaKind::BF16 ? 2 : 1;
+static std::string to_mma_type_string(const MmaKind& mma_kind) {
+    switch (mma_kind) {
+        case MmaKind::BF16:     return "bf16xbf16";
+        case MmaKind::MXFP8FP4: return "fp8xfp4";
+        case MmaKind::MXFP4:    return "mxf4xmxf4";
+        case MmaKind::NVFP4:    return "nvfp4xnvfp4";
+    }
+    DG_HOST_UNREACHABLE("Unknown MMA kind");
+}
+
+static std::string to_mma_kind_name(const MmaKind& mma_kind) {
+    switch (mma_kind) {
+        case MmaKind::BF16:     return "MmaKind::BF16";
+        case MmaKind::MXFP8FP4: return "MmaKind::MXFP8FP4";
+        case MmaKind::MXFP4:    return "MmaKind::MXFP4";
+        case MmaKind::NVFP4:    return "MmaKind::NVFP4";
+    }
+    DG_HOST_UNREACHABLE("Unknown MMA kind");
 }
 
 static bool is_mma_with_sf(const MmaKind& mma_kind) {
-    return mma_kind == MmaKind::MXFP8FP4;
+    return mma_kind == MmaKind::MXFP8FP4 or mma_kind == MmaKind::MXFP4 or mma_kind == MmaKind::NVFP4;
+}
+
+static bool is_mxf4_mma_kind(const MmaKind& mma_kind) {
+    return mma_kind == MmaKind::MXFP4;
+}
+
+static bool is_nvfp4_mma_kind(const MmaKind& mma_kind) {
+    return mma_kind == MmaKind::NVFP4;
 }
 
 static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
     const int& num_ranks, const int& num_experts,
     const int& num_max_tokens_per_rank, const int& num_topk,
     const int& num_tokens,
-    const MmaKind& mma_kind,
-    const bool& use_mxf4_kind = false) {
+    const MmaKind& mma_kind) {
     auto [cluster_size, block_m, store_block_m, block_k, num_epilogue_warpgroups] = [&]() -> std::tuple<int, int, int, int, int> {
         float num_expected_tokens_per_expert = static_cast<float>(num_tokens) * num_ranks * num_topk / num_experts;
         if (num_expected_tokens_per_expert <= 8.5) {
-            // Really small token-per-expert (e.g. RL long-tail rollout), use larger BLOCK_K for less synchronization.
-            // Under kind::mxf4, bump block_m so the dense FP4 A/B smem tiles remain comfortably aligned.
-            return use_mxf4_kind ? std::tuple<int, int, int, int, int>{2, 32, 16, 128, 2}
-                                 : std::tuple<int, int, int, int, int>{2, 16, 8, 256, 2};
+            // Really small token-per-expert (e.g. RL long-tail rollout), use the smallest block_m and larger BLOCK_K for less synchronization
+            return {2, 16, 8, 256, 2};
         } else if (num_expected_tokens_per_expert <= 16.5) {
             // Small batch size, small EP, decoding, e.g. 6/384 experts, EP8, bsz 128
             return {2, 32, 16, 128, 2};
@@ -103,14 +131,7 @@ static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
             return {2, 192, 32, 128, 2};
         }
     }();
-    block_k /= get_num_mma_elem_bytes(mma_kind);
-    if (mma_kind == MmaKind::MXFP8FP4 and not use_mxf4_kind) {
-        // K-major SM100 descriptors only support swizzles up to 128 bytes.
-        // The non-MXF4 FP8/FP4 path stores both operands as 1 byte per K
-        // element in smem, so a 256-element tile would require an illegal
-        // 256-byte swizzle.
-        block_k = std::min(block_k, 128);
-    }
+    block_k = block_k * 8 / get_element_bits(mma_kind);
 
     // Check whether our `block_m` lies in `kCandidateBlockM`
     DG_HOST_ASSERT(std::any_of(
@@ -125,16 +146,15 @@ static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
 static std::pair<int, int> get_pipeline_config_for_mega_moe(
     const int& smem_capacity,
     const int& num_experts, const int& hidden,
-    const int& block_m, const int& block_n, const int& block_k, 
+    const int& block_m, const int& block_n, const int& block_k,
     const int& num_bytes_per_pull, const int& store_block_m,
     const int& sf_block_m, const int& sf_block_n, const int& gran_k,
     const int& num_dispatch_warps, const int& num_epilogue_warps,
-    const MmaKind& mma_kind,
-    const bool& use_mxf4_kind = false) {
+    const MmaKind& mma_kind) {
     constexpr int kSmemAlignment = 1024;
     constexpr int kNumEpilogueStages = 2;
     constexpr int kNumTMAStoreStages = 2;
-    const int num_mma_elem_bytes = get_num_mma_elem_bytes(mma_kind);
+    const int elem_bits = get_element_bits(mma_kind);
 
     // Always multicast on A
     const int load_block_m = block_m / 2;
@@ -149,7 +169,7 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
 
     // C/D output region: max of L1 output staging and L2 BF16 staging.
     const auto num_epilogue_warpgroups = num_epilogue_warps / 4;
-    const int smem_cd_l1 = num_epilogue_warpgroups * store_block_m * (block_n / 2) * kNumTMAStoreStages * get_num_mma_elem_bytes(mma_kind);
+    const int smem_cd_l1 = num_epilogue_warpgroups * store_block_m * (block_n / 2) * kNumTMAStoreStages * elem_bits / 8;
     const int smem_cd_l2 = num_epilogue_warpgroups * store_block_m * block_n * static_cast<int>(sizeof(nv_bfloat16));
     const int smem_cd = align(std::max(smem_cd_l1, smem_cd_l2), kSmemAlignment);
 
@@ -173,19 +193,14 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
     const int smem_sfb_per_stage = is_mma_with_sf(mma_kind) ? sf_block_n * (block_k / gran_k) : 0;
 
     // Per-stage: A tile + B tile + optional SF tiles + full/empty barriers.
-    // Dense FP4 kind halves both A and B byte footprints in shared memory.
-    const int smem_a_size_per_stage = use_mxf4_kind
-        ? (load_block_m * block_k / 2)
-        : (load_block_m * block_k * num_mma_elem_bytes);
-    const int smem_b_size_per_stage = use_mxf4_kind
-        ? (block_n * block_k / 2)
-        : (block_n * block_k * num_mma_elem_bytes);
+    // NOTES: for `MXFP8FP4` the FP4 weights are unpacked into 8-bit containers in smem,
+    // so A and B always share the same per-element footprint
+    const int smem_a_size_per_stage = load_block_m * block_k * elem_bits / 8;
+    const int smem_b_size_per_stage = block_n * block_k * elem_bits / 8;
     DG_HOST_ASSERT(smem_a_size_per_stage % kSmemAlignment == 0);
     DG_HOST_ASSERT(smem_b_size_per_stage % kSmemAlignment == 0);
     const int smem_stage_barriers = 2 * 8;
-    const int smem_size_per_stage = smem_a_size_per_stage + smem_b_size_per_stage +
-                                    smem_sfa_per_stage + smem_sfb_per_stage +
-                                    smem_stage_barriers;
+    const int smem_size_per_stage = smem_a_size_per_stage + smem_b_size_per_stage + smem_sfa_per_stage + smem_sfb_per_stage + smem_stage_barriers;
 
     // Fixed total
     const int smem_fixed = smem_dispatch_size + smem_cd + smem_amax_reduction + smem_barriers +
@@ -204,26 +219,21 @@ static MegaMoEConfig get_mega_moe_config(
     const int& hidden, const int& intermediate_hidden,
     const int& num_ring_tokens,
     const int& num_sf_ring_tokens,
-    const MmaKind& mma_kind,
-    const bool& use_fp4_acts = false,
-    const bool& use_mxf4_kind = false) {
+    const MmaKind& mma_kind) {
 
     // Block config
     const auto [cluster_size, block_m, store_block_m, block_k, num_epilogue_threads] =
-        get_block_config_for_mega_moe(num_ranks, num_experts, num_max_tokens_per_rank, num_topk, num_tokens, mma_kind, use_mxf4_kind);
+        get_block_config_for_mega_moe(num_ranks, num_experts, num_max_tokens_per_rank, num_topk, num_tokens, mma_kind);
     const int block_n = 128;
     const int load_block_m = block_m / 2;
     const int load_block_n = block_n;
     const auto [sf_block_m, sf_block_n] = is_mma_with_sf(mma_kind) ?
-        SM100ArchSpec::get_sf_uttcp_aligned_block_sizes(block_m, block_n, MmaKind::MXFP8FP4) : std::pair(0, 0);
-    // NOTES: FP8 activations and FP4 weights (unpacked to 8-bit in smem) both use 128B swizzle
+        SM100ArchSpec::get_sf_uttcp_aligned_block_sizes(block_m, block_n, mma_kind) : std::pair(0, 0);
+    // NOTES: FP8 activations and FP4 weights (unpacked to 8-bit in smem) both use 128B swizzle;
+    // NVFP4 keeps FP4 packed, so a 128B swizzle atom covers twice as many elements
     const int swizzle_acts_mode = 128;
     const int swizzle_weights_mode = 128;
-    const int gran_k = 32;
-    const int num_max_pool_tokens = layout::get_num_max_pool_tokens(
-        num_ranks, num_max_tokens_per_rank, num_topk, num_experts_per_rank);
-    const bool use_full_pool_fp8_fp4_path =
-        mma_kind == MmaKind::MXFP8FP4 and num_ring_tokens >= num_max_pool_tokens;
+    const int gran_k = is_mma_with_sf(mma_kind) ? get_sf_gran_k(mma_kind) : 32;
 
     // Thread layout
     const int num_dispatch_threads = 128;
@@ -231,10 +241,8 @@ static MegaMoEConfig get_mega_moe_config(
 
     // Pull: divide token bytes by 2 until <= kPullThreshold
     constexpr int kPullThreshold = 4096;
-    int num_bytes_per_pull = use_full_pool_fp8_fp4_path ?
-        hidden * get_num_mma_elem_bytes(mma_kind) :
-        (use_fp4_acts ? (hidden / 2) : hidden * get_num_mma_elem_bytes(mma_kind));
-    while (not use_full_pool_fp8_fp4_path and num_bytes_per_pull > kPullThreshold) {
+    int num_bytes_per_pull = hidden * get_element_bits(mma_kind) / 8;
+    while (num_bytes_per_pull > kPullThreshold) {
         DG_HOST_ASSERT(num_bytes_per_pull % 2 == 0);
         num_bytes_per_pull /= 2;
     }
@@ -246,12 +254,12 @@ static MegaMoEConfig get_mega_moe_config(
         block_m, block_n, block_k, num_bytes_per_pull, store_block_m,
         sf_block_m, sf_block_n, gran_k,
         num_dispatch_threads / 32, num_epilogue_threads / 32,
-        mma_kind, use_mxf4_kind);
+        mma_kind);
 
     const auto config = MegaMoEConfig {
         block_m, block_n, block_k,
         load_block_m, load_block_n, store_block_m,
-        sf_block_m, sf_block_n,
+        sf_block_m, sf_block_n, gran_k,
         num_ring_tokens, is_mma_with_sf(mma_kind) ? num_sf_ring_tokens : 0,
         swizzle_acts_mode, swizzle_weights_mode,
         num_stages, smem_size,

--- a/csrc/jit_kernels/heuristics/sm100.hpp
+++ b/csrc/jit_kernels/heuristics/sm100.hpp
@@ -20,6 +20,8 @@ struct SM100ArchSpec {
         switch (mma_kind) {
             case MmaKind::BF16: return {0, 0};
             case MmaKind::MXFP8FP4: return {align(block_m, num_utccp_aligned_elems), align(block_n, num_utccp_aligned_elems)};
+            case MmaKind::MXFP4: return {align(block_m, num_utccp_aligned_elems), align(block_n, num_utccp_aligned_elems)};
+            case MmaKind::NVFP4: return {align(block_m, num_utccp_aligned_elems), align(block_n, num_utccp_aligned_elems)};
             default: DG_HOST_UNREACHABLE("Unknown dtype");
         }
     }
@@ -47,7 +49,7 @@ struct SM100ArchSpec {
         for (int swap_ab = 0; swap_ab < 2; ++ swap_ab) {
             // Block M/N candidates
             std::vector<int> block_m_candidates;
-            std::vector<int> block_n_candidates;            
+            std::vector<int> block_n_candidates;
             if (swap_ab) {
                 int step = std::lcm(16, heuristics_runtime->get_block_m_multiple_of());
                 int end = 256;
@@ -122,7 +124,9 @@ struct SM100ArchSpec {
 
                             // Check tensor memory capacity
                             const auto [sf_block_m, sf_block_n] = get_sf_uttcp_aligned_block_sizes(block_m, block_n, desc.get_mma_kind());
-                            const auto tmem_sf_cols = desc.get_mma_kind() == MmaKind::MXFP8FP4 ? sf_block_m / 32 + sf_block_n / 32 : 0;
+                            const auto sf_granularity = get_sf_gran_k(desc.get_mma_kind());
+                            const auto tmem_sf_cols = sf_granularity ?
+                                sf_block_m / sf_granularity + sf_block_n / sf_granularity : sf_granularity;
                             const auto umma_n = swap_ab ? block_m : block_n;
                             if (2 * umma_n + tmem_sf_cols > 512)
                                 continue;

--- a/csrc/jit_kernels/impls/runtime_utils.hpp
+++ b/csrc/jit_kernels/impls/runtime_utils.hpp
@@ -83,6 +83,7 @@ static CUtensorMapDataType aten_dtype_to_tensor_map_dtype(const at::ScalarType& 
         case torch::kFloat:         return CU_TENSOR_MAP_DATA_TYPE_FLOAT32;
         case torch::kBFloat16:      return CU_TENSOR_MAP_DATA_TYPE_BFLOAT16;
         case torch::kFloat8_e4m3fn: return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+        case torch::kUInt8:         return CU_TENSOR_MAP_DATA_TYPE_UINT8;
 #if CUDA_VERSION >= 12080
         case kPackedFP4:            return fp4_unpacked_smem ? CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
                                                              : CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B;

--- a/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/python.h>
+#include <torch/torch.h>
 
 #include "../../jit/compiler.hpp"
 #include "../../jit/kernel_runtime.hpp"
@@ -23,26 +23,24 @@ public:
         int hidden, intermediate_hidden;
         int num_experts, num_shared_experts, num_topk;
         int num_ranks;
+        MmaKind mma_kind;
         float activation_clamp;
+        float swiglu_alpha;
         bool use_situ;
         bool fast_math;
-        // Stream A0.1: enable FP4 (E2M1) activations from L1 epilogue.
-        // Default false — keeps the FP8-acts baseline byte-identical.
-        bool use_fp4_acts;
-        // Stream A0.5: when set, run kind::mxf4 (K=64 dense) instead of
-        // kind::mxf8f6f4 (K=32 with-padding) for both L1 and L2 mainloops.
-        // Only honored when `use_fp4_acts` is also set.
-        bool use_mxf4_kind;
-        // Stream B (combine path): when set, the L2 epilogue writes FP8 E4M3
-        // + per-(token,N=128) UE8M0 SF over NVLink instead of BF16. The
-        // combine reduce dequantizes on the fly. Halves NVLink bytes/token
-        // on the second a2a (kHidden + kHidden/128 vs kHidden*2).
+        bool use_x_scales;
+        bool with_l1_alphas;
+        bool with_l2_alphas;
+        bool with_l2_act_scales;
         bool use_fp8_combine;
         MegaMoEConfig config;
 
         // Runtime arguments
         void* y;
         int* cumulative_local_expert_recv_stats;
+        const float* l1_alphas;
+        const float* l2_alphas;
+        const float* l2_act_scales;
         int num_tokens;
         layout::SymBuffer<> sym_buffer_ptrs;
 
@@ -89,13 +87,13 @@ static void __instantiate_kernel() {{
         {},
         {},
         {},
+        {},
         {}, {}, {},
+        {}, {},
         {}, {},
         {},
         {},
-        {},
-        {},
-        {}
+        {}, {}, {}, {}, {}
     >);
 }};
 )", args.num_max_tokens_per_rank,
@@ -105,17 +103,20 @@ static void __instantiate_kernel() {{
     args.config.block_m, args.config.block_n, args.config.block_k,
     args.config.store_block_m,
     args.config.sf_block_m, args.config.sf_block_n,
+    to_mma_kind_name(args.mma_kind),
     args.config.num_ring_tokens,
     args.config.num_sf_ring_tokens,
     args.config.num_stages,
     args.config.num_bytes_per_pull,
     args.config.num_dispatch_threads, args.config.num_non_epilogue_threads, args.config.num_epilogue_threads,
     args.launch_args.grid_dim.first, args.num_ranks,
-    to_string(args.activation_clamp),
+    to_string(args.activation_clamp), to_string(args.swiglu_alpha),
     args.use_situ ? "true" : "false",
     args.fast_math ? "true" : "false",
-    args.use_fp4_acts ? "true" : "false",
-    args.use_mxf4_kind ? "true" : "false",
+    args.use_x_scales ? "true" : "false",
+    args.with_l1_alphas ? "true" : "false",
+    args.with_l2_alphas ? "true" : "false",
+    args.with_l2_act_scales ? "true" : "false",
     args.use_fp8_combine ? "true" : "false");
     }
 
@@ -124,6 +125,9 @@ static void __instantiate_kernel() {{
         DG_CUDA_UNIFIED_CHECK(launch_kernel(kernel, config,
             args.y,
             args.cumulative_local_expert_recv_stats,
+            args.l1_alphas,
+            args.l2_alphas,
+            args.l2_act_scales,
             args.num_tokens,
             args.sym_buffer_ptrs,
             args.tensor_map_l1_acts,
@@ -166,151 +170,82 @@ static void sm100_fp8_fp4_mega_moe(
     const int& num_tokens, const int& num_topk,
     const int& hidden, const int& intermediate_hidden,
     const float& activation_clamp,
+    const float& swiglu_alpha,
     const bool& use_situ,
     const bool& fast_math,
-    const bool& use_fp4_acts = false,
-    const bool& use_mxf4_kind = false,
-    const bool& use_fp8_combine = false
+    const bool& use_x_scales,
+    const float* l1_alphas,
+    const float* l2_alphas,
+    const float* l2_act_scales,
+    const MmaKind& mma_kind,
+    const bool& use_fp8_combine
 ) {
     const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
     const auto num_experts = num_experts_per_rank * num_ranks;
     const auto num_ring_tokens = static_cast<int>(l1_acts.size(0));
     const auto num_sf_ring_tokens = static_cast<int>(l1_acts_sf.size(0));
     const auto shared_intermediate_hidden = intermediate_hidden * num_shared_experts;
-    // Stream A0.5 sanity: kind::mxf4 only accepts FP4 inputs.
-    DG_HOST_ASSERT(not use_mxf4_kind or use_fp4_acts);
-    DG_HOST_ASSERT(not use_fp4_acts or num_shared_experts == 0);
 
     // Heuristics
     const auto config = get_mega_moe_config(
         num_ranks, num_experts, num_experts_per_rank,
         num_max_tokens_per_rank, num_tokens, num_topk, hidden, intermediate_hidden,
         num_ring_tokens, num_sf_ring_tokens,
-        MmaKind::MXFP8FP4, use_fp4_acts, use_mxf4_kind);
+        mma_kind);
 
     // Make tensormap
-    constexpr int kGranK = 32;
+    const bool is_packed_fp4 = mma_kind == MmaKind::NVFP4 or mma_kind == MmaKind::MXFP4;
+    const int kGranK = config.gran_k;
+    const int elem_bits = get_element_bits(mma_kind);
+    const auto to_inner = [=](const int& num_elems) { return num_elems * elem_bits / 8; };
+    const auto weight_tensor = [=](const torch::Tensor& t) { return is_packed_fp4 ? t.view(torch::kUInt8) : t; };
+    const auto weight_inner = [=](const int& num_elems) { return is_packed_fp4 ? num_elems / 2 : num_elems; };
+    const int block_k_inner = to_inner(config.block_k);
     const int sf_smem_outer_dim = config.block_k / (kGranK * 4);
-    // Stream A0.5: when `use_mxf4_kind` is on, BOTH L1 and L2 acts AND
-    // weights TMA descriptors switch from `_ALIGN16B` (FP4 with-padding,
-    // 8 data + 8 pad bytes per 16-byte atom) to `_ALIGN8B` (dense FP4,
-    // 2 nibbles/byte). The smem byte stride per K-row halves accordingly,
-    // and swizzle mode halves to match (128B → 64B). The gmem layout is
-    // unchanged — the underlying `l1_acts` / `l1_weights` storage is still
-    // packed FP4 nibbles; only how TMA expands them into smem changes.
-    const bool fp4_unpacked = not use_mxf4_kind;
-    const int swizzle_acts = use_mxf4_kind ? config.swizzle_acts_mode / 2
-                                           : config.swizzle_acts_mode;
-    const int swizzle_weights = use_mxf4_kind ? config.swizzle_weights_mode / 2
-                                              : config.swizzle_weights_mode;
-    // Stream A0.0b: when `use_fp4_acts` is on, the L1 token pool buffer
-    // (`l1_acts`) is already viewed as `kPackedFP4` (int8) by the symm-buffer
-    // slice (see `csrc/apis/mega.hpp`), with shape `[num_pool_tokens, hidden/2]`
-    // of packed E2M1 (low nibble = even col, high nibble = odd col).
-    // `make_tma_2d_desc` then auto-selects `CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B`
-    // via `aten_dtype_to_tensor_map_dtype` (runtime_utils.hpp:84-87) — or
-    // `_ALIGN8B` under `use_mxf4_kind` (Stream A0.5).
-    //
-    // TMA descriptor: `gmem_inner_dim = hidden` U4 elements (the descriptor
-    // reads `hidden/2` storage bytes per row); smem inner box has `config.block_k`
-    // elements and swizzle follows the selected dense/with-padding FP4 mode.
     const auto tensor_map_l1_acts = make_tma_2d_desc(l1_acts,
-                                                     hidden, config.num_ring_tokens,
-                                                     config.block_k, config.load_block_m,
+                                                     to_inner(hidden), config.num_ring_tokens,
+                                                     block_k_inner, config.load_block_m,
                                                      static_cast<int>(l1_acts.stride(-2)),
-                                                     swizzle_acts, /*swizzle_base=*/0,
-                                                     /*allow_tf32=*/false,
-                                                     /*fp4_unpacked_smem=*/fp4_unpacked);
+                                                     config.swizzle_acts_mode);
     const auto tensor_map_l1_acts_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l1_acts_sf,
                                                         config.num_sf_ring_tokens, hidden,
                                                         config.sf_block_m, kGranK,
                                                         1, 0, 0, false,
                                                         sf_smem_outer_dim);
-    const auto tensor_map_l1_weights = make_tma_2d_desc(l1_weights,
-                                                        hidden, num_experts_per_rank * intermediate_hidden * 2,
-                                                        config.block_k, config.load_block_n,
+    const auto tensor_map_l1_weights = make_tma_2d_desc(weight_tensor(l1_weights),
+                                                        weight_inner(hidden), num_experts_per_rank * intermediate_hidden * 2,
+                                                        block_k_inner, config.load_block_n,
                                                         static_cast<int>(l1_weights.stride(-2)),
-                                                        swizzle_weights, /*swizzle_base=*/0,
-                                                        /*allow_tf32=*/false,
-                                                        /*fp4_unpacked_smem=*/fp4_unpacked);
+                                                        config.swizzle_weights_mode, 0, false, not is_packed_fp4);
     const auto tensor_map_l1_weights_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l1_weights_sf,
                                                            intermediate_hidden * 2, hidden,
                                                            config.block_n, kGranK,
                                                            num_experts_per_rank, 0, 0, false,
-                                                           sf_smem_outer_dim);
+                                                        sf_smem_outer_dim);
     // NOTES: L1 output and L2 activations are essentially the same tensor.
     // Post-SwiGLU output has half the N width (`BLOCK_N / 2` per input tile),
     // so the swizzle mode is also halved (128 -> 64).
-    //
-    // Stream A0.2: when `use_fp4_acts` is on, the L1 epilogue emits packed
-    // E2M1 (FP4) where each byte holds 2 elements. The kernel writes a
-    // **dense canonical** smem layout (no swizzle XOR) — see the FP4 store
-    // branch in `sm100_fp8_fp4_mega_moe.cuh`. To match, we build the L1
-    // output TMA descriptor with `swizzle = 0`. The gmem result is the
-    // canonical `[M, intermediate_hidden / 2]` packed FP4 layout, byte-
-    // identical to what `kernels/fused_gemm_swiglu_fp4_quant_1cta` produces
-    // (Stream A2). The L2 reader (built below) consumes this same canonical
-    // layout via `_ALIGN16B`. The per-row gmem byte footprint halves
-    // (`intermediate_hidden / 2` bytes vs `intermediate_hidden` for FP8);
-    // outer stride in the underlying buffer is unchanged.
-    const auto tensor_map_l1_output = use_fp4_acts
-        ? make_tma_2d_desc(l2_acts,
-                           intermediate_hidden / 2, config.num_ring_tokens,
-                           config.block_n / 4, config.store_block_m,
-                           static_cast<int>(l2_acts.stride(-2)),
-                           /*swizzle_mode=*/0)
-        : make_tma_2d_desc(l2_acts,
-                           intermediate_hidden, config.num_ring_tokens,
-                           config.block_n / 2, config.store_block_m,
-                           static_cast<int>(l2_acts.stride(-2)),
-                           config.swizzle_acts_mode / 2);
-    // Stream A0.2: when FP4 acts on, L2 reads packed E2M1 via `_ALIGN16B`.
-    // `make_tma_2d_desc` selects the descriptor dtype from the source
-    // tensor's `scalar_type`; `l2_acts` is allocated as FP8 (1 byte/elem).
-    // For the FP4 path we re-view the same byte buffer as `kPackedFP4` so
-    // the descriptor dtype is `CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B`.
-    //
-    // gmem layout (FP4 path, set up by L1 epilogue):
-    //   - per row: first `intermediate_hidden / 2` bytes are packed E2M1
-    //     (low nibble = even col, high nibble = odd col — canonical MXFP4),
-    //     remaining bytes in the row are stale FP8 from prior runs.
-    //   - row stride: `l2_acts.stride(-2)` source bytes (= same as FP8
-    //     because the buffer view's underlying allocation hasn't changed).
-    //
-    // TMA descriptor tells the hardware:
-    //   - `gmem_inner_dim = intermediate_hidden` U4 elements (=
-    //     `intermediate_hidden / 2` source bytes are read per row).
-    //   - `gmem_outer_stride = stride(-2)` source bytes (the actual storage
-    //     row pitch — leaves the unused tail of each FP8-sized row alone).
-    //   - smem inner box = `BLOCK_K = 128` elements (= 64 source bytes per
-    //     row, expands to 128 smem bytes after `_ALIGN16B` doubling); 128B
-    //     swizzle aligns with the per-stage atom (same as B-side, which has
-    //     used this layout for FP4 weights from day one).
-    const auto tensor_map_l2_acts = use_fp4_acts
-        ? make_tma_2d_desc(l2_acts.view(kPackedFP4),
-                           intermediate_hidden, config.num_ring_tokens,
-                           config.block_k, config.load_block_m,
-                           static_cast<int>(l2_acts.stride(-2)),
-                           swizzle_acts, /*swizzle_base=*/0,
-                           /*allow_tf32=*/false,
-                           /*fp4_unpacked_smem=*/fp4_unpacked)
-        : make_tma_2d_desc(l2_acts,
-                           intermediate_hidden, config.num_ring_tokens,
-                           config.block_k, config.load_block_m,
-                           static_cast<int>(l2_acts.stride(-2)),
-                           config.swizzle_acts_mode);
+    const int l1_out_block_n_bytes = to_inner(config.block_n / 2);
+    const auto tensor_map_l1_output = make_tma_2d_desc(l2_acts,
+                                                       to_inner(intermediate_hidden), config.num_ring_tokens,
+                                                       l1_out_block_n_bytes, config.store_block_m,
+                                                       static_cast<int>(l2_acts.stride(-2)),
+                                                       l1_out_block_n_bytes);
+    const auto tensor_map_l2_acts = make_tma_2d_desc(l2_acts,
+                                                     to_inner(intermediate_hidden), config.num_ring_tokens,
+                                                     block_k_inner, config.load_block_m,
+                                                     static_cast<int>(l2_acts.stride(-2)),
+                                                     config.swizzle_acts_mode);
     const auto tensor_map_l2_acts_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l2_acts_sf,
                                                         config.num_sf_ring_tokens, intermediate_hidden,
                                                         config.sf_block_m, kGranK,
                                                         1, 0, 0, false,
                                                         sf_smem_outer_dim);
-    const auto tensor_map_l2_weights = make_tma_2d_desc(l2_weights,
-                                                        intermediate_hidden, num_experts_per_rank * hidden,
-                                                        config.block_k, config.load_block_n,
+    const auto tensor_map_l2_weights = make_tma_2d_desc(weight_tensor(l2_weights),
+                                                        weight_inner(intermediate_hidden), num_experts_per_rank * hidden,
+                                                        block_k_inner, config.load_block_n,
                                                         static_cast<int>(l2_weights.stride(-2)),
-                                                        swizzle_weights, /*swizzle_base=*/0,
-                                                        /*allow_tf32=*/false,
-                                                        /*fp4_unpacked_smem=*/fp4_unpacked);
+                                                        config.swizzle_weights_mode, 0, false, not is_packed_fp4);
     const auto tensor_map_l2_weights_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l2_weights_sf,
                                                            hidden, intermediate_hidden,
                                                            config.block_n, kGranK,
@@ -319,8 +254,8 @@ static void sm100_fp8_fp4_mega_moe(
 
     const auto tensor_map_shared_l1_acts = num_shared_experts > 0 ? make_tma_2d_desc(
         shared_l1_acts,
-        hidden, num_max_tokens_per_rank,
-        config.block_k, config.load_block_m,
+        to_inner(hidden), num_max_tokens_per_rank,
+        block_k_inner, config.load_block_m,
         static_cast<int>(shared_l1_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l1_acts;
     const auto tensor_map_shared_l1_acts_sf = num_shared_experts > 0 ? make_tma_sf_desc(
@@ -330,9 +265,9 @@ static void sm100_fp8_fp4_mega_moe(
         1, 0, 0, false,
         sf_smem_outer_dim) : tensor_map_l1_acts_sf;
     const auto tensor_map_shared_l1_weights = num_shared_experts > 0 ? make_tma_2d_desc(
-        shared_l1_weights,
-        hidden, shared_intermediate_hidden * 2,
-        config.block_k, config.load_block_n,
+        weight_tensor(shared_l1_weights),
+        to_inner(hidden), shared_intermediate_hidden * 2,
+        block_k_inner, config.load_block_n,
         static_cast<int>(shared_l1_weights.stride(-2)),
         config.swizzle_weights_mode) : tensor_map_l1_weights;
     const auto tensor_map_shared_l1_weights_sf = num_shared_experts > 0 ? make_tma_sf_desc(
@@ -343,14 +278,14 @@ static void sm100_fp8_fp4_mega_moe(
         sf_smem_outer_dim) : tensor_map_l1_weights_sf;
     const auto tensor_map_shared_l1_output = num_shared_experts > 0 ? make_tma_2d_desc(
         shared_l2_acts,
-        shared_intermediate_hidden, num_max_tokens_per_rank,
-        config.block_n / 2, config.store_block_m,
+        to_inner(shared_intermediate_hidden), num_max_tokens_per_rank,
+        l1_out_block_n_bytes, config.store_block_m,
         static_cast<int>(shared_l2_acts.stride(-2)),
-        config.swizzle_acts_mode / 2) : tensor_map_l1_output;
+        l1_out_block_n_bytes) : tensor_map_l1_output;
     const auto tensor_map_shared_l2_acts = num_shared_experts > 0 ? make_tma_2d_desc(
         shared_l2_acts,
-        shared_intermediate_hidden, num_max_tokens_per_rank,
-        config.block_k, config.load_block_m,
+        to_inner(shared_intermediate_hidden), num_max_tokens_per_rank,
+        block_k_inner, config.load_block_m,
         static_cast<int>(shared_l2_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l2_acts;
     const auto tensor_map_shared_l2_acts_sf = num_shared_experts > 0 ? make_tma_sf_desc(
@@ -360,9 +295,9 @@ static void sm100_fp8_fp4_mega_moe(
         1, 0, 0, false,
         sf_smem_outer_dim) : tensor_map_l2_acts_sf;
     const auto tensor_map_shared_l2_weights = num_shared_experts > 0 ? make_tma_2d_desc(
-        shared_l2_weights,
-        shared_intermediate_hidden, hidden,
-        config.block_k, config.load_block_n,
+        weight_tensor(shared_l2_weights),
+        to_inner(shared_intermediate_hidden), hidden,
+        block_k_inner, config.load_block_n,
         static_cast<int>(shared_l2_weights.stride(-2)),
         config.swizzle_weights_mode) : tensor_map_l2_weights;
     const auto tensor_map_shared_l2_weights_sf = num_shared_experts > 0 ? make_tma_sf_desc(
@@ -385,15 +320,22 @@ static void sm100_fp8_fp4_mega_moe(
         .num_experts = num_experts, .num_shared_experts = num_shared_experts,
         .num_topk = num_topk,
         .num_ranks = num_ranks,
+        .mma_kind = mma_kind,
         .activation_clamp = activation_clamp,
+        .swiglu_alpha = swiglu_alpha,
         .use_situ = use_situ,
         .fast_math = fast_math,
-        .use_fp4_acts = use_fp4_acts,
-        .use_mxf4_kind = use_mxf4_kind,
+        .use_x_scales = use_x_scales,
+        .with_l1_alphas = l1_alphas != nullptr,
+        .with_l2_alphas = l2_alphas != nullptr,
+        .with_l2_act_scales = l2_act_scales != nullptr,
         .use_fp8_combine = use_fp8_combine,
         .config = config,
         .y = y.data_ptr(),
         .cumulative_local_expert_recv_stats = cumulative_local_expert_recv_stats_ptr,
+        .l1_alphas = l1_alphas,
+        .l2_alphas = l2_alphas,
+        .l2_act_scales = l2_act_scales,
         .num_tokens = num_tokens,
         .sym_buffer_ptrs = layout::SymBuffer<>(sym_buffer_ptrs, rank_idx),
         .tensor_map_l1_acts = tensor_map_l1_acts,

--- a/csrc/jit_kernels/impls/sm100_mega_moe_pre_dispatch.hpp
+++ b/csrc/jit_kernels/impls/sm100_mega_moe_pre_dispatch.hpp
@@ -2,9 +2,12 @@
 
 #include <torch/python.h>
 
+#include <optional>
+
 #include "../../jit/compiler.hpp"
 #include "../../jit/device_runtime.hpp"
 #include "../../jit/kernel_runtime.hpp"
+#include "../heuristics/mega_moe.hpp"
 #include "../../utils/exception.hpp"
 #include "../../utils/format.hpp"
 #include "../../utils/math.hpp"
@@ -13,21 +16,23 @@ namespace deep_gemm {
 
 // JIT runtime for `sm100_mega_moe_pre_dispatch` (see
 // `deep_gemm/include/deep_gemm/impls/sm100_mega_moe_pre_dispatch.cuh`).
-// Templated on (kGroupSize, kUseFp4Acts, kUsePDL); host fn picks the
+// Templated on (kGroupSize, kMmaKind, kUsePDL); host fn picks the
 // instantiation from explicit args.
 class SM100MegaMoEPreDispatchRuntime final : public LaunchRuntime<SM100MegaMoEPreDispatchRuntime> {
 public:
     struct Args {
         int group_size;
-        bool use_fp4_acts;
+        MmaKind mma_kind;
         bool use_pdl;
 
         // Runtime args (passed to the kernel via the params struct).
         const void* x;
         const void* topk_idx;
         const void* topk_weights;
+        const void* expert_scales;
         void*       buf_x;
         void*       buf_x_sf;
+        void*       buf_x_scales;
         void*       buf_topk_idx;
         void*       buf_topk_weights;
         uint32_t    num_tokens;
@@ -51,14 +56,15 @@ static void __instantiate_kernel() {{
     >);
 }};
 )", args.group_size,
-    args.use_fp4_acts ? "true" : "false",
+    to_mma_kind_name(args.mma_kind),
     args.use_pdl ? "true" : "false");
     }
 
     static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
         DG_CUDA_UNIFIED_CHECK(launch_kernel(kernel, config,
-            args.x, args.topk_idx, args.topk_weights,
-            args.buf_x, args.buf_x_sf, args.buf_topk_idx, args.buf_topk_weights,
+            args.x, args.topk_idx, args.topk_weights, args.expert_scales,
+            args.buf_x, args.buf_x_sf, args.buf_x_scales,
+            args.buf_topk_idx, args.buf_topk_weights,
             args.num_tokens, args.padded_max, args.hidden, args.num_groups, args.top_k));
     }
 };
@@ -67,7 +73,7 @@ static void __instantiate_kernel() {{
 //   - x:            (M, H) bf16, contiguous.
 //   - topk_idx:     (M, K) int32, contiguous.
 //   - topk_weights: (M, K) float, contiguous.
-//   - buf_x:        (P, H) fp8_e4m3 if !use_fp4_acts, else (P, H/2) int8 (packed FP4).
+//   - buf_x:        (P, H) fp8_e4m3 for `fp8xfp4`, else (P, H/2) int8 (packed FP4).
 //   - buf_x_sf:     (P, G/4) int32, contiguous; G = H / group_size; each int32
 //                   stores 4 UE8M0 bytes row-major.
 //   - buf_topk_idx: (P, K) int64.
@@ -87,8 +93,29 @@ static void mega_moe_pre_dispatch(
     const torch::Tensor& buf_topk_weights,
     const int& num_tokens,
     const int& group_size,
-    const bool& use_fp4_acts) {
-    DG_HOST_ASSERT(group_size == 32 || group_size == 64 || group_size == 128);
+    const std::string& mma_type,
+    const std::optional<torch::Tensor>& buf_x_scales,
+    const std::optional<torch::Tensor>& expert_scales) {
+    const auto mma_kind = parse_mma_kind(mma_type);
+    DG_HOST_ASSERT(mma_kind != MmaKind::BF16);
+    const bool is_packed_fp4 = mma_kind == MmaKind::MXFP4 or mma_kind == MmaKind::NVFP4;
+    if (mma_kind == MmaKind::NVFP4) {
+        // NVFP4 per-token acts: 16-elem UE4M3 block SFs plus one FP32 outer
+        // scale per token (written to `buf_x_scales`).
+        DG_HOST_ASSERT(group_size == 16);
+        DG_HOST_ASSERT(buf_x_scales.has_value());
+        DG_HOST_ASSERT(buf_x_scales->scalar_type() == torch::kFloat);
+        DG_HOST_ASSERT(buf_x_scales->is_contiguous());
+        DG_HOST_ASSERT(buf_x_scales->numel() >= num_tokens);
+    } else {
+        DG_HOST_ASSERT(group_size == 32 || group_size == 64 || group_size == 128);
+        DG_HOST_ASSERT(!buf_x_scales.has_value());
+    }
+    if (expert_scales.has_value()) {
+        DG_HOST_ASSERT(expert_scales->scalar_type() == torch::kFloat);
+        DG_HOST_ASSERT(expert_scales->is_contiguous());
+        DG_HOST_ASSERT(expert_scales->dim() == 1);
+    }
     DG_HOST_ASSERT(x.scalar_type() == torch::kBFloat16);
     DG_HOST_ASSERT(x.is_contiguous());
     DG_HOST_ASSERT(topk_idx.scalar_type() == torch::kInt32);
@@ -123,7 +150,7 @@ static void mega_moe_pre_dispatch(
     DG_HOST_ASSERT(static_cast<int>(buf_x_sf.size(0)) == padded_max);
     DG_HOST_ASSERT(static_cast<int>(buf_x_sf.size(1)) == num_groups / 4);
 
-    if (use_fp4_acts) {
+    if (is_packed_fp4) {
         // Packed FP4: (P, hidden/2) bytes. The symm-buffer slice views this
         // as kPackedFP4 (int8); accept either int8 / uint8 / float8_e4m3fn
         // re-views since callers may bind the slot differently.
@@ -149,13 +176,17 @@ static void mega_moe_pre_dispatch(
 
     SM100MegaMoEPreDispatchRuntime::Args args = {
         .group_size = group_size,
-        .use_fp4_acts = use_fp4_acts,
+        .mma_kind = mma_kind,
         .use_pdl = use_pdl,
         .x = x.const_data_ptr(),
         .topk_idx = topk_idx.const_data_ptr(),
         .topk_weights = topk_weights.const_data_ptr(),
+        .expert_scales = expert_scales.has_value()
+            ? expert_scales->const_data_ptr() : nullptr,
         .buf_x = buf_x.data_ptr(),
         .buf_x_sf = buf_x_sf.data_ptr(),
+        .buf_x_scales = buf_x_scales.has_value()
+            ? buf_x_scales->data_ptr() : nullptr,
         .buf_topk_idx = buf_topk_idx.data_ptr(),
         .buf_topk_weights = buf_topk_weights.data_ptr(),
         .num_tokens = static_cast<uint32_t>(num_tokens),

--- a/csrc/tvm_ffi_api.cpp
+++ b/csrc/tvm_ffi_api.cpp
@@ -639,21 +639,22 @@ int64_t dg_get_token_alignment_for_mega_moe() {
     return (int64_t)mega::get_token_alignment_for_mega_moe();
 }
 
-static Tensor mega_tensor_to_ffi(const torch::Tensor& tensor) {
-    if (not tensor.defined())
-        return Tensor();
-    // DLPack/TVM-FFI does not expose PyTorch's float8 dtype consistently.
-    // Preserve its storage as int8 and restore the logical dtype in Python.
-    const auto ffi_tensor = tensor.scalar_type() == torch::kFloat8_e4m3fn ?
-        tensor.view(torch::kInt8) : tensor;
-    return Tensor::FromDLPack(at::toDLPack(ffi_tensor));
+int64_t dg_get_block_m_for_mega_moe(int64_t num_ranks, int64_t num_experts,
+                                    int64_t num_max_tokens_per_rank, int64_t num_tokens,
+                                    int64_t num_topk, std::string mma_type) {
+    return static_cast<int64_t>(mega::get_block_m_for_mega_moe(
+        static_cast<int>(num_ranks),
+        static_cast<int>(num_experts),
+        static_cast<int>(num_max_tokens_per_rank),
+        static_cast<int>(num_tokens),
+        static_cast<int>(num_topk),
+        mma_type));
 }
 
-using MegaBufferTensors = Tuple<Tensor, Tensor, Tensor, Tensor,
-                                Tensor, Tensor, Tensor, Tensor,
-                                Tensor, Tensor, Tensor, Tensor>;
+using MegaSliceResult = Tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor,
+                              Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor>;
 
-Tuple<int64_t, TypedFunction<MegaBufferTensors(TensorView)>>
+Tuple<int64_t, TypedFunction<MegaSliceResult(TensorView)>>
 dg_get_symm_buffer_size_for_mega_moe(int64_t num_ranks, int64_t num_experts, int64_t num_max_tokens_per_rank, int64_t num_topk, int64_t hidden,
                                     int64_t intermediate_hidden, std::string mma_type, std::string activation,
                                     int64_t num_shared_experts) {
@@ -670,19 +671,32 @@ dg_get_symm_buffer_size_for_mega_moe(int64_t num_ranks, int64_t num_experts, int
     );
 
     auto slice_input_buffers = [=](TensorView buffer) {
+        const auto buffer_torch = convert_to_torch_tensor(buffer);
         auto [x, x_sf, topk_idx, topk_weights,
               shared_l1_acts, shared_l1_acts_sf, shared_l2_acts, shared_l2_acts_sf,
-              l1_acts, l1_acts_sf, l2_acts, l2_acts_sf] = fn(convert_to_torch_tensor(buffer));
-        return MegaBufferTensors(
-            mega_tensor_to_ffi(x), mega_tensor_to_ffi(x_sf),
-            mega_tensor_to_ffi(topk_idx), mega_tensor_to_ffi(topk_weights),
-            mega_tensor_to_ffi(shared_l1_acts), mega_tensor_to_ffi(shared_l1_acts_sf),
-            mega_tensor_to_ffi(shared_l2_acts), mega_tensor_to_ffi(shared_l2_acts_sf),
-            mega_tensor_to_ffi(l1_acts), mega_tensor_to_ffi(l1_acts_sf),
-            mega_tensor_to_ffi(l2_acts), mega_tensor_to_ffi(l2_acts_sf)
+              l1_acts, l1_acts_sf, l2_acts, l2_acts_sf, x_scales] = fn(buffer_torch);
+        // DLPack cannot carry FP8/FP4 dtypes, so activation views cross the
+        // bridge as raw bytes; undefined views (BF16 SFs, absent shared
+        // experts) cross as empty byte tensors.
+        const auto as_bytes = [&](const torch::Tensor& t) {
+            const auto t_val = t.defined()
+                ? t
+                : torch::empty({0}, torch::TensorOptions().dtype(torch::kChar).device(buffer_torch.device()));
+            return Tensor::FromDLPack(at::toDLPack(
+                t_val.scalar_type() == torch::kFloat8_e4m3fn or t_val.scalar_type() == torch::kUInt8
+                    ? t_val.view(at::kChar) : t_val));
+        };
+        return MegaSliceResult(
+            as_bytes(x), as_bytes(x_sf),
+            as_bytes(topk_idx), as_bytes(topk_weights),
+            as_bytes(shared_l1_acts), as_bytes(shared_l1_acts_sf),
+            as_bytes(shared_l2_acts), as_bytes(shared_l2_acts_sf),
+            as_bytes(l1_acts), as_bytes(l1_acts_sf),
+            as_bytes(l2_acts), as_bytes(l2_acts_sf),
+            as_bytes(x_scales)
         );
     };
-    return Tuple<int64_t, TypedFunction<MegaBufferTensors(TensorView)>>(
+    return Tuple<int64_t, TypedFunction<MegaSliceResult(TensorView)>>(
         num_bytes, slice_input_buffers);
 }
 
@@ -717,15 +731,14 @@ dg_get_symm_buffer_size_for_sm90_mega_moe(int64_t num_ranks, int64_t num_experts
         num_bytes, slice_input_buffers);
 }
 
-void dg_fp8_fp4_mega_moe(TensorView y,
-                        TensorView l1_weights, TensorView l1_weights_sf,
-                        TensorView l2_weights, TensorView l2_weights_sf,
+void dg_fp8_fp4_mega_moe(TensorView y, TensorView l1_weights, TensorView l1_weights_sf, TensorView l2_weights, TensorView l2_weights_sf,
                         Optional<TensorView> shared_l1_weights, Optional<TensorView> shared_l1_weights_sf,
                         Optional<TensorView> shared_l2_weights, Optional<TensorView> shared_l2_weights_sf,
                         Optional<TensorView> cumulative_local_expert_recv_stats, TensorView sym_buffer, Array<int64_t> sym_buffer_ptrs,
                         int64_t rank_idx, int64_t num_max_tokens_per_rank, int64_t num_experts, int64_t num_topk,
-                        Tuple<int64_t, int64_t, int64_t> recipe, std::string activation, Optional<double> activation_clamp_opt,
-                        bool fast_math) {
+                        Tuple<int64_t, int64_t, int64_t> recipe, std::string mma_type, std::string activation, Optional<double> activation_clamp_opt,
+                        bool fast_math, bool use_x_scales, Optional<TensorView> l1_alphas,
+                        Optional<TensorView> l2_alphas, Optional<TensorView> l2_act_scales) {
     auto c_val = cumulative_local_expert_recv_stats.has_value()? std::optional<torch::Tensor>(convert_to_torch_tensor(cumulative_local_expert_recv_stats.value())) : std::nullopt;
     auto act_clamp_opt_val = activation_clamp_opt.has_value()? std::optional<float>(static_cast<float>(activation_clamp_opt.value())) : std::nullopt;
     std::vector<int64_t> sym_buffer_ptrs_val;
@@ -736,27 +749,29 @@ void dg_fp8_fp4_mega_moe(TensorView y,
     }
     auto [recipe_a, recipe_b, recipe_c] = recipe;
     auto recipe_val = std::make_tuple(static_cast<int>(recipe_a), static_cast<int>(recipe_b), static_cast<int>(recipe_c));
-    std::optional<std::tuple<torch::Tensor, torch::Tensor>> shared_l1_weights_val = std::nullopt;
-    std::optional<std::tuple<torch::Tensor, torch::Tensor>> shared_l2_weights_val = std::nullopt;
-    if (shared_l1_weights.has_value() and shared_l1_weights_sf.has_value()) {
-        shared_l1_weights_val = std::make_tuple(
-            convert_to_torch_tensor(shared_l1_weights.value()),
-            convert_to_torch_tensor(shared_l1_weights_sf.value()));
-    }
-    if (shared_l2_weights.has_value() and shared_l2_weights_sf.has_value()) {
-        shared_l2_weights_val = std::make_tuple(
-            convert_to_torch_tensor(shared_l2_weights.value()),
-            convert_to_torch_tensor(shared_l2_weights_sf.value()));
-    }
+    DG_HOST_ASSERT(shared_l1_weights.has_value() == shared_l1_weights_sf.has_value());
+    DG_HOST_ASSERT(shared_l2_weights.has_value() == shared_l2_weights_sf.has_value());
+    auto shared_l1_val = shared_l1_weights.has_value()
+        ? std::optional<std::tuple<torch::Tensor, torch::Tensor>>(std::make_tuple(
+              convert_to_torch_tensor(shared_l1_weights.value()), convert_to_torch_tensor(shared_l1_weights_sf.value())))
+        : std::nullopt;
+    auto shared_l2_val = shared_l2_weights.has_value()
+        ? std::optional<std::tuple<torch::Tensor, torch::Tensor>>(std::make_tuple(
+              convert_to_torch_tensor(shared_l2_weights.value()), convert_to_torch_tensor(shared_l2_weights_sf.value())))
+        : std::nullopt;
 
     mega::fp8_fp4_mega_moe(
         convert_to_torch_tensor(y),
-        std::make_pair(convert_to_torch_tensor(l1_weights), convert_to_torch_tensor(l1_weights_sf)),
-        std::make_pair(convert_to_torch_tensor(l2_weights), convert_to_torch_tensor(l2_weights_sf)),
-        shared_l1_weights_val, shared_l2_weights_val,
+        std::make_tuple(convert_to_torch_tensor(l1_weights), convert_to_torch_tensor(l1_weights_sf)),
+        std::make_tuple(convert_to_torch_tensor(l2_weights), convert_to_torch_tensor(l2_weights_sf)),
+        shared_l1_val, shared_l2_val,
         c_val, convert_to_torch_tensor(sym_buffer), sym_buffer_ptrs_val, static_cast<int>(rank_idx),
         static_cast<int>(num_max_tokens_per_rank), static_cast<int>(num_experts),
-        static_cast<int>(num_topk), recipe_val, activation, act_clamp_opt_val, fast_math
+        static_cast<int>(num_topk), recipe_val, mma_type, activation, act_clamp_opt_val, fast_math,
+        use_x_scales,
+        l1_alphas.has_value() ? std::optional<torch::Tensor>(convert_to_torch_tensor(l1_alphas.value())) : std::nullopt,
+        l2_alphas.has_value() ? std::optional<torch::Tensor>(convert_to_torch_tensor(l2_alphas.value())) : std::nullopt,
+        l2_act_scales.has_value() ? std::optional<torch::Tensor>(convert_to_torch_tensor(l2_act_scales.value())) : std::nullopt
     );
 }
 
@@ -774,16 +789,14 @@ void dg_bf16_mega_moe(TensorView y, TensorView l1_weights, TensorView l2_weights
     for (Array<int64_t>::iterator it = sym_buffer_ptrs.begin(); it != sym_buffer_ptrs.end(); ++it) {
         sym_buffer_ptrs_val.push_back(*it);
     }
-    auto shared_l1_weights_val = shared_l1_weights.has_value() ?
-        std::make_optional(convert_to_torch_tensor(shared_l1_weights.value())) : std::nullopt;
-    auto shared_l2_weights_val = shared_l2_weights.has_value() ?
-        std::make_optional(convert_to_torch_tensor(shared_l2_weights.value())) : std::nullopt;
+    auto shared_l1_val = shared_l1_weights.has_value()? std::optional<torch::Tensor>(convert_to_torch_tensor(shared_l1_weights.value())) : std::nullopt;
+    auto shared_l2_val = shared_l2_weights.has_value()? std::optional<torch::Tensor>(convert_to_torch_tensor(shared_l2_weights.value())) : std::nullopt;
 
     mega::bf16_mega_moe(
         convert_to_torch_tensor(y),
         convert_to_torch_tensor(l1_weights),
         convert_to_torch_tensor(l2_weights),
-        shared_l1_weights_val, shared_l2_weights_val,
+        shared_l1_val, shared_l2_val,
         c_val, convert_to_torch_tensor(sym_buffer), sym_buffer_ptrs_val, static_cast<int>(rank_idx),
         static_cast<int>(num_max_tokens_per_rank), static_cast<int>(num_experts),
         static_cast<int>(num_topk), activation, act_clamp_opt_val, fast_math
@@ -820,7 +833,8 @@ void dg_mega_moe_pre_dispatch(
     TensorView x, TensorView topk_idx, TensorView topk_weights,
     TensorView buf_x, TensorView buf_x_sf,
     TensorView buf_topk_idx, TensorView buf_topk_weights,
-    int64_t num_tokens, int64_t group_size, bool use_fp4_acts) {
+    int64_t num_tokens, int64_t group_size, std::string mma_type,
+    Optional<TensorView> buf_x_scales, Optional<TensorView> expert_scales) {
     mega_moe_pre_dispatch(
         convert_to_torch_tensor(x),
         convert_to_torch_tensor(topk_idx),
@@ -831,7 +845,13 @@ void dg_mega_moe_pre_dispatch(
         convert_to_torch_tensor(buf_topk_weights),
         static_cast<int>(num_tokens),
         static_cast<int>(group_size),
-        use_fp4_acts
+        mma_type,
+        buf_x_scales.has_value()
+            ? std::optional<torch::Tensor>(convert_to_torch_tensor(buf_x_scales.value()))
+            : std::nullopt,
+        expert_scales.has_value()
+            ? std::optional<torch::Tensor>(convert_to_torch_tensor(expert_scales.value()))
+            : std::nullopt
     );
 }
 
@@ -855,6 +875,7 @@ void dg_mega_moe_pre_dispatch_sm90(
 }
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_token_alignment_for_mega_moe, dg_get_token_alignment_for_mega_moe);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_block_m_for_mega_moe, dg_get_block_m_for_mega_moe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_symm_buffer_size_for_mega_moe, dg_get_symm_buffer_size_for_mega_moe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_symm_buffer_size_for_sm90_mega_moe, dg_get_symm_buffer_size_for_sm90_mega_moe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fp8_fp4_mega_moe, dg_fp8_fp4_mega_moe);

--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 import torch
+import tvm_ffi
+from glob import glob
 
 # Set some default environment provided at setup
 try:
@@ -12,73 +14,88 @@ try:
 except ImportError:
     pass
 
-# Configs
-from . import _C
-from ._C import (
-    set_num_sms,
-    get_num_sms,
-    set_tc_util,
-    get_tc_util,
-    set_ignore_compile_dims,
-    set_block_size_multiple_of,
-    set_pdl,
-    get_pdl,
-)
+_extension_paths = glob(os.path.join(os.path.dirname(__file__), '_C*.so'))
+if not _extension_paths:
+    raise ImportError('DeepGEMM extension is missing; build the TVM-FFI _C module first.')
+_C = tvm_ffi.load_module(max(_extension_paths, key=os.path.getmtime))
 
-# cuBLASLt Kernels
-from ._C import (
-    cublaslt_gemm_nt, cublaslt_gemm_nn,
-    cublaslt_gemm_tn, cublaslt_gemm_tt,
+
+def _bind_exports(*names: str) -> None:
+    for name in names:
+        globals()[name] = getattr(_C, name)
+
+
+# Configs and cuBLASLt kernels
+_bind_exports(
+    'set_num_sms', 'get_num_sms', 'set_tc_util', 'get_tc_util',
+    'set_pdl', 'get_pdl',
+    'cublaslt_gemm_nt', 'cublaslt_gemm_nn', 'cublaslt_gemm_tn', 'cublaslt_gemm_tt',
 )
 
 try:
     # DeepGEMM Kernels
-    from ._C import (
+    _kernel_exports = (
         # FP8 FP4 GEMMs
-        fp8_fp4_gemm_nt, fp8_fp4_gemm_nn,
-        fp8_fp4_gemm_tn, fp8_fp4_gemm_tt,
-        m_grouped_fp8_fp4_gemm_nt_contiguous,
-        m_grouped_fp8_fp4_gemm_nn_contiguous,
-        m_grouped_fp8_fp4_gemm_nt_masked,
+        'fp8_fp4_gemm_nt', 'fp8_fp4_gemm_nn',
+        'fp8_fp4_gemm_tn', 'fp8_fp4_gemm_tt',
+        'm_grouped_fp8_fp4_gemm_nt_contiguous',
+        'm_grouped_fp8_fp4_gemm_nn_contiguous',
+        'm_grouped_fp8_fp4_gemm_nt_masked',
         # FP8 GEMMs
-        fp8_gemm_nt, fp8_gemm_nn,
-        fp8_gemm_tn, fp8_gemm_tt,
-        fp8_gemm_nt_skip_head_mid,
-        m_grouped_fp8_gemm_nt_contiguous,
-        m_grouped_fp8_gemm_nn_contiguous,
-        m_grouped_fp8_gemm_nt_masked,
-        k_grouped_fp8_gemm_nt_contiguous,
-        k_grouped_fp8_gemm_tn_contiguous,
+        'fp8_gemm_nt', 'fp8_gemm_nn',
+        'fp8_gemm_tn', 'fp8_gemm_tt',
+        'fp8_gemm_nt_skip_head_mid',
+        'm_grouped_fp8_gemm_nt_contiguous',
+        'm_grouped_fp8_gemm_nn_contiguous',
+        'm_grouped_fp8_gemm_nt_masked',
+        'k_grouped_fp8_gemm_nt_contiguous',
+        'k_grouped_fp8_gemm_tn_contiguous',
         # BF16 GEMMs
-        bf16_gemm_nt, bf16_gemm_nn,
-        bf16_gemm_tn, bf16_gemm_tt,
-        m_grouped_bf16_gemm_nt_contiguous,
-        m_grouped_bf16_gemm_nn_contiguous,
-        m_grouped_bf16_gemm_nt_masked,
-        k_grouped_bf16_gemm_tn_contiguous,
+        'bf16_gemm_nt', 'bf16_gemm_nn',
+        'bf16_gemm_tn', 'bf16_gemm_tt',
+        'm_grouped_bf16_gemm_nt_contiguous',
+        'm_grouped_bf16_gemm_nn_contiguous',
+        'm_grouped_bf16_gemm_nt_masked',
+        'k_grouped_bf16_gemm_tn_contiguous',
         # Einsum kernels
-        einsum,
-        fp8_einsum,
+        'einsum',
+        'fp8_einsum',
         # Attention kernels
-        fp8_fp4_mqa_logits,
-        get_paged_mqa_logits_metadata,
-        fp8_fp4_paged_mqa_logits,
+        'fp8_fp4_mqa_logits',
+        'get_paged_mqa_logits_metadata',
+        'fp8_fp4_paged_mqa_logits',
         # Attention kernels (legacy)
-        fp8_mqa_logits,
-        fp8_paged_mqa_logits,
+        'fp8_mqa_logits',
+        'fp8_paged_mqa_logits',
         # Hyperconnection kernels
-        tf32_hc_prenorm_gemm,
+        'tf32_hc_prenorm_gemm',
         # Layout kernels
-        transform_sf_into_required_layout,
-        # MegaMoE
-        get_block_m_for_mega_moe,
+        'transform_sf_into_required_layout',
     )
+    # Bind per-name: one kernel absent from this build (e.g. plain FP8 GEMMs
+    # not exported by the TVM-FFI bridge, or CUDA < 12.1) must not drop the rest.
+    for _name in _kernel_exports:
+        try:
+            _bind_exports(_name)
+        except AttributeError:
+            pass
+
+    # Sugared recipe-tuple form matching the sgl_deep_gemm wheel API
+    # (the raw _C entry takes the recipe flattened into 3 ints).
+    if hasattr(_C, 'transform_sf_into_required_layout'):
+        def transform_sf_into_required_layout(sf, mn, k, recipe, num_groups=None,
+                                              is_sfa=None, disable_ue8m0_cast=False):
+            (recipe_a, recipe_b, recipe_c) = recipe if len(recipe) == 3 else (recipe[0], recipe[1], None)
+            return _C.transform_sf_into_required_layout(
+                sf, mn, k, recipe_a, recipe_b, recipe_c, num_groups, is_sfa, disable_ue8m0_cast)
 
     # Some alias for legacy supports
     # TODO: remove these later
-    fp8_m_grouped_gemm_nt_masked = m_grouped_fp8_gemm_nt_masked
-    bf16_m_grouped_gemm_nt_masked = m_grouped_bf16_gemm_nt_masked
-except ImportError:
+    if 'm_grouped_fp8_gemm_nt_masked' in globals():
+        fp8_m_grouped_gemm_nt_masked = m_grouped_fp8_gemm_nt_masked
+    if 'm_grouped_bf16_gemm_nt_masked' in globals():
+        bf16_m_grouped_gemm_nt_masked = m_grouped_bf16_gemm_nt_masked
+except AttributeError:
     # Expected behavior for CUDA runtime version before 12.1
     pass
 
@@ -88,6 +105,7 @@ from .mega import (
     get_symm_buffer_for_mega_moe,
     transform_weights_for_mega_moe,
     fp8_fp4_mega_moe,
+    nvfp4_mega_moe,
     bf16_mega_moe,
     mega_moe_pre_dispatch,
 )
@@ -101,7 +119,8 @@ from .utils import *
 try:
     from . import legacy
 except Exception as e:
-    print(f'Failed to load legacy DeepGEMM A100 Triton kernels: {e}')
+    if not (isinstance(e, ImportError) and 'PyInit__C' in str(e)):
+        print(f'Failed to load legacy DeepGEMM A100 Triton kernels: {e}')
 
 # Initialize CPP modules
 def _find_cuda_home() -> str:

--- a/deep_gemm/include/deep_gemm/common/math.cuh
+++ b/deep_gemm/include/deep_gemm/common/math.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cuda/std/cstdint>
+#include <cuda_fp8.h>
 #include <deep_gemm/common/compile.cuh>
 #include <deep_gemm/common/exception.cuh>
 
@@ -110,6 +111,31 @@ CUTLASS_DEVICE void get_e2m1_sf_and_sf_inv(const float2& amax, float2& sf, float
     const auto exp_y = fast_log2_ceil(scaled.y);
     sf.x = fast_pow2(exp_x), sf_inv.x = fast_pow2(-exp_x);
     sf.y = fast_pow2(exp_y), sf_inv.y = fast_pow2(-exp_y);
+}
+
+CUTLASS_DEVICE void get_nvfp4_sf_and_sf_inv(const float2& amax, float2& sf, float2& sf_inv, uint2& sf_bits) {
+    constexpr float kInvMax = 1.0f / 6.0f;
+    const __nv_fp8_e4m3 qx(amax.x * kInvMax), qy(amax.y * kInvMax);
+    sf_bits = {qx.__x, qy.__x};
+    sf = {static_cast<float>(qx), static_cast<float>(qy)};
+    sf_inv.x = sf.x > 0.0f ? __frcp_rn(sf.x) : 0.0f;
+    sf_inv.y = sf.y > 0.0f ? __frcp_rn(sf.y) : 0.0f;
+}
+
+
+CUTLASS_DEVICE uint32_t cast_into_e2m1x2_pairs(const float2& lower, const float2& upper) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b8 byte0;\n\t"
+        ".reg .b8 byte1;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 byte0, %3, %1;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 byte1, %4, %2;\n\t"
+        "mov.b32 %0, {byte0, byte1, byte0, byte1};\n\t"
+        "}\n"
+        : "=r"(packed)
+        : "f"(lower.x), "f"(lower.y), "f"(upper.x), "f"(upper.y));
+    return packed;
 }
 
 // Pack two FP32 values into one FP4 (E2M1) byte: lower nibble = a, upper = b.

--- a/deep_gemm/include/deep_gemm/common/types.cuh
+++ b/deep_gemm/include/deep_gemm/common/types.cuh
@@ -7,12 +7,35 @@ namespace deep_gemm {
 enum class MmaKind {
     BF16        = 0,
     MXFP8FP4    = 1,
+    MXFP4       = 2,
+    NVFP4       = 3,
 };
 
 constexpr CUTLASS_HOST_DEVICE int get_element_size(const MmaKind& mma_kind) {
     switch (mma_kind) {
         case MmaKind::BF16:     return 2;
         case MmaKind::MXFP8FP4: return 1;
+        case MmaKind::MXFP4:    return 1;
+        case MmaKind::NVFP4:    return 1;
+        default: return 0;
+    }
+}
+
+constexpr CUTLASS_HOST_DEVICE int get_element_bits(const MmaKind& mma_kind) {
+    switch (mma_kind) {
+        case MmaKind::BF16:     return 16;
+        case MmaKind::MXFP8FP4: return 8;
+        case MmaKind::MXFP4:    return 4;
+        case MmaKind::NVFP4:    return 4;
+        default: return 0;
+    }
+}
+
+constexpr CUTLASS_HOST_DEVICE int get_sf_gran_k(const MmaKind& mma_kind) {
+    switch (mma_kind) {
+        case MmaKind::MXFP8FP4: return 32;
+        case MmaKind::MXFP4:    return 32;
+        case MmaKind::NVFP4:    return 16;
         default: return 0;
     }
 }

--- a/deep_gemm/include/deep_gemm/impls/sm100_bf16_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_bf16_mega_moe.cuh
@@ -102,7 +102,7 @@ sm100_bf16_mega_moe_impl(void* y,
         kNumRanks, kNumExperts,
         kNumMaxTokensPerRank, kNumTopk,
         kNumRingTokens, 0,
-        /*with_sf=*/ false,
+        MmaKind::BF16,
         kNumSharedExperts
     );
     const auto workspace = buffer.workspace;

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -26,6 +26,7 @@ template <
     uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,
     uint32_t STORE_BLOCK_M,
     uint32_t SF_BLOCK_M, uint32_t SF_BLOCK_N,
+    MmaKind kMmaKind,
     uint32_t kNumRingTokens,
     uint32_t kNumSFRingTokens,
     uint32_t kNumStages,
@@ -34,38 +35,17 @@ template <
     uint32_t kNumEpilogueThreads,
     uint32_t kNumSMs, uint32_t kNumRanks,
     float kActivationClamp,
+    float kSwiGLUAlpha,
     bool kUseSitu,
     bool kFastMath,
-    // ====== Stream A0.1 — DG_USE_FP4_ACTS ======
-    // When true, the L1 epilogue quantizes its SwiGLU outputs to E2M1 (FP4) +
-    // UE8M0 SF instead of E4M3 (FP8) + UE8M0 SF. The per-row gmem footprint
-    // halves (intermediate_hidden / 2 packed bytes vs intermediate_hidden FP8
-    // bytes) and the smem CD staging is sized accordingly. The L2 phase still
-    // reads its activations as FP8 in this step (separate flag for A0.2), so
-    // end-to-end output is intentionally not bit-equivalent to the FP8 path —
-    // the accuracy harness compares L1's quantized output decoded back to BF16.
-    bool kUseFp4Acts = false,
-    // ====== Stream A0.5 — DG_USE_MXF4_KIND ======
-    // When true (and `kUseFp4Acts` also true), L1 + L2 mainloops swap from
-    // `kind::mxf8f6f4.block_scale.block32` (K=32 with-padding FP4 smem) to
-    // `kind::mxf4.block_scale.block32` (K=64 dense FP4 smem). Per the
-    // `recipes/mxf4_vs_mxf8f6f4` microbench, `kind::mxf4` delivers 2× FLOPS/
-    // cycle in isolation; the standalone GEMM (`kernels/fused_gemm_mxf4_native_1cta`)
-    // realizes +22%, the fused capstone (`kernels/fused_swiglu_mxf4_native_two_gemm`)
-    // realizes +20.6%. This kernel ports the same swap into the production
-    // mega_moe path. `kind::mxf4` is K-major-only (PTX ISA Table 53) and
-    // accepts only E2M1 inputs — see the host-side `DG_HOST_ASSERT(not
-    // use_mxf4_kind or use_fp4_acts)` in `mega.hpp`.
-    bool kUseMxf4Kind = false,
-    // ====== Stream B (combine path) — DG_USE_FP8_COMBINE ======
-    // When true, the L2 epilogue ships FP8 E4M3 + per-(token, N=128) UE8M0
-    // SF over NVLink instead of BF16. Byte footprint per token per slot:
-    //   off: kHidden * 2  (BF16)
-    //   on:  kHidden + kHidden / kCombineGranK  (FP8 + SF, kCombineGranK=128)
-    // Halves NVLink bytes/token on the second a2a. Independent of
-    // `kUseFp4Acts` / `kUseMxf4Kind` (which control the dispatch a2a +
-    // mainloops); this flag only changes the combine slot's layout +
-    // L2 epilogue write-back + combine-reduce read.
+    bool kUseXScales,
+    bool kWithL1Alphas,
+    bool kWithL2Alphas,
+    bool kWithL2ActScales,
+    // When true, the L2 epilogue ships FP8 E4M3 + a per-(token, N block) UE8M0 SF over
+    // NVLink instead of BF16, and the combine reduce dequantizes on the fly. Halves the
+    // second all-to-all's bytes per token. Independent of the MMA kind, which only
+    // controls the dispatch a2a and the mainloops.
     bool kUseFp8Combine = false,
     bool kHasShared = (kNumSharedExperts > 0),
     uint32_t L1_SHAPE_N = kIntermediateHidden * 2,
@@ -87,6 +67,9 @@ template <
 CUTLASS_GLOBAL __launch_bounds__(kNumThreads, 1) void
 sm100_fp8_fp4_mega_moe_impl(void* y,
                             int* cumulative_local_expert_recv_stats,
+                            const float* __restrict__ l1_alphas,
+                            const float* __restrict__ l2_alphas,
+                            const float* __restrict__ l2_act_scales,
                             const uint32_t num_tokens,
                             const __grid_constant__ layout::SymBuffer<kNumRanks> sym_buffer,
                             const __grid_constant__ cute::TmaDescriptor tensor_map_l1_acts,
@@ -146,27 +129,21 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         cute::prefetch_tma_descriptor(&tensor_map_shared_l2_weights_sf);
     }
 
-    // Stream A0.0b — DG_USE_FP4_ACTS L1 input path. The registered input
-    // token and routed L1 token buffers use packed E2M1 when enabled.
-    constexpr uint32_t kInputTokenBytes = kUseFp4Acts ? (kHidden / 2) : kHidden;
-    constexpr uint32_t kNumBytesPerPullForActs =
-        kNumBytesPerPull < kInputTokenBytes ? kNumBytesPerPull : kInputTokenBytes;
-    constexpr uint32_t kNumTokenPullChunks = kInputTokenBytes / kNumBytesPerPullForActs;
-    DG_STATIC_ASSERT(kNumTokenPullChunks * kNumBytesPerPullForActs == kInputTokenBytes,
-                     "kNumBytesPerPullForActs must divide input token bytes");
-    constexpr auto pull_layout = layout::Data(kNumBytesPerPullForActs);
+    DG_STATIC_ASSERT(kMmaKind == MmaKind::NVFP4 or kMmaKind == MmaKind::MXFP4 or kMmaKind == MmaKind::MXFP8FP4,
+                     "Invalid MMA kind");
+    constexpr bool kIsNVFP4 = kMmaKind == MmaKind::NVFP4;
+    constexpr bool kIsMXFP4 = kMmaKind == MmaKind::MXFP4;
+    constexpr bool kIsFP4Acts = kIsNVFP4 or kIsMXFP4;
 
-    // Workspace and unified buffer layout. Shared experts and FP4 acts are
-    // deliberately mutually exclusive at the host boundary.
+    // Workspaces and Buffer
     const auto buffer = layout::MegaMoEBuffer(
         sym_buffer.get_base_ptr(),
         kHidden, kIntermediateHidden,
         kNumRanks, kNumExperts,
         kNumMaxTokensPerRank, kNumTopk,
         kNumRingTokens, kNumSFRingTokens,
-        /*with_sf=*/ true,
+        kMmaKind,
         kNumSharedExperts,
-        kUseFp4Acts,
         kUseFp8Combine
     );
     const auto workspace = buffer.workspace;
@@ -196,7 +173,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     };
 
     // SF and its buffer configs
-    constexpr uint32_t kGranK = 32;
+    constexpr uint32_t kGranK = get_sf_gran_k(kMmaKind);
+    constexpr uint32_t kSFChunkK = kGranK * 4;
     constexpr uint32_t kNumUTCCPAlignedElems = 128;
     DG_STATIC_ASSERT(SF_BLOCK_M == math::constexpr_align(BLOCK_M, kNumUTCCPAlignedElems), "Invalid SF_BLOCK_M");
     DG_STATIC_ASSERT(SF_BLOCK_N == BLOCK_N, "No padding is needed for SFB");
@@ -211,55 +189,41 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t kCombineGranK = 128;
     DG_STATIC_ASSERT(kHidden % kCombineGranK == 0, "kHidden must be a multiple of 128 for FP8 combine SF");
     // Data types
-    // NOTES: activations are FP8 (e4m3), weights are FP4 (e2m1)
-    using a_dtype_t = cutlass::float_e4m3_t;
-    using b_dtype_t = cutlass::detail::float_e2m1_unpacksmem_t;
-    using shared_b_dtype_t = cutlass::float_e4m3_t;
-    // Stream A0.2: when `kUseFp4Acts` is on, the L2 phase reads acts as
-    // E2M1 instead of E4M3. Both share the same byte footprint in smem
-    // (FP8 = 1 B, FP4 unpacksmem = 1 B with `_ALIGN16B` padding), so the
-    // smem A allocation, swizzle mode (128 B), and umma_desc stride math
-    // are identical. Only the *MMA instruction descriptor*'s A-dtype field
-    // and the source-side TMA `expect_tx` differ between phases.
-    using l2_a_dtype_t = cute::conditional_t<kUseFp4Acts, b_dtype_t, a_dtype_t>;
-    // Stream A0.0b: same deal for L1 — when `kUseFp4Acts` is on, the L1
-    // phase reads its A operand from the L1 token pool as packed E2M1.
-    // Same `_ALIGN16B` padded smem layout as L2; same MMA instruction
-    // descriptor flip from E4M3 to E2M1.
-    using l1_a_dtype_t = cute::conditional_t<kUseFp4Acts, b_dtype_t, a_dtype_t>;
+    // NOTES: MXFP8FP4 uses FP8 (e4m3) activations with FP4 (e2m1) weights unpacked into
+    // 8-bit smem containers; NVFP4/MXFP4 use packed FP4 for both. A and B tiles are therefore
+    // always addressed in bytes, and only the MMA instruction descriptor sees the real formats.
+    // Dense `float_e2m1_t` resolves to `MXF4Format::E2M1`, `float_e2m1_unpacksmem_t` to
+    // `MXF8F6F4Format::E2M1` — mixing them up launches but hits `cudaErrorIllegalInstruction`
+    constexpr uint32_t kNumElemBits = kIsFP4Acts ? 4 : 8;
+    using a_dtype_t = uint8_t;
+    using b_dtype_t = uint8_t;
+    using shared_b_dtype_t = uint8_t;
+    using mma_a_fmt_t = cute::conditional_t<kIsFP4Acts, cutlass::float_e2m1_t, cutlass::float_e4m3_t>;
+    using mma_b_fmt_t = cute::conditional_t<kIsFP4Acts, cutlass::float_e2m1_t, cutlass::detail::float_e2m1_unpacksmem_t>;
+    using mma_shared_b_fmt_t = cute::conditional_t<kIsFP4Acts, cutlass::float_e2m1_t, cutlass::float_e4m3_t>;
+    using sf_fmt_t = cute::conditional_t<kIsNVFP4, cutlass::float_ue4m3_t, cutlass::float_ue8m0_t>;
 
     // MMA configs
     // NOTES: always swap A/B, 2-CTA MMA, and matrices are K-major
     constexpr uint32_t LAYOUT_AD_M = 128;
     constexpr uint32_t UMMA_M = LAYOUT_AD_M * 2;
     constexpr uint32_t UMMA_N = BLOCK_M;  // Swap AB
-    // Stream A0.5: kind::mxf4 runs K=64 dense per call (vs K=32 for
-    // kind::mxf8f6f4). The number of MMA calls per K-tile is BLOCK_K / UMMA_K.
-    constexpr uint32_t UMMA_K = kUseMxf4Kind ? 64 : 32;
+    constexpr uint32_t BLOCK_K_BYTES = BLOCK_K * kNumElemBits / 8;
+    constexpr uint32_t UMMA_BLOCK_K_BYTES = 128;
+    constexpr uint32_t UMMA_K_BYTES = 32;
+    constexpr uint32_t UMMA_K = UMMA_K_BYTES * 8 / kNumElemBits;
+    constexpr uint32_t kNumMMAsPerSFChunk = kSFChunkK / UMMA_K;
+    constexpr uint32_t kNumRoutedBTxTiles = kIsFP4Acts ? 2 : 1;
     constexpr uint32_t LOAD_BLOCK_M = BLOCK_M / 2;  // Multicast on A
     constexpr uint32_t LOAD_BLOCK_N = BLOCK_N;
     DG_STATIC_ASSERT(BLOCK_M % 16 == 0, "Invalid block M");
     DG_STATIC_ASSERT(BLOCK_N == LAYOUT_AD_M, "Invalid block N");
-    DG_STATIC_ASSERT(BLOCK_K % 128 == 0, "Invalid block K");
+    DG_STATIC_ASSERT(BLOCK_K_BYTES % UMMA_BLOCK_K_BYTES == 0, "Invalid block K");
+    DG_STATIC_ASSERT(kNumMMAsPerSFChunk == (kIsNVFP4 ? 1u : kIsMXFP4 ? 2u : 4u), "Invalid SF chunking");
 
     // Swizzle configs
-    // Stream A0.5: under `kUseMxf4Kind`, A and B smem use the dense FP4
-    // layout (`_ALIGN8B`, 2 nibbles/byte) instead of the with-padding
-    // layout (`_ALIGN16B`, 1 byte per element). Per-K-row byte stride
-    // halves: BLOCK_K elements × 0.5 B/elem = BLOCK_K / 2 bytes. Swizzle
-    // mode tracks the row-byte width.
-    constexpr uint32_t kSwizzleAMode = kUseMxf4Kind
-        ? (BLOCK_K / 2)
-        : (BLOCK_K * static_cast<uint32_t>(sizeof(a_dtype_t)));
-    constexpr uint32_t kSwizzleBMode = kUseMxf4Kind
-        ? (BLOCK_K / 2)
-        : (BLOCK_K * static_cast<uint32_t>(sizeof(b_dtype_t)));
-    // Stream A0.2: l2_a_dtype must keep the same smem footprint as
-    // a_dtype so SMEM_A_SIZE_PER_STAGE / kSwizzleAMode are unchanged.
-    DG_STATIC_ASSERT(sizeof(l2_a_dtype_t) == sizeof(a_dtype_t),
-                     "L2 A dtype must match A in smem footprint");
-    DG_STATIC_ASSERT(sizeof(l1_a_dtype_t) == sizeof(a_dtype_t),
-                     "L1 A dtype must match A in smem footprint");
+    constexpr uint32_t kSwizzleAMode = 128;
+    constexpr uint32_t kSwizzleBMode = 128;
     constexpr uint32_t kSwizzleCDMode = 128;
     DG_STATIC_ASSERT(BLOCK_N % kSwizzleCDMode == 0, "Invalid block N");
 
@@ -278,40 +242,40 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     // Shared memory sizes
     // NOTES: FP8 CD output for L1 (2 TMA stages, BLOCK_N/2 post-SwiGLU), BF16 output for L2 (no TMA, a single stage)
     constexpr uint32_t L1_OUT_BLOCK_N = BLOCK_N / 2;
-    // ====== Stream A0.1 ======
-    // FP4 path packs 2 elements per byte → row footprint halves. We keep
-    // `L1_OUT_BLOCK_N` in *elements* and introduce a row-byte-stride that
-    // depends on the flag, so the existing offset arithmetic (`row *
-    // L1_OUT_BLOCK_N_BYTES`) still works for both paths.
-    constexpr uint32_t L1_OUT_ROW_BYTES = kUseFp4Acts ? (L1_OUT_BLOCK_N / 2) : L1_OUT_BLOCK_N;
-    constexpr uint32_t SMEM_EXPERT_COUNT_SIZE =
-        math::constexpr_align<uint32_t>(kNumExperts * sizeof(uint32_t), kSharedMemoryAlignment);
-    constexpr uint32_t SMEM_SEND_BUFFER_SIZE =
-        math::constexpr_align(pull_layout.get_num_bytes() * kNumDispatchWarps, kSharedMemoryAlignment);
-    // Stream A0.5: under `kUseMxf4Kind`, dense FP4 smem (2 nibbles/byte)
-    // halves the per-stage byte footprint vs the with-padding layout.
-    constexpr uint32_t SMEM_A_SIZE_PER_STAGE = kUseMxf4Kind
-        ? (LOAD_BLOCK_M * BLOCK_K / 2)
-        : (LOAD_BLOCK_M * BLOCK_K * static_cast<uint32_t>(sizeof(a_dtype_t)));
-    constexpr uint32_t SMEM_B_SIZE_PER_STAGE = kUseMxf4Kind
-        ? (LOAD_BLOCK_N * BLOCK_K / 2)
-        : (LOAD_BLOCK_N * BLOCK_K * static_cast<uint32_t>(sizeof(b_dtype_t)));
-    constexpr uint32_t SMEM_SFA_SIZE_PER_STAGE = SF_BLOCK_M * (BLOCK_K / 128) * sizeof(uint32_t);
-    constexpr uint32_t SMEM_SFB_SIZE_PER_STAGE = SF_BLOCK_N * (BLOCK_K / 128) * sizeof(uint32_t);
-    // L1 CD smem: FP8 path = STORE_BLOCK_M * L1_OUT_BLOCK_N bytes/stage,
-    // FP4 path = STORE_BLOCK_M * L1_OUT_BLOCK_N / 2 bytes/stage.
-    constexpr uint32_t SMEM_CD_L1_SIZE =
-        kNumEpilogueWarpgroups * STORE_BLOCK_M * L1_OUT_ROW_BYTES * kNumTMAStoreStages;
-    constexpr uint32_t SMEM_CD_L2_SIZE =
-        kNumEpilogueWarpgroups * STORE_BLOCK_M * BLOCK_N * sizeof(nv_bfloat16);
-    constexpr uint32_t SMEM_CD_SIZE = SMEM_CD_L1_SIZE > SMEM_CD_L2_SIZE ? SMEM_CD_L1_SIZE : SMEM_CD_L2_SIZE;
-    constexpr uint32_t SMEM_CD_L1_SIZE_PER_STAGE = SMEM_CD_L1_SIZE / kNumTMAStoreStages;
-    constexpr uint32_t SMEM_BEFORE_BARRIER_SIZE =
-        SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE + SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE);
-    DG_STATIC_ASSERT(SMEM_CD_SIZE % kSharedMemoryAlignment == 0 and
-                     SMEM_A_SIZE_PER_STAGE % kSharedMemoryAlignment == 0 and
-                     SMEM_B_SIZE_PER_STAGE % kSharedMemoryAlignment == 0,
-                     "Shared memory of CD/A/B must be aligned to 1024 bytes");
+    constexpr uint32_t L1_OUT_BLOCK_N_BYTES = L1_OUT_BLOCK_N * kNumElemBits / 8;
+    constexpr uint32_t AMAX_REDUCTION_WARP_BUFFER_SIZE = STORE_BLOCK_M / 2; // float2
+
+    struct SharedStorage {
+        alignas(kSharedMemoryAlignment) uint32_t expert_token_count[kNumExperts];
+        alignas(kSharedMemoryAlignment) uint8_t dispatch_send_buffer[kNumDispatchWarps][kNumBytesPerPull];
+        union {
+            alignas(kSharedMemoryAlignment) uint8_t l1[kNumEpilogueWarpgroups][kNumTMAStoreStages][STORE_BLOCK_M * L1_OUT_BLOCK_N_BYTES];
+            alignas(kSharedMemoryAlignment) nv_bfloat16 l2[kNumEpilogueWarpgroups][STORE_BLOCK_M * BLOCK_N];
+        } smem_d;
+        alignas(kSharedMemoryAlignment) a_dtype_t smem_a[kNumStages][LOAD_BLOCK_M * BLOCK_K_BYTES];
+        alignas(kSharedMemoryAlignment) b_dtype_t smem_b[kNumStages][LOAD_BLOCK_N * BLOCK_K_BYTES];
+        uint32_t smem_sfa[kNumStages][SF_BLOCK_M * (BLOCK_K / kSFChunkK)];
+        uint32_t smem_sfb[kNumStages][SF_BLOCK_N * (BLOCK_K / kSFChunkK)];
+        float2 amax_reduction[kNumEpilogueWarps][AMAX_REDUCTION_WARP_BUFFER_SIZE];
+        task_info_t task_infos[kNumScheduleStages];
+        Barrier dispatch_barriers[kNumDispatchWarps];
+        Barrier full_barriers[kNumStages];
+        Barrier empty_barriers[kNumStages];
+        Barrier tmem_full_barriers[kNumEpilogueStages];
+        Barrier tmem_empty_barriers[kNumEpilogueStages];
+        Barrier combine_barriers[kNumEpilogueWarps * 2];
+        Barrier task_info_full_barriers[kNumScheduleStages];
+        Barrier task_info_empty_barriers[kNumScheduleStages];
+        uint32_t tmem_ptr_in_smem;
+    };
+    constexpr uint32_t kNumReusableSmemBytes = offsetof(SharedStorage, dispatch_barriers);
+    SharedStorage &shared_storage = *reinterpret_cast<SharedStorage*>(smem_buffer);
+
+    // Send buffers
+    constexpr auto pull_layout = layout::Data(kNumBytesPerPull);
+    const auto smem_send_buffers = layout::Buffer(
+        pull_layout, kNumDispatchWarps, 1,
+        static_cast<void*>(shared_storage.dispatch_send_buffer));
 
     // Tensor memory size
     constexpr uint32_t kNumAccumTmemCols = UMMA_N * kNumEpilogueStages;
@@ -322,103 +286,53 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t kTmemStartColOfSFB = kNumAccumTmemCols + kNumSFATmemCols;
     DG_STATIC_ASSERT(32 <= kNumTmemCols and kNumTmemCols <= 512, "Invalid tensor memory columns");
 
-    // Assign shared memory for dispatch warps
-    const auto smem_expert_count = reinterpret_cast<uint32_t*>(smem_buffer);
-    const auto smem_send_buffers = layout::Buffer(
-        pull_layout, kNumDispatchWarps, 1,
-        math::advance_ptr(smem_buffer, SMEM_EXPERT_COUNT_SIZE));
-
-    // GEMM shared memory: C/D, A, B
-    // NOTES: GEMM shared memory starts after the dispatch region, aligned to 1024 bytes
-    auto smem_gemm_base = math::advance_ptr(
-        smem_buffer, SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE
-    );
-
-    // D/A/B shared memory
-    auto smem_cd = utils::PatternVisitor([=](const uint32_t& i) {
-        return math::advance_ptr<uint8_t>(smem_gemm_base, i * SMEM_CD_L1_SIZE_PER_STAGE);
-    });
-    auto smem_cd_l2 = smem_cd[0];
-    auto smem_a = utils::PatternVisitor([=](const uint32_t& i) {
-        return math::advance_ptr<a_dtype_t>(smem_gemm_base, SMEM_CD_SIZE + i * SMEM_A_SIZE_PER_STAGE);
-    });
-    auto smem_b = utils::PatternVisitor([=](const uint32_t& i) {
-        return math::advance_ptr<b_dtype_t>(smem_gemm_base, SMEM_CD_SIZE + kNumStages * SMEM_A_SIZE_PER_STAGE + i * SMEM_B_SIZE_PER_STAGE);
-    });
-
-    // SF shared memory: SFA and SFB per pipeline stage
-    auto sf_start_ptr = math::advance_ptr<uint8_t>(smem_gemm_base,
-        SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE));
-    auto smem_sfa = utils::PatternVisitor([=](const uint32_t& i) {
-        return reinterpret_cast<uint32_t*>(sf_start_ptr + i * SMEM_SFA_SIZE_PER_STAGE);
-    });
-    auto smem_sfb = utils::PatternVisitor([=](const uint32_t& i) {
-        return reinterpret_cast<uint32_t*>(sf_start_ptr + kNumStages * SMEM_SFA_SIZE_PER_STAGE + i * SMEM_SFB_SIZE_PER_STAGE);
-    });
-
-    // Epilogue amax reduction shared memory
-    auto smem_amax_reduction = reinterpret_cast<float2*>(smem_sfb[kNumStages]);
-
-    // Barriers and tensor memory pointer
-    auto barrier_start_ptr = reinterpret_cast<Barrier*>(smem_amax_reduction + STORE_BLOCK_M * kNumEpilogueWarps / 2);
-    auto dispatch_barriers      = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (i); });
-    auto full_barriers          = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + i); });
-    auto empty_barriers         = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + kNumStages + i); });
-    auto tmem_full_barriers     = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + kNumStages * 2 + i); });
-    auto tmem_empty_barriers    = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + kNumStages * 2 + kNumEpilogueStages + i); });
-    auto combine_barriers       = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + kNumStages * 2 + kNumEpilogueStages * 2 + i); });
-    auto task_info_full_barriers = barrier_start_ptr + kNumDispatchWarps +
-        kNumStages * 2 + kNumEpilogueStages * 2 + kNumEpilogueWarps * 2;
-    auto task_info_empty_barriers = task_info_full_barriers + kNumScheduleStages;
-    auto task_infos = reinterpret_cast<task_info_t*>(
-        barrier_start_ptr + kNumDispatchWarps + kNumStages * 2 +
-        kNumEpilogueStages * 2 + kNumEpilogueWarps * 2 +
-        kNumScheduleStages * 2);
-    auto tmem_ptr_in_smem = reinterpret_cast<uint32_t*>(task_infos + kNumScheduleStages);
-
     // A cluster sync is essential for 2CTA tensor memory allocation
     comm::cluster_sync_with_relaxed_arrive();
 
     // Initialization
     if (warp_idx == 0) {
         // Clean shared memory
-        if (cute::elect_one_sync())
-            ptx::st_shared_bulk(smem_expert_count, kNumExperts * sizeof(uint32_t));
+        if (cute::elect_one_sync()) {
+            ptx::st_shared_bulk(
+                shared_storage.expert_token_count,
+                math::constexpr_align<uint32_t>(kNumExperts * sizeof(uint32_t), kSharedMemoryAlignment)
+            );
+        }
     } else if (warp_idx == 1) {
         // Init m-barriers for dispatch
         #pragma unroll
         for (uint32_t i = lane_idx; i < kNumDispatchWarps; i += 32)
-            dispatch_barriers[i]->init(1);
+            shared_storage.dispatch_barriers[i].init(1);
         cutlass::arch::fence_barrier_init();
     } else if (warp_idx == 2) {
         // Init GEMM barriers
         if (cute::elect_one_sync()) {
             #pragma unroll
             for (uint32_t i = 0; i < kNumStages; ++ i) {
-                // Arrive at all CTAs
-                full_barriers[i]->init(2 * 2);
-                empty_barriers[i]->init(1);
+                // Arrive at 2 CTAs, A + B
+                shared_storage.full_barriers[i].init(2 * 2);
+                shared_storage.empty_barriers[i].init(1);
             }
             #pragma unroll
             for (uint32_t i = 0; i < kNumEpilogueStages; ++ i) {
                 // Arrive at all CTAs
-                tmem_full_barriers[i]->init(1);
+                shared_storage.tmem_full_barriers[i].init(1);
                 // Arrive only at the leader CTA
-                tmem_empty_barriers[i]->init(2 * kNumEpilogueThreads);
+                shared_storage.tmem_empty_barriers[i].init(2 * kNumEpilogueThreads);
             }
             #pragma unroll
             for (uint32_t i = 0; i < kNumEpilogueWarps * 2; ++ i)
-                combine_barriers[i]->init(1);
+                shared_storage.combine_barriers[i].init(1);
             #pragma unroll
             for (uint32_t i = 0; i < kNumScheduleStages; ++ i) {
-                task_info_full_barriers[i].init(1);
-                task_info_empty_barriers[i].init(kNumScheduleConsumerThreads);
+                shared_storage.task_info_full_barriers[i].init(1);
+                shared_storage.task_info_empty_barriers[i].init(kNumScheduleConsumerThreads);
             }
         }
         cutlass::arch::fence_barrier_init();
     } else if (warp_idx == 3) {
         // Allocate tensor memory
-        Allocator().allocate(kNumTmemCols, tmem_ptr_in_smem);
+        Allocator().allocate(kNumTmemCols, &shared_storage.tmem_ptr_in_smem);
     }
     // NOTES: Using `.relaxed` is allowed here since `fence_barrier_init` is `.release.cluster`,
     // and `barrier.cluster.wait.aligned` is by default `.acquire`
@@ -434,9 +348,9 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         kNumRingBlocks,
         kNumSharedExperts>(
             workspace,
-            task_info_full_barriers,
-            task_info_empty_barriers,
-            task_infos
+            shared_storage.task_info_full_barriers,
+            shared_storage.task_info_empty_barriers,
+            shared_storage.task_infos
     );
 
     // MMA pipeline and TMA phases
@@ -461,9 +375,10 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t kAfterWorkspaceCleanBarrierTag = 3;
 
     // Adjust registers
-    constexpr uint32_t kNumDispatchRegisters = 48;
-    constexpr uint32_t kNumNonEpilogueRegisters = 40;
-    constexpr uint32_t kNumEpilogueRegisters = 208;
+    constexpr bool kUseMoreEpilogueRegisters = kNumExpertsPerRank <= 64;
+    constexpr uint32_t kNumDispatchRegisters = kUseMoreEpilogueRegisters ? 48 : 96;
+    constexpr uint32_t kNumNonEpilogueRegisters = kUseMoreEpilogueRegisters ? 40 : 88;
+    constexpr uint32_t kNumEpilogueRegisters = kUseMoreEpilogueRegisters ? 208 : 160;
     DG_STATIC_ASSERT(kNumDispatchRegisters * kNumDispatchThreads +
                      kNumNonEpilogueRegisters * kNumNonEpilogueThreads +
                      kNumEpilogueRegisters * kNumEpilogueThreads <= 64512,
@@ -502,15 +417,15 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
         // Count experts' tokens
         read_topk_idx([&](const uint32_t& token_topk_idx, const int& expert_idx) {
-           atomicAdd_block(smem_expert_count + expert_idx, 1);
+           atomicAdd_block(shared_storage.expert_token_count + expert_idx, 1);
         });
         ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
 
         // Get SM offset (~6.5 us)
         #pragma unroll
         for (uint32_t i = thread_idx; i < kNumExperts; i += kNumDispatchThreads) {
-            const uint64_t send_value = (1ull << 32) | static_cast<uint64_t>(smem_expert_count[i]);
-            smem_expert_count[i] = static_cast<uint32_t>(
+            const uint64_t send_value = (1ull << 32) | static_cast<uint64_t>(shared_storage.expert_token_count[i]);
+            shared_storage.expert_token_count[i] = static_cast<uint32_t>(
                 ptx::atomic_add(workspace.get_expert_send_count_ptr(i), send_value));
         }
         ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
@@ -518,7 +433,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         // Write source indices (~2 us with 512 tokens)
         read_topk_idx([&](const uint32_t& token_topk_idx, const int& expert_idx) {
             const auto dst_rank_idx = expert_idx / kNumExpertsPerRank;
-            const auto dst_slot_idx = atomicAdd_block(smem_expert_count + expert_idx, 1);
+            const auto dst_slot_idx = atomicAdd_block(shared_storage.expert_token_count + expert_idx, 1);
             const auto dst_ptr = workspace.get_src_token_topk_idx_ptr(
                 expert_idx % kNumExpertsPerRank, sym_buffer.rank_idx, dst_slot_idx);
             *sym_buffer.map(dst_ptr, dst_rank_idx) = token_topk_idx;
@@ -562,7 +477,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         // Pull token data and SF from remote ranks into local L1 buffer
         uint32_t pull_mbarrier_phase = 0;
         const auto pull_buffer = smem_send_buffers.get_rank_buffer(warp_idx).get_data_buffer(0);
-        const auto pull_mbarrier = dispatch_barriers[warp_idx];
+        const auto pull_mbarrier = &shared_storage.dispatch_barriers[warp_idx];
 
         // Per-rank counts for current expert (re-loaded when expert changes)
         constexpr uint32_t kNumRanksPerLane = math::constexpr_ceil_div(kNumRanks, 32u);
@@ -662,9 +577,10 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             const uint32_t src_token_idx = src_token_topk_idx / kNumTopk;
             const uint32_t src_topk_idx = src_token_topk_idx % kNumTopk;
 
-            // Hidden bytes are divided into chunks on the reusable-ring path.
-            // The full-pool path keeps the tuned one-shot pull/store sequence.
-            DG_STATIC_ASSERT(kNumTokenPullChunks >= 1, "Invalid token pull chunk count");
+            // Hidden bytes are divided into chunks
+            constexpr uint32_t kNumHiddenTokenBytes = kHidden * kNumElemBits / 8;
+            constexpr uint32_t kNumChunks = kNumHiddenTokenBytes / kNumBytesPerPull;
+            DG_STATIC_ASSERT(kNumChunks * kNumBytesPerPull == kNumHiddenTokenBytes, "kNumBytesPerPull must divide the token bytes");
             const uint32_t pool_token_idx = expert_pool_block_offset * BLOCK_M + token_idx_in_expert;
             const uint32_t pool_block_idx = pool_token_idx / BLOCK_M;
 
@@ -684,8 +600,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             const auto issue_and_wait_pull_store = [&](const uint32_t& i) {
                 ptx::mbarrier_wait_and_flip_phase(pull_mbarrier, pull_mbarrier_phase);
                 ptx::tma_store_1d(
-                    math::advance_ptr(dst_base_ptr, i * kNumBytesPerPullForActs),
-                    pull_buffer.get_base_ptr(), kNumBytesPerPullForActs
+                    math::advance_ptr(dst_base_ptr, i * kNumBytesPerPull),
+                    pull_buffer.get_base_ptr(), kNumBytesPerPull
                 );
                 cute::tma_store_arrive();
                 ptx::tma_store_wait<0>();
@@ -693,27 +609,27 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             if constexpr (kUseFullPoolFP8FP4Path) {
                 if (cute::elect_one_sync()) {
                     ptx::tma_load_1d(
-                        pull_buffer.get_base_ptr(), src_base_ptr, pull_mbarrier, kInputTokenBytes);
+                        pull_buffer.get_base_ptr(), src_base_ptr, pull_mbarrier, kNumHiddenTokenBytes);
                 }
             } else {
                 if (cute::elect_one_sync()) {
                     #pragma unroll
-                    for (uint32_t i = 0; i < kNumTokenPullChunks; ++ i) {
+                    for (uint32_t i = 0; i < kNumChunks; ++ i) {
                         ptx::tma_load_1d(
                             pull_buffer.get_base_ptr(),
-                            math::advance_ptr(src_base_ptr, i * kNumBytesPerPullForActs),
-                            pull_mbarrier, kNumBytesPerPullForActs
+                            math::advance_ptr(src_base_ptr, i * kNumBytesPerPull),
+                            pull_mbarrier, kNumBytesPerPull
                         );
-                        ptx::mbarrier_arrive_and_set_tx(pull_mbarrier, kNumBytesPerPullForActs);
-                        i != (kNumTokenPullChunks - 1) ? issue_and_wait_pull_store(i) : void();
+                        ptx::mbarrier_arrive_and_set_tx(pull_mbarrier, kNumBytesPerPull);
+                        i != (kNumChunks - 1) ? issue_and_wait_pull_store(i) : void();
                     }
                 }
             }
             __syncwarp();
 
-            // Load and store SF (overlaps with TMA token load)
-            constexpr uint32_t kNumSFUint32 = kHidden / 128;
-            DG_STATIC_ASSERT(kNumSFUint32 > 0 and kHidden % 128 == 0, "Invalid SF");
+            // Load and store SF (overlaps with last chunk's TMA load from remote)
+            constexpr uint32_t kNumSFUint32 = kHidden / kSFChunkK;
+            DG_STATIC_ASSERT(kNumSFUint32 > 0 and kHidden % kSFChunkK == 0, "Invalid SF");
             const auto remote_sf_ptr = sym_buffer.map(
                 buffer.input_sf_buffer.get_data_buffer(src_token_idx).get_base_ptr<uint32_t>(),
                 current_rank_in_expert_idx);
@@ -730,7 +646,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             }
             __syncwarp();
 
-            // Store weights and token data
+            // Store weights and metadata
             if (cute::elect_one_sync()) {
                 // Load weights
                 const auto weight = *sym_buffer.map(
@@ -738,20 +654,26 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     current_rank_in_expert_idx);
                 *buffer.l1_topk_weights_buffer.get_data_buffer(get_ring_token_idx(pool_token_idx)).template get_base_ptr<float>() = weight;
 
+                if constexpr (kUseXScales) {
+                    const auto x_scale = *sym_buffer.map(
+                        buffer.input_x_scales_buffer.get_base_ptr<float>() + src_token_idx,
+                        current_rank_in_expert_idx);
+                    *buffer.l1_x_scales_buffer.get_data_buffer(get_ring_token_idx(pool_token_idx)).template get_base_ptr<float>() = x_scale;
+                }
+
                 if constexpr (kUseFullPoolFP8FP4Path) {
-                    // Wait for TMA token load to complete
-                    ptx::mbarrier_arrive_and_set_tx(pull_mbarrier, kInputTokenBytes);
+                    // Wait for the one-shot TMA token load to complete
+                    ptx::mbarrier_arrive_and_set_tx(pull_mbarrier, kNumHiddenTokenBytes);
                     ptx::mbarrier_wait_and_flip_phase(pull_mbarrier, pull_mbarrier_phase);
 
                     // Store token to local L1 buffer via TMA
                     ptx::tma_store_1d(
-                        dst_base_ptr, pull_buffer.get_base_ptr(), kInputTokenBytes);
+                        dst_base_ptr, pull_buffer.get_base_ptr(), kNumHiddenTokenBytes);
 
-                    // Write source metadata for combine write-back
+                    // Write source metadata for combine write-back (logical pool token)
                     *workspace.get_token_src_metadata_ptr(pool_token_idx) =
                         {current_rank_in_expert_idx, src_token_idx, src_topk_idx};
 
-                    // Wait for token TMA store to complete
                     cute::tma_store_arrive();
                     ptx::tma_store_wait<0>();
                     ptx::red_add_rel(
@@ -762,10 +684,10 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         {current_rank_in_expert_idx, src_token_idx, src_topk_idx};
 
                     // Complete last chunk's store
-                    issue_and_wait_pull_store(kNumTokenPullChunks - 1);
+                    issue_and_wait_pull_store(kNumChunks - 1);
                     const bool is_last_token = (token_idx == expert_end_idx - 1);
                     ptx::red_add_rel(
-                        workspace.get_l1_full_count_ptr(ring_block_idx),
+                        workspace.get_l1_full_count_ptr(get_ring_block_idx(pool_block_idx)),
                         is_last_token ? BLOCK_M - (token_idx_in_expert % BLOCK_M) : 1u
                     );
                 }
@@ -822,7 +744,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     *workspace.get_expert_recv_count_ptr(j, i) = 0;
                 __syncwarp();
 
-                // Clean L1 and L2 arrivals / ring-buffer counters
+                // Clean L1 and L2 full stuffs and ring buffer counts
                 for (uint32_t j = thread_idx; j < num_recv_m_blocks; j += kNumDispatchThreads) {
                     const auto pool_block_idx = expert_pool_block_offset + j;
                     if constexpr (kUseFullPoolFP8FP4Path) {
@@ -899,64 +821,28 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
             for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
                 // Wait consumer release
-                empty_barriers[stage_idx]->wait(phase ^ 1);
+                shared_storage.empty_barriers[stage_idx].wait(phase ^ 1);
 
                 // Compute token offsets from block index
                 uint32_t m_idx = block_idx * BLOCK_M;
-                uint32_t k_idx = k_block_idx * BLOCK_K;
+                uint32_t k_idx = k_block_idx * BLOCK_K_BYTES;
                 const uint32_t sfa_m_idx = block_idx * SF_BLOCK_M;
-                uint32_t sfa_k_idx = k_block_idx * (BLOCK_K / 128);
+                uint32_t sfa_k_idx = k_block_idx * (BLOCK_K / kSFChunkK);
 
                 // Add 2 CTA offsets for non-leader CTA
                 if (not is_leader_cta)
                     m_idx += task_info.get_umma_aligned_valid_m() / 2;
 
-                // TMA copy tokens and SFA, then arrive at full barrier.
-                // Stream A0.2 + A0.0b: under FP4 acts, BOTH L1 and L2 phases
-                // load A as packed E2M1 (`l1_a_dtype_t == l2_a_dtype_t == b_dtype_t`).
-                // Same per-byte smem layout as FP8 A (1 B/elem under `_ALIGN16B`),
-                // but source-side packed bytes are halved → expect_tx halved.
+                // TMA copy tokens and SFA, then arrive at full barrier
                 if (cute::elect_one_sync()) {
-                    if constexpr (kUseMxf4Kind) {
-                        // Stream A0.5: dense FP4 smem (`_ALIGN8B`). The TMA
-                        // descriptor's inner box covers BLOCK_K elements in
-                        // BLOCK_K/2 bytes per row; one cluster-multicast TMA
-                        // call fills the full A stage. Bypass `tma::copy`
-                        // because its `BLOCK_INNER_ATOM = kSwizzleMode /
-                        // sizeof(dtype_t)` math assumes ≥1-byte elements
-                        // and would mis-stride sub-byte FP4 destinations.
-                        cute::SM100_TMA_2SM_LOAD_2D::copy(
-                            tensor_map_a_ptr,
-                            reinterpret_cast<uint64_t*>(full_barriers[stage_idx]),
-                            static_cast<uint64_t>(cute::TMA::CacheHintSm100::EVICT_NORMAL),
-                            reinterpret_cast<uint8_t*>(smem_a[stage_idx]),
-                            k_idx, m_idx);
-                    } else if constexpr (kUseFp4Acts) {
-                        // Both Linear1 (L1) and Linear2 (L2) take the FP4 path.
-                        tma::copy<BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, l1_a_dtype_t>(
-                            tensor_map_a_ptr, full_barriers[stage_idx],
-                            reinterpret_cast<l1_a_dtype_t*>(smem_a[stage_idx]),
-                            k_idx, m_idx, 2);
-                    } else {
-                        tma::copy<BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(
-                            tensor_map_a_ptr, full_barriers[stage_idx], smem_a[stage_idx],
-                            k_idx, m_idx, 2);
-                    }
-                    tma::copy<SF_BLOCK_M, BLOCK_K / 128, 0>(
-                        tensor_map_sfa_ptr, full_barriers[stage_idx], smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
+                    tma::copy<BLOCK_K_BYTES, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(
+                        tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_a[stage_idx], k_idx, m_idx, 2);
+                    tma::copy<SF_BLOCK_M, 1, 0>(
+                        tensor_map_sfa_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
                     if (is_leader_cta) {
-                        // Stream A0.5: under `kUseMxf4Kind`, smem A is dense
-                        // FP4 (LOAD_BLOCK_M * BLOCK_K / 2 bytes per CTA, equal
-                        // to source-side packed bytes — no `_ALIGN16B` doubling).
-                        // For 2 CTAs (cluster multicast), tx-count is
-                        // `2 * SMEM_A_SIZE_PER_STAGE` — same multiplier as the
-                        // FP8 dense path.
-                        const uint32_t expect_a_bytes = (kUseFp4Acts and not kUseMxf4Kind)
-                            ? SMEM_A_SIZE_PER_STAGE       // FP4 _ALIGN16B: source = LOAD_BLOCK_M * BLOCK_K / 2 per CTA × 2 CTAs (smem 2× larger)
-                            : SMEM_A_SIZE_PER_STAGE * 2;  // FP8 dense or FP4 dense (mxf4): source = smem footprint × 2 CTAs
-                        full_barriers[stage_idx]->arrive_and_expect_tx(expect_a_bytes + SMEM_SFA_SIZE_PER_STAGE * 2);
+                        shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_a[0]) * 2 + sizeof(SharedStorage::smem_sfa[0]) * 2);
                     } else {
-                        full_barriers[stage_idx]->arrive(0u);
+                        shared_storage.full_barriers[stage_idx].arrive(0u);
                     }
                 }
                 __syncwarp();
@@ -980,59 +866,42 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
             const auto shape_k = task_info.shape_k;
             const auto shape_n = task_info.shape_n;
-            const auto shape_sfb_k = math::ceil_div(shape_k, kGranK * 4u);
+            const auto shape_sfb_k = math::ceil_div(shape_k, kSFChunkK);
             const auto n_block_idx = task_info.n_cluster_idx * 2 + (is_leader_cta ? 0u : 1u);
             const auto num_k_blocks = math::ceil_div(shape_k, BLOCK_K);
 
             for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
                 // Wait consumer release
-                empty_barriers[stage_idx]->wait(phase ^ 1);
+                shared_storage.empty_barriers[stage_idx].wait(phase ^ 1);
 
                 // Compute weight offset
                 uint32_t n_idx = task_info.is_shared() ? n_block_idx * BLOCK_N : task_info.local_expert_idx * shape_n + n_block_idx * BLOCK_N;
-                uint32_t k_idx = k_block_idx * BLOCK_K;
+                uint32_t k_idx = k_block_idx * BLOCK_K_BYTES;
                 uint32_t sfb_n_idx = n_block_idx * BLOCK_N;
-                uint32_t sfb_k_idx = task_info.is_shared() ? k_block_idx * (BLOCK_K / 128) : task_info.local_expert_idx * shape_sfb_k + k_block_idx * (BLOCK_K / 128);
+                uint32_t sfb_k_idx = task_info.is_shared() ? k_block_idx * (BLOCK_K / kSFChunkK) : task_info.local_expert_idx * shape_sfb_k + k_block_idx * (BLOCK_K / kSFChunkK);
 
                 // TMA copy weights with SF
                 if (cute::elect_one_sync()) {
-                    if constexpr (kUseMxf4Kind) {
-                        // Stream A0.5: dense FP4 smem; one cluster-multicast
-                        // TMA call covers the full B stage. See A-side comment.
-                        cute::SM100_TMA_2SM_LOAD_2D::copy(
-                            tensor_map_b_ptr,
-                            reinterpret_cast<uint64_t*>(full_barriers[stage_idx]),
-                            static_cast<uint64_t>(cute::TMA::CacheHintSm100::EVICT_NORMAL),
-                            reinterpret_cast<uint8_t*>(smem_b[stage_idx]),
-                            k_idx, n_idx);
-                    } else if (task_info.is_shared()) {
-                        tma::copy<BLOCK_K, LOAD_BLOCK_N, kSwizzleBMode, shared_b_dtype_t>(
-                            tensor_map_b_ptr, full_barriers[stage_idx],
-                            reinterpret_cast<shared_b_dtype_t*>(smem_b[stage_idx]),
-                            k_idx, n_idx, 2);
+                    if (task_info.is_shared()) {
+                        tma::copy<BLOCK_K_BYTES, LOAD_BLOCK_N, kSwizzleBMode, shared_b_dtype_t>(
+                            tensor_map_b_ptr, &shared_storage.full_barriers[stage_idx], reinterpret_cast<shared_b_dtype_t*>(shared_storage.smem_b[stage_idx]), k_idx, n_idx, 2);
+                        tma::copy<BLOCK_N, 1, 0>(
+                            tensor_map_sfb_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfb[stage_idx], sfb_n_idx, sfb_k_idx, 2);
+                        if (is_leader_cta) {
+                            shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_b[0]) * 2 + sizeof(SharedStorage::smem_sfb[0]) * 2);
+                        } else {
+                            shared_storage.full_barriers[stage_idx].arrive(0u);
+                        }
                     } else {
-                        tma::copy<BLOCK_K, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(
-                            tensor_map_b_ptr, full_barriers[stage_idx], smem_b[stage_idx], k_idx, n_idx, 2);
-                    }
-                    tma::copy<BLOCK_N, BLOCK_K / 128, 0>(
-                        tensor_map_sfb_ptr, full_barriers[stage_idx], smem_sfb[stage_idx], sfb_n_idx, sfb_k_idx, 2);
-                    if (is_leader_cta) {
-                        // Stream A0.5: B-side tx-count for cluster-multicast
-                        // counts SOURCE BYTES PER PEER × 2 PEERS (broadcast: both
-                        // peers receive a copy of the same source bytes). For the
-                        // existing FP4 unpacksmem path, that happens to equal
-                        // `LOAD_BLOCK_N * BLOCK_K * 1B = SMEM_B_SIZE_PER_STAGE`
-                        // (sizeof(b_dtype_t)=1 makes "smem footprint" a coincidental
-                        // alias for source-bytes-summed). Under mxf4 dense FP4,
-                        // SMEM_B_SIZE_PER_STAGE halves to `LOAD_BLOCK_N * BLOCK_K / 2`,
-                        // so we need `* 2` to get the same source-bytes-summed value.
-                        const uint32_t expect_b_bytes =
-                            (kUseMxf4Kind or task_info.is_shared())
-                                ? SMEM_B_SIZE_PER_STAGE * 2
-                                : SMEM_B_SIZE_PER_STAGE;
-                        full_barriers[stage_idx]->arrive_and_expect_tx(expect_b_bytes + SMEM_SFB_SIZE_PER_STAGE * 2);
-                    } else {
-                        full_barriers[stage_idx]->arrive(0u);
+                        tma::copy<BLOCK_K_BYTES, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(
+                            tensor_map_b_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_b[stage_idx], k_idx, n_idx, 2);
+                        tma::copy<BLOCK_N, 1, 0>(
+                            tensor_map_sfb_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfb[stage_idx], sfb_n_idx, sfb_k_idx, 2);
+                        if (is_leader_cta) {
+                            shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_b[0]) * kNumRoutedBTxTiles + sizeof(SharedStorage::smem_sfb[0]) * 2);
+                        } else {
+                            shared_storage.full_barriers[stage_idx].arrive(0u);
+                        }
                     }
                 }
                 __syncwarp();
@@ -1047,73 +916,24 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             // Make instruction descriptor with block scaling
             // NOTES: always swap A/B
             auto routed_instr_desc = cute::UMMA::make_instr_desc_block_scaled<
-                    b_dtype_t, a_dtype_t, float, cutlass::float_ue8m0_t,
+                    mma_b_fmt_t, mma_a_fmt_t, float, sf_fmt_t,
                     UMMA_M, UMMA_N,
                     cute::UMMA::Major::K, cute::UMMA::Major::K
                 >();
             auto shared_instr_desc = cute::UMMA::make_instr_desc_block_scaled<
-                shared_b_dtype_t, a_dtype_t, float, cutlass::float_ue8m0_t,
-                UMMA_M, UMMA_N,
-                cute::UMMA::Major::K, cute::UMMA::Major::K
-            >();
-            // Stream A0.2 + A0.0b: when both L1 and L2 read FP4 acts under
-            // `kUseFp4Acts`, we need a separate instruction descriptor whose
-            // A-dtype field is E2M1 (not E4M3). All other fields (block-scale
-            // shape, UMMA M/N/K, K-major) are unchanged. The smem layout
-            // descriptors don't change because both dtypes have `sizeof = 1`
-            // (FP4 has the `_ALIGN16B` 1-byte-per-element padded smem layout).
-            // Single shared idesc — both `l1_a_dtype_t` and `l2_a_dtype_t`
-            // resolve to `b_dtype_t` (E2M1 unpacksmem) under the flag.
-            //
-            // Stream A0.5: under `kUseMxf4Kind`, the descriptor's a/b_format
-            // fields encode E2M1 as `MXF4Format::E2M1 = 1`, NOT
-            // `MXF8F6F4Format::E2M1 = 5`. CUTLASS picks the right enum via
-            // `to_UMMAFormat<T>()`: passing `cute::float_e2m1_t` (dense) yields
-            // `MXF4Format::E2M1=1`; passing `cutlass::detail::float_e2m1_unpacksmem_t`
-            // yields `MXF8F6F4Format::E2M1=5`. Wrong encoding → the kernel
-            // launches but throws `cudaErrorIllegalInstruction` on first MMA.
-            using mxf4_e2m1_t = cute::float_e2m1_t;
-            using fp4_a_dtype_for_idesc = cute::conditional_t<
-                kUseMxf4Kind, mxf4_e2m1_t, b_dtype_t>;
-            using fp4_b_dtype_for_idesc = cute::conditional_t<
-                kUseMxf4Kind, mxf4_e2m1_t, l1_a_dtype_t>;
-            auto instr_desc_fp4 = cute::UMMA::make_instr_desc_block_scaled<
-                fp4_a_dtype_for_idesc, fp4_b_dtype_for_idesc,
-                float, cutlass::float_ue8m0_t,
+                mma_shared_b_fmt_t, mma_a_fmt_t, float, sf_fmt_t,
                 UMMA_M, UMMA_N,
                 cute::UMMA::Major::K, cute::UMMA::Major::K
             >();
             auto sf_desc = mma::sm100::make_sf_desc(nullptr);
 
             DG_STATIC_ASSERT(kNumStages <= 32, "Too many stages");
-            // Stream A0.5: under `kUseMxf4Kind`, smem A and B carry dense
-            // FP4 (2 nibbles/byte). The `make_umma_desc` helper asserts
-            // `kSwizzleMode == BLOCK_K * sizeof(dtype_t)`, so we pass a
-            // BLOCK_K of `BLOCK_K / 2` (the byte count) and `dtype_t =
-            // uint8_t` to get the right byte-stride math. The smem ptrs
-            // are reinterpreted to `uint8_t*` since the underlying buffer
-            // is just bytes.
-            cute::UMMA::SmemDescriptor a_desc, b_desc;
-            if constexpr (kUseMxf4Kind) {
-                a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, BLOCK_K / 2, kSwizzleAMode>(
-                    reinterpret_cast<uint8_t*>(smem_a[0]), 0, 0);
-                b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, BLOCK_K / 2, kSwizzleBMode>(
-                    reinterpret_cast<uint8_t*>(smem_b[0]), 0, 0);
-            } else {
-                a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, BLOCK_K, kSwizzleAMode>(smem_a[0], 0, 0);
-                b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, BLOCK_K, kSwizzleBMode>(smem_b[0], 0, 0);
-            }
-            uint32_t a_desc_lo = lane_idx < kNumStages ? a_desc.lo + lane_idx * SMEM_A_SIZE_PER_STAGE / 16 : 0u;
-            uint32_t b_desc_lo = lane_idx < kNumStages ? b_desc.lo + lane_idx * SMEM_B_SIZE_PER_STAGE / 16 : 0u;
-            auto shared_b_desc = b_desc;
-            if constexpr (kHasShared) {
-                shared_b_desc = mma::sm100::make_umma_desc<
-                    cute::UMMA::Major::K, LOAD_BLOCK_N, BLOCK_K, kSwizzleBMode>(
-                        reinterpret_cast<shared_b_dtype_t*>(smem_b[0]), 0, 0);
-            }
-            uint32_t shared_b_desc_lo = lane_idx < kNumStages
-                ? shared_b_desc.lo + lane_idx * SMEM_B_SIZE_PER_STAGE / 16
-                : 0u;
+            auto a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, UMMA_BLOCK_K_BYTES, kSwizzleAMode>(shared_storage.smem_a[0], 0, 0);
+            auto b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, UMMA_BLOCK_K_BYTES, kSwizzleBMode>(shared_storage.smem_b[0], 0, 0);
+            auto shared_b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, UMMA_BLOCK_K_BYTES, kSwizzleBMode>(reinterpret_cast<shared_b_dtype_t*>(shared_storage.smem_b[0]), 0, 0);
+            uint32_t a_desc_lo = lane_idx < kNumStages ? a_desc.lo + lane_idx * sizeof(SharedStorage::smem_a[0]) / 16 : 0u;
+            uint32_t b_desc_lo = lane_idx < kNumStages ? b_desc.lo + lane_idx * sizeof(SharedStorage::smem_b[0]) / 16 : 0u;
+            uint32_t shared_b_desc_lo = lane_idx < kNumStages ? shared_b_desc.lo + lane_idx * sizeof(SharedStorage::smem_b[0]) / 16 : 0u;
 
             // Checks for MMA instructions
             DG_STATIC_ASSERT((UMMA_M == 64  and UMMA_N %  8 == 0 and  8 <= UMMA_N and UMMA_N <= 256) or
@@ -1130,14 +950,11 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 // Dynamic update of UMMA N based on effective M
                 auto& instr_desc = task_info.is_shared() ? shared_instr_desc : routed_instr_desc;
                 mma::sm100::update_instr_desc_with_umma_n(instr_desc, task_info.get_umma_aligned_valid_m());
-                if constexpr (kUseFp4Acts)
-                    mma::sm100::update_instr_desc_with_umma_n(
-                        instr_desc_fp4, task_info.get_umma_aligned_valid_m());
 
                 // Wait tensor memory empty barrier arrival
                 const auto accum_stage_idx = current_iter_idx % kNumEpilogueStages;
                 const auto accum_phase = (current_iter_idx ++ / kNumEpilogueStages) & 1;
-                tmem_empty_barriers[accum_stage_idx]->wait(accum_phase ^ 1);
+                shared_storage.tmem_empty_barriers[accum_stage_idx].wait(accum_phase ^ 1);
                 ptx::tcgen05_after_thread_sync();
 
                 // Empty barrier arrival
@@ -1146,11 +963,11 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         constexpr uint16_t kCTAMask = (1 << 2) - 1;
                         cutlass::arch::umma_arrive_multicast_2x1SM(barrier, kCTAMask);
                     };
-                    umma_arrive(reinterpret_cast<uint64_t*>(empty_barriers[stage_idx]));
+                    umma_arrive(reinterpret_cast<uint64_t*>(&shared_storage.empty_barriers[stage_idx]));
 
                     // NOTES: the tensor memory accumulator pipeline has nothing to do with multicasting
                     if (do_tmem_full_arrive)
-                        umma_arrive(reinterpret_cast<uint64_t*>(tmem_full_barriers[accum_stage_idx]));
+                        umma_arrive(reinterpret_cast<uint64_t*>(&shared_storage.tmem_full_barriers[accum_stage_idx]));
                     __syncwarp();
                 };
 
@@ -1158,79 +975,59 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 #pragma unroll 2
                 for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
                     // Wait TMA load completion
-                    full_barriers[stage_idx]->wait(phase);
+                    shared_storage.full_barriers[stage_idx].wait(phase);
                     ptx::tcgen05_after_thread_sync();
 
                     const auto a_desc_base_lo = ptx::exchange(a_desc_lo, stage_idx);
                     const auto b_desc_base_lo = ptx::exchange(task_info.is_shared() ? shared_b_desc_lo : b_desc_lo, stage_idx);
                     if (cute::elect_one_sync()) {
-                        // UTCCP copy SFA and SFB to TMEM
-                        using cute_utccp_t = cute::SM100_UTCCP_4x32dp128bit_2cta;
                         #pragma unroll
-                        for (uint32_t i = 0; i < SF_BLOCK_M / kNumUTCCPAlignedElems; ++ i) {
-                            auto smem_ptr = smem_sfa[stage_idx] + i * kNumUTCCPAlignedElems;
-                            mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
-                            cute_utccp_t::copy(sf_desc, kTmemStartColOfSFA + i * 4);
-                        }
-                        #pragma unroll
-                        for (uint32_t i = 0; i < SF_BLOCK_N / kNumUTCCPAlignedElems; ++ i) {
-                            auto smem_ptr = smem_sfb[stage_idx] + i * kNumUTCCPAlignedElems;
-                            mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
-                            cute_utccp_t::copy(sf_desc, kTmemStartColOfSFB + i * 4);
-                        }
+                        for (uint32_t sf_chunk_idx = 0; sf_chunk_idx < BLOCK_K / kSFChunkK; ++ sf_chunk_idx) {
+                            // UTCCP copy SFA and SFB to TMEM
+                            using cute_utccp_t = cute::SM100_UTCCP_4x32dp128bit_2cta;
+                            #pragma unroll
+                            for (uint32_t i = 0; i < SF_BLOCK_M / kNumUTCCPAlignedElems; ++ i) {
+                                auto smem_ptr = shared_storage.smem_sfa[stage_idx] + sf_chunk_idx * SF_BLOCK_M + i * kNumUTCCPAlignedElems;
+                                mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
+                                cute_utccp_t::copy(sf_desc, kTmemStartColOfSFA + i * 4);
+                            }
+                            #pragma unroll
+                            for (uint32_t i = 0; i < SF_BLOCK_N / kNumUTCCPAlignedElems; ++ i) {
+                                auto smem_ptr = shared_storage.smem_sfb[stage_idx] + sf_chunk_idx * SF_BLOCK_N + i * kNumUTCCPAlignedElems;
+                                mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
+                                cute_utccp_t::copy(sf_desc, kTmemStartColOfSFB + i * 4);
+                            }
 
-                        // Issue UMMA. Stream A0.2: L2 phase under FP4 acts
-                        // uses `instr_desc_l2` (A=E2M1) instead of `instr_desc`
-                        // (A=E4M3). The smem K-stride for A is the same
-                        // (sizeof(l2_a_dtype_t) == sizeof(a_dtype_t) == 1) so
-                        // `advance_umma_desc_lo` on `a_dtype_t` is correct
-                        // for both phases.
-                        // Stream A0.5: under `kUseMxf4Kind`, swap the MMA to
-                        // `kind::mxf4` (cta_group::2). UMMA_K=64 (vs 32),
-                        // so K_PER_TILE=2 (vs 4). The SF address top-2 bits
-                        // are HALF-WORD offsets {0, 2} for scale_vec::2X
-                        // (NOT byte offsets {0..3}); encode as `k * 2`, not `k`.
-                        // Smem K-stride for the dense FP4 layout is `BLOCK_K/2`
-                        // bytes/row, so `advance_umma_desc_lo` is templated on
-                        // `uint8_t` and `BLOCK_K / 2` to match.
-                        #pragma unroll
-                        for (uint32_t k = 0; k < BLOCK_K / UMMA_K; ++ k) {
-                            if constexpr (kUseMxf4Kind) {
-                                const auto sf_id = k * 2u;  // half-word offset for scale_vec::2X
+                            // Issue UMMA
+                            #pragma unroll
+                            for (uint32_t k = 0; k < kNumMMAsPerSFChunk; ++ k) {
+                                const uint32_t mma_idx = sf_chunk_idx * kNumMMAsPerSFChunk + k;
+                                const uint32_t atom_byte_offset = (mma_idx * UMMA_K_BYTES / UMMA_BLOCK_K_BYTES) * UMMA_BLOCK_K_BYTES;
+                                const uint32_t in_atom_byte_idx = mma_idx * UMMA_K_BYTES - atom_byte_offset;
+                                // `kind::mxf4` uses `scale_vec::2X`
+                                const uint32_t sf_id = kIsMXFP4 ? k * 2 : k;
                                 const auto runtime_instr_desc =
-                                    mma::sm100::make_runtime_instr_desc_with_sf_id(instr_desc_fp4, sf_id, sf_id);
+                                    mma::sm100::make_runtime_instr_desc_with_sf_id(instr_desc, sf_id, sf_id);
                                 a_desc.lo = mma::sm100::advance_umma_desc_lo<
-                                    cute::UMMA::Major::K, LOAD_BLOCK_M, kSwizzleAMode, uint8_t>(
-                                        a_desc_base_lo, 0, k * UMMA_K / 2);
+                                    cute::UMMA::Major::K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(a_desc_base_lo, atom_byte_offset * LOAD_BLOCK_M, in_atom_byte_idx);
                                 b_desc.lo = mma::sm100::advance_umma_desc_lo<
-                                    cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, uint8_t>(
-                                        b_desc_base_lo, 0, k * UMMA_K / 2);
-                                ptx::SM100_MMA_MXF4_2x1SM_SS::fma(
-                                    b_desc, a_desc, accum_stage_idx * UMMA_N,
-                                    k_block_idx > 0 or k > 0, runtime_instr_desc,
-                                    kTmemStartColOfSFB, kTmemStartColOfSFA);
-                            } else {
-                                // Stream A0.0b: under `kUseFp4Acts`, both L1 and L2 read
-                                // A as E2M1. Shared tasks retain their upstream FP8×FP8
-                                // descriptor; routed tasks select FP4 or the baseline descriptor.
-                                const auto runtime_instr_desc = kUseFp4Acts
-                                    ? mma::sm100::make_runtime_instr_desc_with_sf_id(instr_desc_fp4, k, k)
-                                    : mma::sm100::make_runtime_instr_desc_with_sf_id(instr_desc, k, k);
-                                a_desc.lo = mma::sm100::advance_umma_desc_lo<
-                                    cute::UMMA::Major::K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(a_desc_base_lo, 0, k * UMMA_K);
-                                if (task_info.is_shared()) {
-                                    b_desc.lo = mma::sm100::advance_umma_desc_lo<
-                                        cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, shared_b_dtype_t>(
-                                            b_desc_base_lo, 0, k * UMMA_K);
+                                    cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(b_desc_base_lo, atom_byte_offset * LOAD_BLOCK_N, in_atom_byte_idx);
+                                if constexpr (kIsNVFP4) {
+                                    ptx::SM100_MMA_MXF4NVF4_2x1SM_SS::fma(
+                                        b_desc, a_desc, accum_stage_idx * UMMA_N,
+                                        k_block_idx > 0 or mma_idx > 0, runtime_instr_desc,
+                                        kTmemStartColOfSFB, kTmemStartColOfSFA);
+                                } else if constexpr (kIsMXFP4) {
+                                    ptx::SM100_MMA_MXF4_2x1SM_SS::fma(
+                                        b_desc, a_desc, accum_stage_idx * UMMA_N,
+                                        k_block_idx > 0 or mma_idx > 0, runtime_instr_desc,
+                                        kTmemStartColOfSFB, kTmemStartColOfSFA);
                                 } else {
-                                    b_desc.lo = mma::sm100::advance_umma_desc_lo<
-                                        cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(
-                                            b_desc_base_lo, 0, k * UMMA_K);
+                                    ptx::SM100_MMA_MXF8F6F4_2x1SM_SS::fma(
+                                        b_desc, a_desc, accum_stage_idx * UMMA_N,
+                                        k_block_idx > 0 or mma_idx > 0, runtime_instr_desc,
+                                        kTmemStartColOfSFB, kTmemStartColOfSFA);
                                 }
-                                ptx::SM100_MMA_MXF8F6F4_2x1SM_SS::fma(
-                                    b_desc, a_desc, accum_stage_idx * UMMA_N,
-                                    k_block_idx > 0 or k > 0, runtime_instr_desc,
-                                    kTmemStartColOfSFB, kTmemStartColOfSFA);
                             }
                         }
                     }
@@ -1245,7 +1042,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             // To safely deconstruct barriers, we need another round of waits
             if (current_iter_idx > 0) {
                 const auto accum_phase_idx = ((current_iter_idx - 1) / kNumEpilogueStages) & 1;
-                tmem_empty_barriers[(current_iter_idx - 1) % kNumEpilogueStages]->wait(accum_phase_idx);
+                shared_storage.tmem_empty_barriers[(current_iter_idx - 1) % kNumEpilogueStages].wait(accum_phase_idx);
             }
         }
     } else if (warp_idx == kNumDispatchWarps + 3) {
@@ -1262,7 +1059,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         // NOTES: tensor memory addresses are simplified, as the hardware will ignore the warp index bits,
         // i.e., no need for `tmem_ptr |= (epilogue_warp_idx * 32) << 16`.
         // NOTES: we also forbid two CTAs to share the same SM and its tensor memory
-        DG_TRAP_ONLY_DEVICE_ASSERT(ptx::ld_shared(tmem_ptr_in_smem) == 0);
+        DG_TRAP_ONLY_DEVICE_ASSERT(ptx::ld_shared(&shared_storage.tmem_ptr_in_smem) == 0);
 
         // GEMM epilogue warps
         const auto epilogue_warp_idx = warp_idx - (kNumDispatchWarps + kNumMMANonEpilogueWarps);
@@ -1297,7 +1094,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             // Wait UMMA arrival
             const auto accum_stage_idx = current_iter_idx % kNumEpilogueStages;
             const auto accum_phase = (current_iter_idx ++ / kNumEpilogueStages) & 1;
-            tmem_full_barriers[accum_stage_idx]->wait(accum_phase);
+            shared_storage.tmem_full_barriers[accum_stage_idx].wait(accum_phase);
             ptx::tcgen05_after_thread_sync();
 
             // Now we can release the task
@@ -1327,17 +1124,29 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
                 // Unified L1 epilogue: SwiGLU in-place using granularity 8 interleaved weights
                 // With `SM100_TMEM_LOAD_16dp256b1x`, gate/up pairs are:
-                //   (values[0], values[2]), (values[1], values[3]),
-                //   (values[4], values[6]), (values[5], values[7])
-                // Shared experts have no routed top-k weight and therefore use 1.
                 float stored_cached_weight = 1.0f;
+                float stored_cached_x_scale = 1.0f;
+
+                float2 l1_alpha = {1.0f, 1.0f};
+                if constexpr (kWithL1Alphas) {
+                    if (not task_info.is_shared())
+                        l1_alpha = __ldg(reinterpret_cast<const float2*>(l1_alphas) +
+                                         task_info.local_expert_idx);
+                }
+
+                // fc2 input global scale; the caller folds the inverse into `l2_alphas`
+                float l2_act_gs = 1.0f;
+                if constexpr (kWithL2ActScales) {
+                    if (not task_info.is_shared())
+                        l2_act_gs = __ldg(l2_act_scales + task_info.local_expert_idx);
+                }
 
                 #pragma unroll
                 for (uint32_t s = 0; s < WG_BLOCK_M / STORE_BLOCK_M; ++ s) {
                     // Early break if the entire store block is beyond the valid token range
                     if (epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M >= valid_m) {
                         ptx::tcgen05_before_thread_sync();
-                        tmem_empty_barriers[accum_stage_idx]->arrive(0u);
+                        shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         break;
                     }
 
@@ -1357,53 +1166,81 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                 .template get_base_ptr<float>();
                         }
 
+                        // Per-token L1 input outer scales, cached like the topk weights.
+                        // Routed rows read the ring copy made at dispatch; shared rows
+                        // read the local input scales directly.
+                        if constexpr (kUseXScales) {
+                            if ((j * ATOM_M) % 32 == 0 and
+                                (WG_BLOCK_M % 32 == 0 or j * ATOM_M + lane_idx < WG_BLOCK_M)) {
+                                const uint32_t row = epilogue_wg_idx * WG_BLOCK_M + j * ATOM_M + lane_idx;
+                                stored_cached_x_scale = task_info.is_shared() ?
+                                    *buffer.input_x_scales_buffer.get_data_buffer(m_idx + row).template get_base_ptr<float>() :
+                                    *buffer.l1_x_scales_buffer.get_data_buffer(ring_m_idx + row).template get_base_ptr<float>();
+                            }
+                        }
+                        const float2 x_scales = kUseXScales ? float2{
+                            ptx::exchange(stored_cached_x_scale, (j * ATOM_M) % 32 + (lane_idx % 4) * 2 + 0),
+                            ptx::exchange(stored_cached_x_scale, (j * ATOM_M) % 32 + (lane_idx % 4) * 2 + 1)
+                        } : float2{1.0f, 1.0f};
+                        const float2 gate_scales = kWithL1Alphas ?
+                            __fmul2_rn(x_scales, {l1_alpha.x, l1_alpha.x}) : x_scales;
+                        const float2 up_scales = kWithL1Alphas ?
+                            __fmul2_rn(x_scales, {l1_alpha.y, l1_alpha.y}) : x_scales;
+
                         // Load weights from register cache
-                        const float2 weights = {
+                        float2 weights = {
                             ptx::exchange(stored_cached_weight, (j * ATOM_M) % 32 + (lane_idx % 4) * 2 + 0),
                             ptx::exchange(stored_cached_weight, (j * ATOM_M) % 32 + (lane_idx % 4) * 2 + 1)
                         };
+                        if constexpr (kWithL2ActScales)
+                            weights = __fmul2_rn(weights, {l2_act_gs, l2_act_gs});
 
                         // Load from TMEM
+                        uint2 raw_values[4];
                         uint32_t tmem_addr = accum_stage_idx * UMMA_N + epilogue_wg_idx * WG_BLOCK_M + j * ATOM_M;
-                        uint32_t values[ATOM_M];
                         cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr,
-                                                               values[0], values[1], values[2], values[3]);
+                                                               raw_values[0].x, raw_values[0].y, raw_values[1].x, raw_values[1].y);
                         cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr | 0x00100000,
-                                                               values[4], values[5], values[6], values[7]);
+                                                               raw_values[2].x, raw_values[2].y, raw_values[3].x, raw_values[3].y);
                         cutlass::arch::fence_view_async_tmem_load();
 
                         // Signal tensor memory consumed on the last atom
                         if (j == WG_BLOCK_M / ATOM_M - 1) {
                             ptx::tcgen05_before_thread_sync();
-                            tmem_empty_barriers[accum_stage_idx]->arrive(0u);
+                            shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         }
 
-                        // Apply the explicitly selected SwiGLU or Kimi-K3 SiTU activation.
-                        // Gate/up pairs: (0, 2), (1, 3), (4, 6), (5, 7)
+                        // Apply the selected activation: SwiGLU, OAI SwiGLU, or Kimi-K3 SiTU
                         // SiTU:
                         //   act = kSituBeta * tanh(gate/kSituBeta) * sigmoid(gate)
                         //   up' = kSituLinearBeta * tanh(up/kSituLinearBeta)
                         // K3 config constants baked in (activation_situ_{beta,linear_beta}).
                         constexpr float kSituBeta = 4.0f;
                         constexpr float kSituLinearBeta = 25.0f;
-                        auto fp32_values = reinterpret_cast<float*>(values);
+                        auto fp32_values = reinterpret_cast<float2*>(raw_values);
                         #pragma unroll
                         for (uint32_t k = 0; k < 2; ++ k) {
-                            auto bf16_gate = __float22bfloat162_rn(make_float2(fp32_values[k * 4], fp32_values[k * 4 + 1]));
-                            auto bf16_up = __float22bfloat162_rn(make_float2(fp32_values[k * 4 + 2], fp32_values[k * 4 + 3]));
+                            if constexpr (kUseXScales or kWithL1Alphas) {
+                                fp32_values[k * 2 + 0] = __fmul2_rn(fp32_values[k * 2 + 0], gate_scales);
+                                fp32_values[k * 2 + 1] = __fmul2_rn(fp32_values[k * 2 + 1], up_scales);
+                            }
+                            auto bf16_gate = __float22bfloat162_rn(fp32_values[k * 2 + 0]);
+                            auto bf16_up =   __float22bfloat162_rn(fp32_values[k * 2 + 1]);
 
                             // Clamp (SwiGLU-with-limit only; SiTU soft-clips below)
-                            if constexpr (!kUseSitu && kActivationClamp != cute::numeric_limits<float>::infinity()) {
+                            if constexpr (not kUseSitu and kActivationClamp != cute::numeric_limits<float>::infinity()) {
                                 bf16_gate = __hmin2(bf16_gate, {kActivationClamp, kActivationClamp});
                                 bf16_up = __hmax2(bf16_up, {-kActivationClamp, -kActivationClamp});
                                 bf16_up = __hmin2(bf16_up, {kActivationClamp, kActivationClamp});
                             }
 
-                            // sigmoid(gate)
+                            constexpr bool kIsOAISwiGLU = kSwiGLUAlpha != 0.0f;
                             auto gate = __bfloat1622float2(bf16_gate);
+                            const auto sigmoid_in = kIsOAISwiGLU ?
+                                __fmul2_rn(gate, {kSwiGLUAlpha, kSwiGLUAlpha}) : gate;
                             auto neg_gate_exp = make_float2(
-                                kFastMath ? __expf(-gate.x) : expf(-gate.x),
-                                kFastMath ? __expf(-gate.y) : expf(-gate.y));
+                                kFastMath ? __expf(-sigmoid_in.x) : expf(-sigmoid_in.x),
+                                kFastMath ? __expf(-sigmoid_in.y) : expf(-sigmoid_in.y));
                             const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
                             float2 sig;
                             if constexpr (kFastMath) {
@@ -1419,8 +1256,9 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                 up = {kSituLinearBeta * tanhf(up.x / kSituLinearBeta),
                                       kSituLinearBeta * tanhf(up.y / kSituLinearBeta)};
                             } else {
-                                // SwiGLU: silu(gate) * up
                                 gate = __fmul2_rn(gate, sig);
+                                if constexpr (kIsOAISwiGLU)
+                                    up = __fadd2_rn(up, {1.0f, 1.0f});
                             }
                             activation_values[i][k] = __fmul2_rn(__fmul2_rn(gate, up), weights);
                         }
@@ -1440,128 +1278,78 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             thread_local_amax.y, math::ReduceMax<float>());
 
                         // Reduce amax (warp-pair-level)
-                        if (lane_idx < 4)
-                            smem_amax_reduction[epilogue_warp_idx * (STORE_BLOCK_M / 2) + i * (ATOM_M / 2) + lane_idx] = amax_values[i];
+                        if (not kIsNVFP4 and lane_idx < 4)
+                            shared_storage.amax_reduction[epilogue_warp_idx][i * (ATOM_M / 2) + lane_idx] = amax_values[i];
                         __syncwarp();
                     }
 
                     // Wait shared memory release from previous TMA store
-                    // And fence `smem_amax_reduction`
+                    // And fence `shared_storage.amax_reduction`
                     const uint32_t tma_stage_idx = s % kNumTMAStoreStages;
                     ptx::tma_store_wait<kNumTMAStoreStages - 1>();
                     ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
 
-                    // Cast to FP8 E4M3 (or FP4 E2M1 under `kUseFp4Acts`) and
-                    // store into shared memory.
+                    // Cast into the L1 output dtype and store into shared memory
                     #pragma unroll
                     for (uint32_t i = 0; i < kNumAtomsPerStore; ++ i) {
-                        // Reduce amax (warp-pair-level)
-                        const float2 wp_amax =
-                            smem_amax_reduction[(epilogue_warp_idx ^ 1) * (STORE_BLOCK_M / 2) + i * (ATOM_M / 2) + lane_idx % 4];
-                        amax_values[i].x = cute::max(amax_values[i].x, wp_amax.x);
-                        amax_values[i].y = cute::max(amax_values[i].y, wp_amax.y);
-
-                        // Calculate SF (UE8M0 byte; only the finfo divisor differs:
-                        // 1/448 for FP8 E4M3, 1/6 for FP4 E2M1).
+                        // Calculate SF
                         float2 sf, sf_inv;
-                        if constexpr (kUseFp4Acts) {
-                            math::get_e2m1_sf_and_sf_inv(amax_values[i], sf, sf_inv);
+                        uint2 sf_bits;
+                        if constexpr (kIsNVFP4) {
+                            math::get_nvfp4_sf_and_sf_inv(amax_values[i], sf, sf_inv, sf_bits);
                         } else {
-                            math::get_e4m3_sf_and_sf_inv(amax_values[i], sf, sf_inv);
+                            // Reduce amax (warp-pair-level)
+                            const float2 wp_amax =
+                                shared_storage.amax_reduction[epilogue_warp_idx ^ 1][i * (ATOM_M / 2) + lane_idx % 4];
+                            amax_values[i].x = cute::max(amax_values[i].x, wp_amax.x);
+                            amax_values[i].y = cute::max(amax_values[i].y, wp_amax.y);
+                            if constexpr (kIsMXFP4)
+                                math::get_e2m1_sf_and_sf_inv(amax_values[i], sf, sf_inv);
+                            else
+                                math::get_e4m3_sf_and_sf_inv(amax_values[i], sf, sf_inv);
+                            sf_bits = {*reinterpret_cast<const uint32_t*>(&sf.x) >> 23,
+                                       *reinterpret_cast<const uint32_t*>(&sf.y) >> 23};
                         }
 
-                        // Apply scale, cast, store into shared memory.
-                        const float2 upper = __fmul2_rn(activation_values[i][0], sf_inv);
-                        const float2 lower = __fmul2_rn(activation_values[i][1], sf_inv);
-                        if constexpr (kUseFp4Acts) {
-                            // FP4 epilogue: write packed E2M1 nibbles to canonical
-                            // dense smem (TMA descriptor built with swizzle=0 →
-                            // byte-exact smem→gmem copy → canonical packed FP4
-                            // layout `[M, intermediate_hidden/2]` in gmem).
-                            //
-                            // Layout under SwapAB: `tcgen05.ld.16x256b.x1` puts
-                            // lane T's accumulator values (upper.x, upper.y,
-                            // lower.x, lower.y) at smem positions:
-                            //   upper.x → row 2*(T%4),   col_in_stripe T/4
-                            //   upper.y → row 2*(T%4)+1, col_in_stripe T/4
-                            //   lower.x → row 2*(T%4),   col_in_stripe T/4 + 8
-                            //   lower.y → row 2*(T%4)+1, col_in_stripe T/4 + 8
-                            // (16-byte stripe per warp_idx_in_wg ∈ 0..3, 64 B row.)
-                            // Adjacent N-cols therefore sit on lanes T and T XOR 4,
-                            // so packing two values into one FP4 byte requires a
-                            // `__shfl_xor 4` to pull the buddy. Half-warp gate
-                            // (group = lane/4, group%2==0) means each "active"
-                            // lane writes 4 bytes (upper.x, upper.y, lower.x,
-                            // lower.y) and the inactive half is a donor.
-                            //
-                            // The cross-quad shuffle and half-warp gate are
-                            // structural: they're a consequence of SwapAB's
-                            // datapoint=N orientation. Replacing with
-                            // `tcgen05.ld.32x32b.x8` would require dropping
-                            // SwapAB at the mainloop level. See
-                            // DeepGEMM/FP4_EPILOGUE_STORE_MICROBENCH.md for the
-                            // full microbench analysis (P-A through P-D) and
-                            // the negative results from bank-conflict
-                            // elimination + atom-interleaving.
-                            const float buddy_ux = __shfl_xor_sync(0xffffffffu, upper.x, 4);
-                            const float buddy_uy = __shfl_xor_sync(0xffffffffu, upper.y, 4);
-                            const float buddy_lx = __shfl_xor_sync(0xffffffffu, lower.x, 4);
-                            const float buddy_ly = __shfl_xor_sync(0xffffffffu, lower.y, 4);
+                        // Cast
+                        const float2 first = __fmul2_rn(activation_values[i][0], sf_inv);
+                        const float2 second = __fmul2_rn(activation_values[i][1], sf_inv);
 
-                            const uint32_t frag  = lane_idx % 4;          // row-pair index 0..3
-                            const uint32_t group = lane_idx / 4;          // col-group index 0..7
-                            const bool     is_active = (group % 2u) == 0u;
-
-                            // Active lanes pack (own_val, buddy_val) into a byte
-                            // (own=low nibble, buddy=high) and write 4 bytes per
-                            // atom. `cvt_pack_f32_to_e2m1x2(a, b)` → {low=a, high=b}.
-                            if (is_active) {
-                                const uint8_t byte_ux = static_cast<uint8_t>(
-                                    math::cvt_pack_f32_to_e2m1x2(upper.x, buddy_ux));
-                                const uint8_t byte_uy = static_cast<uint8_t>(
-                                    math::cvt_pack_f32_to_e2m1x2(upper.y, buddy_uy));
-                                const uint8_t byte_lx = static_cast<uint8_t>(
-                                    math::cvt_pack_f32_to_e2m1x2(lower.x, buddy_lx));
-                                const uint8_t byte_ly = static_cast<uint8_t>(
-                                    math::cvt_pack_f32_to_e2m1x2(lower.y, buddy_ly));
-
-                                constexpr uint32_t kFp4WarpStripeBytes = 8;  // 16 elements / 2
-                                const uint32_t byte_pos_upper = group / 2u;             // 0..3
-                                const uint32_t byte_pos_lower = 4u + group / 2u;        // 4..7
-                                const uint32_t row_even = i * ATOM_M + 2u * frag;
-                                const uint32_t row_odd  = row_even + 1u;
-                                const auto base = smem_cd[tma_stage_idx]
-                                                + epilogue_wg_idx * STORE_BLOCK_M * L1_OUT_ROW_BYTES
-                                                + warp_idx_in_wg * kFp4WarpStripeBytes;
-                                auto write_byte = [&](uint32_t row, uint32_t bp, uint8_t v) {
-                                    auto p = base + row * L1_OUT_ROW_BYTES + bp;
-                                    asm volatile("st.shared.u8 [%0], %1;\n"
-                                                 :: "l"(__cvta_generic_to_shared(p)),
-                                                    "r"(static_cast<uint32_t>(v)));
-                                };
-                                write_byte(row_even, byte_pos_upper, byte_ux);
-                                write_byte(row_odd,  byte_pos_upper, byte_uy);
-                                write_byte(row_even, byte_pos_lower, byte_lx);
-                                write_byte(row_odd,  byte_pos_lower, byte_ly);
+                        const auto smem_base = reinterpret_cast<uint8_t*>(shared_storage.smem_d.l1[epilogue_wg_idx][tma_stage_idx])
+                            + i * ATOM_M * L1_OUT_BLOCK_N_BYTES;
+                        if constexpr (kIsFP4Acts) {
+                            const uint32_t packed = math::cast_into_e2m1x2_pairs(first, second);
+                            const uint32_t byte_in_row = warp_idx_in_wg * (L1_OUT_BLOCK_N_BYTES / 4) + lane_idx / 4;
+                            #pragma unroll
+                            for (uint32_t t = 0; t < 2; ++ t) {
+                                const uint32_t row = (lane_idx % 4) * 2 + t;
+                                // 32B swizzle: 2 bank groups, XOR-ed by `row / 4`
+                                const uint32_t swizzled_byte =
+                                    ((byte_in_row / kNumBankGroupBytes) ^ ((row / 4) & 1)) * kNumBankGroupBytes +
+                                    byte_in_row % kNumBankGroupBytes;
+                                smem_base[row * L1_OUT_BLOCK_N_BYTES + swizzled_byte] =
+                                    static_cast<uint8_t>(packed >> (t * 8));
                             }
                         } else {
-                            const auto fp8x4_values = __nv_fp8x4_e4m3(make_float4(upper.x, upper.y, lower.x, lower.y));
+                            const auto fp8x4_values = __nv_fp8x4_e4m3(make_float4(first.x, first.y, second.x, second.y));
 
                             // STSM
                             uint32_t row = lane_idx;
                             uint32_t col = warp_idx_in_wg;
-                            const auto smem_ptr = smem_cd[tma_stage_idx] + epilogue_wg_idx * STORE_BLOCK_M * L1_OUT_BLOCK_N
-                                                                         + i * ATOM_M * L1_OUT_BLOCK_N
-                                                                         + row * L1_OUT_BLOCK_N
-                                                                         + (col ^ (row / 2)) * kNumBankGroupBytes;
+                            const auto smem_ptr = smem_base
+                                + row * L1_OUT_BLOCK_N_BYTES
+                                // Use 64B swizzle for SwiGLU, so divided by 2
+                                + (col ^ (row / 2)) * kNumBankGroupBytes;
                             ptx::SM100_U8x4_STSM_T<__nv_fp8x4_e4m3>::copy(fp8x4_values, smem_ptr);
                         }
 
-                        // Store SF to `buffer.l2_sf_buffer` as UE8M0 (MN-major layout)
-                        // Only one warp per pair writes (both hold the same SF after cross-warp reduce)
+                        // Store SF to `buffer.l2_sf_buffer` (MN-major layout)
+                        // For MXFP8FP4 only one warp per pair writes (both hold the same SF after the
+                        // cross-warp reduce); for NVFP4 every warp owns its own 16-element group
                         // Each lane < 4 holds SF for 2 rows (sf.x and sf.y)
-                        if (warp_idx_in_wg % 2 == 0 and lane_idx < 4) {
-                            const uint32_t k_idx = n_block_idx * 2 + warp_idx_in_wg / 2;
+                        if ((kIsNVFP4 or warp_idx_in_wg % 2 == 0) and lane_idx < 4) {
+                            const uint32_t k_idx = kIsNVFP4 ? n_block_idx * 4 + warp_idx_in_wg
+                                                            : n_block_idx * 2 + warp_idx_in_wg / 2;
                             const uint32_t k_uint_idx = k_idx / 4, byte_idx = k_idx % 4;
                             const uint32_t mn_stride = (task_info.is_shared() ? kNumSharedSFTokens : kNumSFRingTokens) * sizeof(uint32_t);
                             const auto sf_base_ptr = task_info.is_shared() ?
@@ -1579,31 +1367,22 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             const auto sf_token_idx = block_idx * SF_BLOCK_M
                                 + transform_sf_token_idx(token_base_idx) + (lane_idx * 2) * 4;
                             const auto sf_addr = k_uint_idx * mn_stride + sf_token_idx * static_cast<uint32_t>(sizeof(uint32_t)) + byte_idx;
-                            sf_base_ptr[sf_addr] =
-                                (*reinterpret_cast<const uint32_t*>(&sf.x) >> 23);
+                            sf_base_ptr[sf_addr] = static_cast<uint8_t>(sf_bits.x);
                             sf_base_ptr[sf_addr + 4 * static_cast<uint32_t>(sizeof(uint32_t))] =
-                                (*reinterpret_cast<const uint32_t*>(&sf.y) >> 23);
+                                static_cast<uint8_t>(sf_bits.y);
                         }
                         __syncwarp();
                     }
                     ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
 
-                    // Issue TMA store after all atoms in this store block.
-                    // FP8 path: out_n in elements-of-FP8 (= bytes), smem
-                    // base offset by FP8 row width (L1_OUT_BLOCK_N).
-                    // FP4 path: TMA descriptor's element type is uint8 with
-                    // half the inner dim → out_n in packed bytes (=
-                    // L1_OUT_BLOCK_N / 2), smem base offset by
-                    // L1_OUT_ROW_BYTES = L1_OUT_BLOCK_N / 2 bytes.
+                    // Issue TMA store after all atoms in this store block
                     if (warp_idx_in_wg == 0 and cute::elect_one_sync()) {
-                        const uint32_t out_n_idx = kUseFp4Acts
-                            ? (n_block_idx * (L1_OUT_BLOCK_N / 2))
-                            : (n_block_idx * L1_OUT_BLOCK_N);
+                        uint32_t out_n_idx = n_block_idx * L1_OUT_BLOCK_N_BYTES;
                         const auto tensor_map_l1_output_ptr = task_info.is_shared() ? &tensor_map_shared_l1_output : &tensor_map_l1_output;
                         cute::tma_store_fence();
                         cute::SM90_TMA_STORE_2D::copy(
                             tensor_map_l1_output_ptr,
-                            smem_cd[tma_stage_idx] + epilogue_wg_idx * STORE_BLOCK_M * L1_OUT_ROW_BYTES,
+                            shared_storage.smem_d.l1[epilogue_wg_idx][tma_stage_idx],
                             out_n_idx,
                             m_idx + epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M);
                         cute::tma_store_arrive();
@@ -1652,6 +1431,12 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 DG_STATIC_ASSERT(STORE_BLOCK_M % 8 == 0, "Invalid store M");
                 constexpr uint32_t kNumRowsPerWarp = STORE_BLOCK_M / 8;
 
+                float l2_alpha = 1.0f;
+                if constexpr (kWithL2Alphas) {
+                    if (not task_info.is_shared())
+                        l2_alpha = __ldg(l2_alphas + task_info.local_expert_idx);
+                }
+
                 // L2 BF16 epilogue: write GEMM output to remote combine buffer via NVLink
                 #pragma unroll
                 for (uint32_t s = 0; s < WG_BLOCK_M / STORE_BLOCK_M; ++ s) {
@@ -1659,7 +1444,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     // TODO: check performance
                     if (epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M >= valid_m) {
                         ptx::tcgen05_before_thread_sync();
-                        tmem_empty_barriers[accum_stage_idx]->arrive(0u);
+                        shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         break;
                     }
 
@@ -1675,6 +1460,13 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                                                values[4], values[5], values[6], values[7]);
                         cutlass::arch::fence_view_async_tmem_load();
 
+                        if constexpr (kWithL2Alphas) {
+                            auto fp32_values = reinterpret_cast<float*>(values);
+                            #pragma unroll
+                            for (uint32_t v = 0; v < ATOM_M; ++ v)
+                                fp32_values[v] *= l2_alpha;
+                        }
+
                         // Wait shared memory release from previous NVLink store
                         // NOTES: skip for the first store block since the prior full barrier already ensures completion
                         if (i == 0 and s > 0)
@@ -1683,16 +1475,14 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         // Signal tensor memory consumed
                         if (s == WG_BLOCK_M / STORE_BLOCK_M - 1 and i == STORE_BLOCK_M / ATOM_M - 1) {
                             ptx::tcgen05_before_thread_sync();
-                            tmem_empty_barriers[accum_stage_idx]->arrive(0u);
+                            shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         }
 
                         // Store into shared memory
-                        // NOTES: only use first 16 lanes for address
-                        // NOTES: 2 warps share a BF16 swizzle atom
+                        // NOTES: each lane provides its own address for stmatrix; 2 warps share a BF16 swizzle atom
                         uint32_t row = lane_idx % 8;
                         uint32_t col = (epilogue_warp_idx % 2) * 4 + lane_idx / 8;
-                        const auto smem_ptr = smem_cd_l2 +
-                            epilogue_wg_idx * STORE_BLOCK_M * BLOCK_N * static_cast<uint32_t>(sizeof(nv_bfloat16)) +
+                        const auto smem_ptr = reinterpret_cast<uint8_t*>(shared_storage.smem_d.l2[epilogue_wg_idx]) +
                             (warp_idx_in_wg / 2) * STORE_BLOCK_M * kSwizzleCDMode +
                             i * ATOM_M * kSwizzleCDMode +
                             row * (kNumBankGroupBytes * 8) +
@@ -1710,7 +1500,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
 
                     // Write into remote buffers
-                    // One warp per row, now the layout is different from shared memory storing
+                    // Each warp writes 2 rows (lane_idx/16 splits the warp into two halves, one per row)
                     const uint32_t row_in_atom = (warp_idx_in_wg * 2 + lane_idx / 16) % ATOM_M;
                     const uint32_t bank_group_idx = lane_idx % 8;
 
@@ -1736,46 +1526,39 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         }
 
                         // Read from shared memory
-                        const auto smem_ptr = smem_cd_l2 +
-                            epilogue_wg_idx * STORE_BLOCK_M * BLOCK_N * static_cast<uint32_t>(sizeof(nv_bfloat16)) +
+                        const auto smem_ptr = reinterpret_cast<uint8_t*>(shared_storage.smem_d.l2[epilogue_wg_idx]) +
                             (lane_idx % 16 / 8) * STORE_BLOCK_M * kSwizzleCDMode +
                             row_in_store * kSwizzleCDMode +
                             (bank_group_idx ^ row_in_atom) * kNumBankGroupBytes;
                         const auto packed = ptx::ld_shared(reinterpret_cast<float4*>(smem_ptr));
 
+                        // Write into remote
                         if constexpr (kUseFp8Combine) {
-                            // Stream B: BF16 (in `packed`) → FP8 E4M3 + per-row UE8M0 SF.
-                            //
-                            // 16 lanes (lane_idx & ~15u) cover one row's
-                            // BLOCK_N=128 elements (= 8 BF16 each). Compute
-                            // per-row amax via warp_reduce over those 16
-                            // lanes, then quantize.
+                            // BF16 (in `packed`) -> FP8 E4M3 + one UE8M0 SF per row tile.
+                            // 16 lanes (lane_idx & ~15u) cover one row's BLOCK_N=128
+                            // elements (8 BF16 each), so the per-row amax is a reduction
+                            // over that 16-lane group.
                             const auto bf_pairs = reinterpret_cast<const nv_bfloat162*>(&packed);
                             float local_amax = 0.0f;
                             #pragma unroll
-                            for (int q = 0; q < 4; ++q) {
+                            for (uint32_t q = 0; q < 4; ++q) {
                                 const float2 vf = __bfloat1622float2(bf_pairs[q]);
                                 local_amax = cute::max(local_amax, cute::abs(vf.x));
                                 local_amax = cute::max(local_amax, cute::abs(vf.y));
                             }
-                            // Reduce within the 16-lane group sharing this row.
-                            // Use a 16-lane mask (NOT 0xffffffff) because the
-                            // outer `if (m_idx_in_block >= valid_m) break` may
-                            // cause the OTHER half-warp's 16 lanes to exit
-                            // early on padding rows. A full-warp shfl would
-                            // deadlock waiting on those exited lanes.
-                            const uint32_t row_mask = 0x0000FFFFu << (16u * (lane_idx / 16));
+                            // A 16-lane mask, not `0xffffffff`: the `m_idx_in_block >= valid_m`
+                            // break above can retire the other half-warp on padding rows, and a
+                            // full-warp shuffle would then wait on lanes that have already exited.
+                            const uint32_t row_mask = 0x0000ffffu << (16u * (lane_idx / 16));
                             local_amax = cute::max(local_amax, __shfl_xor_sync(row_mask, local_amax, 1));
                             local_amax = cute::max(local_amax, __shfl_xor_sync(row_mask, local_amax, 2));
                             local_amax = cute::max(local_amax, __shfl_xor_sync(row_mask, local_amax, 4));
                             local_amax = cute::max(local_amax, __shfl_xor_sync(row_mask, local_amax, 8));
 
-                            // UE8M0 SF (E4M3, finfo_max = 448).
                             const int log2_ceil = math::fast_log2_ceil(local_amax * (1.0f / 448.0f));
                             const float sf_inv = math::fast_pow2(-log2_ceil);
                             const uint8_t sf_byte = static_cast<uint8_t>(log2_ceil + 127);
 
-                            // Scale, cast 4 BF16 pairs → 8 FP8 (= 2 fp8x4 = uint64).
                             float4 lo, hi;
                             const auto lo_pair = __bfloat1622float2(bf_pairs[0]);
                             const auto lo_pair_b = __bfloat1622float2(bf_pairs[1]);
@@ -1798,7 +1581,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             // Write 8 FP8 bytes (uint64) to remote, replacing
                             // the BF16 16-byte write.
                             const auto dst_token = buffer.combine_token_buffer.get_rank_buffer(dst_topk_idx)
-                                                                       .get_data_buffer(dst_token_idx);
+                                                   .get_data_buffer(dst_token_idx);
                             const auto dst_ptr = math::advance_ptr<uint64_t>(
                                 dst_token.get_base_ptr(),
                                 n_idx * static_cast<uint32_t>(sizeof(uint8_t)) +
@@ -1808,7 +1591,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             // 1 SF byte per row tile, written by lane 0 of the 16-lane group.
                             if ((lane_idx & 15u) == 0) {
                                 const auto sf_token = buffer.combine_sf_buffer.get_rank_buffer(dst_topk_idx)
-                                                                         .get_data_buffer(dst_token_idx);
+                                                     .get_data_buffer(dst_token_idx);
                                 const auto sf_ptr = math::advance_ptr<uint8_t>(
                                     sf_token.get_base_ptr(),
                                     n_block_idx * static_cast<uint32_t>(sizeof(uint8_t)));
@@ -1817,7 +1600,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         } else {
                             // Default BF16 path (16 bytes/lane = 8 BF16).
                             const auto dst_token = buffer.combine_token_buffer.get_rank_buffer(dst_topk_idx)
-                                                                       .get_data_buffer(dst_token_idx);
+                                                   .get_data_buffer(dst_token_idx);
                             const auto dst_ptr = math::advance_ptr<float4>(
                                 dst_token.get_base_ptr(),
                                 n_idx * static_cast<uint32_t>(sizeof(nv_bfloat16)) + (lane_idx % 16) * static_cast<uint32_t>(sizeof(float4)));
@@ -1859,20 +1642,19 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         // NOTES: either 1 or 2 chunks for simplicity
         // NOTES: Restrict on both smem and register
         constexpr uint32_t kNumChunks =
-            kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes <= SMEM_BEFORE_BARRIER_SIZE and kHidden <= 32 * kNumMaxRegistersForBuffer ? 1 : 2;
+            kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes <= kNumReusableSmemBytes and kHidden <= 32 * kNumMaxRegistersForBuffer ? 1 : 2;
         constexpr uint32_t kNumChunkBytes = kNumHiddenBytes / kNumChunks;
         constexpr uint32_t kNumChunkUint4 = kNumChunkBytes / sizeof(uint4);
         constexpr uint32_t kNumUint4PerLane = kNumChunkUint4 / 32;
         DG_STATIC_ASSERT(kHidden % kNumChunks == 0, "Hidden must be divisible by number of chunks");
-        DG_STATIC_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes / kNumChunks <= SMEM_BEFORE_BARRIER_SIZE, "Hidden is too large");
+        DG_STATIC_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes / kNumChunks <= kNumReusableSmemBytes, "Hidden is too large");
         DG_STATIC_ASSERT(kNumChunkBytes % 16 == 0, "Combine chunk must be TMA-aligned (16 bytes)");
         DG_STATIC_ASSERT(kNumChunkBytes % sizeof(uint4) == 0, "Combine chunk must be divisible by 16 bytes");
         DG_STATIC_ASSERT(kNumChunkUint4 % 32 == 0, "Combine chunk must be a multiple of 32 16-byte elements (one per lane)");
         DG_STATIC_ASSERT(kNumTopk + (kNumSharedExperts > 0 ? 1u : 0u) <= 32u, "Top-k + shared must fit in a single warp");
 
         // Verify combined shared memory budget at runtime
-        DG_DEVICE_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumChunkBytes <= static_cast<uint32_t>(
-            reinterpret_cast<uint8_t*>(barrier_start_ptr) - smem_buffer));
+        DG_DEVICE_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumChunkBytes <= kNumReusableSmemBytes);
 
         // Per-warp buffer: 2 stage load buffers + 1 store buffer
         const auto combine_load_buffer = utils::PatternVisitor([&](const uint32_t& i) {
@@ -1882,7 +1664,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
         // Per-warp barriers
         auto combine_load_barriers = utils::PatternVisitor([&](const uint32_t& i) {
-            return combine_barriers[i + epilogue_warp_idx * 2];
+            return &shared_storage.combine_barriers[i + epilogue_warp_idx * 2];
         });
 
         // Iterate over all tokens
@@ -1908,7 +1690,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             // Per-uint4 load: BF16 → 8 BF16 = 4 float2 pairs.
             //                 FP8  → 16 FP8 = 8 float2 pairs (dequant'd).
             constexpr uint32_t kNumF32PairsPerLoadUint4 =
-                kUseFp8Combine ? 8u : 4u;
+            kUseFp8Combine ? 8u : 4u;
             // Per-element offset in the chunk for SF lookup:
             //   sf_idx = (chunk * kNumLoadElemsPerChunk + elem_in_chunk) / 128
             constexpr uint32_t kNumLoadElemsPerChunk = kHidden / kNumChunks;

--- a/deep_gemm/include/deep_gemm/impls/sm100_mega_moe_pre_dispatch.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_mega_moe_pre_dispatch.cuh
@@ -5,23 +5,27 @@
 #include <cuda/std/cstdint>
 
 #include <deep_gemm/common/math.cuh>
+#include <deep_gemm/common/types.cuh>
 #include <deep_gemm/common/utils.cuh>
 
 namespace deep_gemm {
 
 // Fused BF16 → quant + topk copy + pad-fill kernel that produces the exact
 // byte layout DeepGEMM's mega-MoE symmetric buffer expects in its `x`,
-// `x_sf`, `topk_idx`, and `topk_weights` slots. Two variants:
+// `x_sf`, `topk_idx`, and `topk_weights` slots. The acts format follows the
+// consuming GEMM's `MmaKind`:
 //
-//   - `kUseFp4Acts == false` → FP8 (E4M3) acts; per-row stride = `hidden`.
-//   - `kUseFp4Acts == true`  → packed FP4 (E2M1) acts; per-row stride
-//                              = `hidden / 2`. Layout: byte holds 2 nibbles,
-//                              low nibble = even col, high nibble = odd col,
-//                              matching `deep_gemm.utils.per_token_cast_to_fp4`.
+//   - `MXFP8FP4` → FP8 (E4M3) acts + UE8M0 group scales; row stride = `hidden`.
+//   - `MXFP4`    → packed FP4 (E2M1) acts + UE8M0 group scales; row stride
+//                  = `hidden / 2`. Layout: byte holds 2 nibbles, low nibble =
+//                  even col, high nibble = odd col, matching
+//                  `deep_gemm.utils.per_token_cast_to_fp4`.
+//   - `NVFP4`    → same packing as `MXFP4`, but UE4M3 SFs over 16-element
+//                  groups plus one FP32 per-token outer scale in `buf_x_scales`.
 //
-// Both paths share the UE8M0 SF byte layout: `byte_off = token*num_groups +
-// group`, with the contiguous `(P, num_groups/4)` int32 slot storing 4 bytes
-// per int32 in row-major order.
+// All paths share the SF byte layout: `byte_off = token*num_groups + group`,
+// with the contiguous `(P, num_groups/4)` int32 slot storing 4 bytes per int32
+// in row-major order.
 //
 // The FP4 quant matches `per_token_cast_to_fp4` (host helper) bytewise via
 // explicit bucketize boundaries — PTX `cvt.rn.satfinite.e2m1x2.f32` rounds
@@ -55,14 +59,29 @@ __forceinline__ __device__ uint32_t pre_dispatch_e2m1_encode(float v) {
     return code;
 }
 
-template <uint32_t kGroupSize, bool kUseFp4Acts, bool kUsePDL>
+__forceinline__ __device__ float pre_dispatch_block_reduce_max(float val) {
+    __shared__ float smem[32];
+    const uint32_t lane = threadIdx.x % 32u;
+    const uint32_t warp = threadIdx.x / 32u;
+    const uint32_t num_warps = (blockDim.x + 31u) / 32u;
+    val = math::warp_reduce<32, /*kIntergroupReduce=*/false>(val, math::ReduceMax<float>{});
+    if (lane == 0)
+        smem[warp] = val;
+    __syncthreads();
+    val = (lane < num_warps) ? smem[lane] : 0.0f;
+    return math::warp_reduce<32, /*kIntergroupReduce=*/false>(val, math::ReduceMax<float>{});
+}
+
+template <uint32_t kGroupSize, MmaKind kMmaKind, bool kUsePDL>
 __launch_bounds__(1024, 2)
 __global__ void mega_moe_pre_dispatch_kernel(
     const __nv_bfloat16* __restrict__ x,
     const int32_t*       __restrict__ topk_idx,
     const float*         __restrict__ topk_weights,
+    const float*         __restrict__ expert_scales,
     void*                __restrict__ buf_x,
     int32_t*             __restrict__ buf_x_sf,
+    float*               __restrict__ buf_x_scales,
     int64_t*             __restrict__ buf_topk_idx,
     float*               __restrict__ buf_topk_weights,
     const uint32_t num_tokens,
@@ -70,8 +89,16 @@ __global__ void mega_moe_pre_dispatch_kernel(
     const uint32_t hidden,
     const uint32_t num_groups,
     const uint32_t top_k) {
-    static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
-                  "kGroupSize must be 32, 64, or 128");
+    static_assert(kGroupSize == 16 || kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
+                  "kGroupSize must be 16, 32, 64, or 128");
+    constexpr bool kNvfp4 = kMmaKind == MmaKind::NVFP4;
+    constexpr bool kPackedFp4 = get_element_bits(kMmaKind) == 4;
+    static_assert(kMmaKind == MmaKind::MXFP8FP4 || kMmaKind == MmaKind::MXFP4 || kNvfp4,
+                  "Acts must be FP8 (MXFP8FP4) or packed FP4 (MXFP4 / NVFP4)");
+    static_assert(!kNvfp4 || kGroupSize == 16,
+                  "NVFP4 acts use 16-element UE4M3 blocks");
+    static_assert(kNvfp4 || kGroupSize >= 32,
+                  "UE8M0 modes keep the original 32/64/128 group sizes");
     constexpr uint32_t kVecElems = 8;  // 16-byte BF16 load per thread
     static_assert(kGroupSize % kVecElems == 0, "kGroupSize must be a multiple of 8");
     constexpr uint32_t kThreadsPerGroup = kGroupSize / kVecElems;
@@ -110,17 +137,39 @@ __global__ void mega_moe_pre_dispatch_kernel(
         local_max = math::warp_reduce<kThreadsPerGroup, /*kIntergroupReduce=*/false>(
             local_max, math::ReduceMax<float>{});
 
-        // Match host `per_token_cast_to_fp4/fp8`: clamp absmax to 1e-4
-        // before dividing by the dtype's max representable value.
-        const float absmax = fmaxf(local_max, 1e-4f);
-        constexpr float kFinfoMax = kUseFp4Acts ? 6.0f : 448.0f;
-        const float raw_scale = absmax / kFinfoMax;
-        const uint32_t ue8m0_exp = pre_dispatch_cast_to_ue8m0(raw_scale);
-        // 1 / 2^(ue8m0_exp - 127) = 2^(127 - ue8m0_exp); fp32 bits =
-        // (127 - ue8m0_exp + 127) << 23 = (254 - ue8m0_exp) << 23.
-        const float inv_scale = __uint_as_float((254u - ue8m0_exp) << 23u);
+        float inv_scale;
+        uint32_t sf_byte;
+        if constexpr (kNvfp4) {
+            // NVFP4 per-token recipe (matches the flashinfer per-token
+            // quantizer's dequant contract): x ≈ e2m1 * ue4m3(sf) * pts with
+            //   pts = row_absmax / (448 * 6)
+            //   sf  = e4m3_rn(group_absmax / (6 * pts))   (≤ 448 by construction)
+            // Encode divides by the ROUNDED sf so dequant is exact w.r.t. it.
+            const float row_max = fmaxf(
+                pre_dispatch_block_reduce_max(local_max), 1e-4f);
+            const float pts = row_max / (448.0f * 6.0f);
+            const __nv_fp8_storage_t sf_fp8 = __nv_cvt_float_to_fp8(
+                local_max / (6.0f * pts), __NV_SATFINITE, __NV_E4M3);
+            const __half_raw sf_hr = __nv_cvt_fp8_to_halfraw(sf_fp8, __NV_E4M3);
+            const float sf_dec = __half2float(*reinterpret_cast<const __half*>(&sf_hr));
+            inv_scale = sf_dec > 0.0f ? 1.0f / (sf_dec * pts) : 0.0f;
+            sf_byte = static_cast<uint32_t>(sf_fp8);
+            if (tid == 0u)
+                buf_x_scales[token_id] = pts;
+        } else {
+            // Match host `per_token_cast_to_fp4/fp8`: clamp absmax to 1e-4
+            // before dividing by the dtype's max representable value.
+            const float absmax = fmaxf(local_max, 1e-4f);
+            constexpr float kFinfoMax = kPackedFp4 ? 6.0f : 448.0f;
+            const float raw_scale = absmax / kFinfoMax;
+            const uint32_t ue8m0_exp = pre_dispatch_cast_to_ue8m0(raw_scale);
+            // 1 / 2^(ue8m0_exp - 127) = 2^(127 - ue8m0_exp); fp32 bits =
+            // (127 - ue8m0_exp + 127) << 23 = (254 - ue8m0_exp) << 23.
+            sf_byte = ue8m0_exp;
+            inv_scale = __uint_as_float((254u - sf_byte) << 23u);
+        }
 
-        if constexpr (kUseFp4Acts) {
+        if constexpr (kPackedFp4) {
             // 8 BF16 → 4 packed nibbles → 4 bytes (uint32_t). Output stride
             // per token is hidden/2; thread tid writes 4 bytes at offset
             // [tid*4, tid*4+4) in the output row. Pairing matches host
@@ -153,23 +202,28 @@ __global__ void mega_moe_pre_dispatch_kernel(
             row_out[tid] = packed;
         }
 
-        // One thread per group writes its UE8M0 exponent byte. Row-major
-        // contiguous layout into `buf_x_sf` viewed as bytes:
-        //   byte_off = token_id * num_groups + group_id.
+        // One thread per group writes its scale byte (UE8M0 exponent, or the
+        // UE4M3 block SF for NVFP4 acts). Row-major contiguous layout into
+        // `buf_x_sf` viewed as bytes: byte_off = token_id * num_groups + group_id.
         const uint32_t group_id = tid / kThreadsPerGroup;
         const uint32_t within_group_id = tid % kThreadsPerGroup;
         if (within_group_id == 0u && group_id < num_groups) {
             const uint32_t byte_off = token_id * num_groups + group_id;
             reinterpret_cast<uint8_t*>(buf_x_sf)[byte_off] =
-                static_cast<uint8_t>(ue8m0_exp);
+                static_cast<uint8_t>(sf_byte);
         }
 
-        // Copy this token's topk row. top_k is small (≤ num_threads enforced
-        // at host); each tid<top_k thread copies one entry.
+        // Copy this token's topk row, optionally folding a per-expert scale
+        // (e.g. w2 weight_scale_2 ratios) into the weight. top_k is small
+        // (≤ num_threads enforced at host); each tid<top_k thread copies one.
         if (tid < top_k) {
             const uint32_t off = token_id * top_k + tid;
-            buf_topk_idx[off]     = static_cast<int64_t>(topk_idx[off]);
-            buf_topk_weights[off] = topk_weights[off];
+            const int32_t expert = topk_idx[off];
+            buf_topk_idx[off] = static_cast<int64_t>(expert);
+            float w = topk_weights[off];
+            if (expert_scales != nullptr && expert >= 0)
+                w *= expert_scales[expert];
+            buf_topk_weights[off] = w;
         }
     } else {
         // ---- Pad path: trailing CTAs fill [num_tokens, padded_max) topk

--- a/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
@@ -4,6 +4,7 @@
 
 #include <deep_gemm/common/math.cuh>
 #include <deep_gemm/common/exception.cuh>
+#include <deep_gemm/common/types.cuh>
 
 namespace deep_gemm::layout {
 
@@ -474,6 +475,11 @@ struct MegaMoEBuffer {
            combine_token_buffer,
            combine_sf_buffer;
 
+    // Optional per-token FP32 outer scales for the L1 (fc13) input, applied on
+    // the L1 accumulator before activation.
+    Buffer input_x_scales_buffer,
+           l1_x_scales_buffer;
+
     CUTLASS_HOST_DEVICE
     MegaMoEBuffer(void* base,
                   const uint32_t& hidden,
@@ -484,10 +490,10 @@ struct MegaMoEBuffer {
                   const uint32_t& num_topk,
                   const uint32_t& num_ring_tokens,
                   const uint32_t& num_sf_ring_tokens,
-                  const bool& with_sf,
+                  const MmaKind& mma_kind,
                   const uint32_t& num_shared_experts = 0,
-                  const bool& use_fp4_acts = false,
                   const bool& use_fp8_combine = false) {
+        const bool with_sf = get_sf_gran_k(mma_kind) != 0;
         // Workspace
         workspace = Workspace(base, num_ranks, num_experts,
                               num_max_tokens_per_rank, num_topk, num_ring_tokens);
@@ -497,21 +503,25 @@ struct MegaMoEBuffer {
         const auto num_max_shared_sf_tokens = with_sf ? get_num_max_shared_sf_tokens(num_max_tokens_per_rank) : 0u;
 
         // Layouts
-        const uint32_t num_mma_elem_bytes = with_sf ? 1 : 2;
-        const auto input_token_layout = layout::Data(
-            use_fp4_acts ? hidden / 2 : hidden * num_mma_elem_bytes);
+        const uint32_t elem_bits = get_element_bits(mma_kind);
+        // NOTE: multiply before dividing — `elem_bits / 8` truncates to 0 for the
+        // 4-bit kinds (NVFP4/MXFP4), which would zero-size every activation slot.
+        const auto num_token_bytes = [=](const uint32_t& num_elems) { return num_elems * elem_bits / 8; };
+        const uint32_t gran_k = with_sf ? get_sf_gran_k(mma_kind) : 1;
+        const auto input_token_layout = layout::Data(num_token_bytes(hidden));
         const auto combine_token_layout = layout::Data(
             use_fp8_combine ? hidden : hidden * 2);
         const auto combine_sf_layout = layout::Data(
             use_fp8_combine ? hidden / 128 : 0, false);
-        const auto intermediate_token_layout = layout::Data(intermediate_hidden * num_mma_elem_bytes);
-        const auto shared_intermediate_token_layout = layout::Data(shared_intermediate_hidden * num_mma_elem_bytes);
-        const auto input_sf_layout = layout::Data(with_sf ? hidden / 32 : 0);
-        const auto intermediate_sf_layout = layout::Data(with_sf ? intermediate_hidden / 32 : 0);
-        const auto shared_intermediate_sf_layout = layout::Data(with_sf ? shared_intermediate_hidden / 32 : 0);
+        const auto intermediate_token_layout = layout::Data(num_token_bytes(intermediate_hidden));
+        const auto shared_intermediate_token_layout = layout::Data(num_token_bytes(shared_intermediate_hidden));
+        const auto input_sf_layout = layout::Data(with_sf ? hidden / gran_k : 0);
+        const auto intermediate_sf_layout = layout::Data(with_sf ? intermediate_hidden / gran_k : 0);
+        const auto shared_intermediate_sf_layout = layout::Data(with_sf ? shared_intermediate_hidden / gran_k : 0);
         const auto input_topk_idx_layout = layout::Data(num_topk * sizeof(int64_t), false);
         const auto input_topk_weights_layout = layout::Data(num_topk * sizeof(float), false);
         const auto l1_topk_weights_layout = layout::Data(sizeof(float), false);
+        const auto x_scale_layout = layout::Data(sizeof(float), false);
 
         // Input buffers
         input_token_buffer = Buffer(
@@ -566,11 +576,18 @@ struct MegaMoEBuffer {
         combine_sf_buffer = Buffer(
             combine_sf_layout, num_topk + (num_shared_experts > 0 ? 1u : 0u), num_max_tokens_per_rank,
             combine_token_buffer.get_end_ptr());
+
+        input_x_scales_buffer = Buffer(
+            x_scale_layout, 1, num_max_tokens_per_rank,
+            combine_sf_buffer.get_end_ptr());
+        l1_x_scales_buffer = Buffer(
+            x_scale_layout, 1, num_ring_tokens,
+            input_x_scales_buffer.get_end_ptr());
     }
 
     CUTLASS_HOST_DEVICE
     int64_t get_num_bytes() const {
-        return static_cast<uint8_t*>(combine_sf_buffer.get_end_ptr())
+        return static_cast<uint8_t*>(l1_x_scales_buffer.get_end_ptr())
                - static_cast<uint8_t*>(workspace.base);
     }
 };

--- a/deep_gemm/include/deep_gemm/ptx/tcgen05.cuh
+++ b/deep_gemm/include/deep_gemm/ptx/tcgen05.cuh
@@ -171,6 +171,30 @@ struct SM100_MMA_MXF4_2x1SM_SS {
     }
 };
 
+struct SM100_MMA_MXF4NVF4_2x1SM_SS {
+    CUTLASS_DEVICE static void
+    fma(uint64_t const& desc_a,
+        uint64_t const& desc_b,
+        uint32_t const& tmem_c,
+        uint32_t const& scale_c,
+        uint64_t const& desc,
+        uint32_t const& tmem_sfa,
+        uint32_t const& tmem_sfb) {
+        asm volatile(
+            "{\n\t"
+            ".reg .pred p;\n\t"
+            "setp.ne.b32 p, %4, 0;\n\t"
+#if (__CUDACC_VER_MAJOR__ > 12) || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 9)
+            "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.block16 [%0], %1, %2, %3, [%5], [%6], p; \n\t"
+#else
+            "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%5], [%6], p; \n\t"
+#endif
+            "}\n"
+            :: "r"(tmem_c), "l"(desc_a), "l"(desc_b), "r"(static_cast<uint32_t>(desc >> 32)), "r"(scale_c),
+               "r"(tmem_sfa), "r"(tmem_sfb));
+    }
+};
+
 struct SM100_MMA_F16BF16_WS_SS {
     CUTLASS_DEVICE static void
     fma(uint64_t const& desc_a,

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -15,6 +15,31 @@ except Exception as exception:
 
 from .. import _C
 
+
+def _check_legacy_fp4_acts_env() -> None:
+    """The fork's `DG_USE_FP4_ACTS` / `DG_USE_MXF4_KIND` env vars are superseded by
+    `mma_type`, and are refused rather than ignored.
+
+    They cannot be silently remapped. `DG_USE_FP4_ACTS` selected FP4 activations under
+    `kind::mxf8f6f4` while leaving weights in the gran-8 *unpacked* gate/up interleave;
+    the equivalent typed kinds (`mxf4xmxf4` / `nvfp4xnvfp4`) are dense `kind::mxf4` and
+    need the gran-16 *packed* interleave from `_interleave_weights_packed_fp4`. Honouring
+    the env var here would leave a caller who does not also pass `mma_type` to
+    `transform_weights_for_mega_moe` handing packed-layout kernels unpacked weights —
+    silently wrong results. Fail loudly instead.
+    """
+    for name in ('DG_USE_FP4_ACTS', 'DG_USE_MXF4_KIND'):
+        if int(os.environ.get(name, '0')) != 0:
+            raise RuntimeError(
+                f'`{name}` is no longer supported; it is replaced by the symmetric '
+                f"buffer's `mma_type`. Pass mma_type='mxf4xmxf4' (per-32 UE8M0 scales) "
+                f"or 'nvfp4xnvfp4' (per-16 UE4M3) to get_symm_buffer_for_mega_moe(), and "
+                f'the SAME mma_type to transform_weights_for_mega_moe() — the FP4 kinds '
+                f'need the packed gate/up interleave, so weights transformed without it '
+                f'would be laid out wrongly.'
+            )
+
+
 class SymmBuffer:
     def __init__(self, group: dist.ProcessGroup,
                  num_experts: int,
@@ -23,15 +48,19 @@ class SymmBuffer:
                  num_shared_experts: int = 0,
                  mma_type: str = 'fp8xfp4',
                  activation: str = 'swiglu'):
-        assert activation in ('swiglu', 'situ'), f'Unsupported activation `{activation}`'
+        assert activation in ('swiglu', 'swigluoai', 'situ'), f'Unsupported activation `{activation}`'
         assert activation != 'situ' or mma_type == 'fp8xfp4', \
             '`situ` activation is supported only for `fp8xfp4` MegaMoE'
+        _check_legacy_fp4_acts_env()
         self.group = group
         self.num_experts = num_experts
         self.num_max_tokens_per_rank = num_max_tokens_per_rank
         self.num_topk = num_topk
         self.hidden = hidden
         self.intermediate_hidden = intermediate_hidden
+        self.num_shared_experts = num_shared_experts
+        self.mma_type = mma_type
+        self.activation = activation
 
         # Allocate a symmetric buffer
         num_bytes, slice_input_buffers = _C.get_symm_buffer_size_for_mega_moe(
@@ -52,36 +81,15 @@ class SymmBuffer:
         self.group.barrier()
         torch.cuda.synchronize()
 
-        # Create input buffer views. TVM-FFI transports float8 storage as
-        # int8, so restore the logical dtype without changing the bytes.
-        raw_buffers = slice_input_buffers(self.buffer)
-        use_fp4_acts = (mma_type != 'bf16xbf16' and num_shared_experts == 0 and
-                        int(os.environ.get('DG_USE_FP4_ACTS', '0')) != 0)
-        acts_dtype = (torch.bfloat16 if mma_type == 'bf16xbf16' else
-                      (torch.int8 if use_fp4_acts else torch.float8_e4m3fn))
-        l2_dtype = torch.bfloat16 if mma_type == 'bf16xbf16' else torch.float8_e4m3fn
-
-        def as_torch(tensor, dtype=None):
-            if tensor is None:
-                return None
-            tensor = torch.from_dlpack(tensor)
-            return tensor.view(dtype) if dtype is not None and tensor.dtype != dtype else tensor
-
-        (x, x_sf, topk_idx, topk_weights,
-         shared_l1_acts, shared_l1_acts_sf, shared_l2_acts, shared_l2_acts_sf,
-         l1_acts, l1_acts_sf, l2_acts, l2_acts_sf) = raw_buffers
-        self.x = as_torch(x, acts_dtype)
-        self.x_sf = as_torch(x_sf)
-        self.topk_idx = as_torch(topk_idx)
-        self.topk_weights = as_torch(topk_weights)
-        self.shared_l1_acts = as_torch(shared_l1_acts, acts_dtype)
-        self.shared_l1_acts_sf = as_torch(shared_l1_acts_sf)
-        self.shared_l2_acts = as_torch(shared_l2_acts, l2_dtype)
-        self.shared_l2_acts_sf = as_torch(shared_l2_acts_sf)
-        self.l1_acts = as_torch(l1_acts, acts_dtype)
-        self.l1_acts_sf = as_torch(l1_acts_sf)
-        self.l2_acts = as_torch(l2_acts, l2_dtype)
-        self.l2_acts_sf = as_torch(l2_acts_sf)
+        # Create input buffer views (as torch tensors, not tvm-ffi tensors).
+        (self.x, self.x_sf,
+         self.topk_idx, self.topk_weights,
+         self.shared_l1_acts, self.shared_l1_acts_sf,
+         self.shared_l2_acts, self.shared_l2_acts_sf,
+         self.l1_acts, self.l1_acts_sf,
+         self.l2_acts, self.l2_acts_sf,
+         self.x_scales) = map(
+            torch.from_dlpack, slice_input_buffers(self.buffer))
 
     def destroy(self):
         self.handle = None
@@ -136,6 +144,22 @@ def _interleave_weights(t: torch.Tensor, gran: int = 8) -> torch.Tensor:
     return result.squeeze(0) if squeeze_group_dim else result
 
 
+def _interleave_weights_packed_fp4(t: torch.Tensor) -> torch.Tensor:
+    assert t.dim() in (2, 3)
+    squeeze_group_dim = t.dim() == 2
+    if squeeze_group_dim:
+        t = t.unsqueeze(0)
+
+    g, n, *rest = t.shape
+    half = n // 2
+    assert half % 16 == 0
+    gate = t[:, :half].reshape(g, half // 16, 16, *rest)
+    up = t[:, half:].reshape(g, half // 16, 16, *rest)
+    result = torch.cat([gate[:, :, 0::2], up[:, :, 0::2], gate[:, :, 1::2], up[:, :, 1::2]], dim=2)
+    result = torch.empty_like(t).copy_(result.reshape(g, n, *rest))
+    return result.squeeze(0) if squeeze_group_dim else result
+
+
 def _transpose_sf_for_utccp(sf: torch.Tensor) -> torch.Tensor:
     # Unsqueeze for 2D
     assert sf.dtype == torch.int and sf.dim() in (2, 3)
@@ -156,17 +180,20 @@ def _transpose_sf_for_utccp(sf: torch.Tensor) -> torch.Tensor:
 def transform_weights_for_mega_moe(
     l1_weights: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
     l2_weights: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
-    activation: str = 'swiglu'
+    activation: str = 'swiglu',
+    mma_type: str = 'fp8xfp4'
 ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
            Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]:
-    assert activation in ('swiglu', 'situ'), f'Unsupported activation `{activation}`'
+    assert activation in ('swiglu', 'swigluoai', 'situ'), f'Unsupported activation `{activation}`'
     assert activation != 'situ' or (
         isinstance(l1_weights, tuple) and isinstance(l2_weights, tuple)
     ), '`situ` activation is supported only for FP8xFP4 MegaMoE weights'
     if isinstance(l1_weights, tuple):
-        # FP8: interleave gate/up for weight and SF, then transpose L1 SF for UTCCP
-        l1_w = _interleave_weights(l1_weights[0])
-        l1_sf = _transpose_sf_for_utccp(_interleave_weights(l1_weights[1]))
+        # FP8/MXFP4/NVFP4: interleave gate/up for weight and SF, then transpose L1 SF for UTCCP.
+        interleave = _interleave_weights_packed_fp4 if mma_type in ('mxf4xmxf4', 'nvfp4xnvfp4') \
+            else _interleave_weights
+        l1_w = interleave(l1_weights[0])
+        l1_sf = _transpose_sf_for_utccp(interleave(l1_weights[1]))
         l1_transformed = (l1_w, l1_sf)
         # L2: only transpose SF for UTCCP
         l2_transformed = (l2_weights[0], _transpose_sf_for_utccp(l2_weights[1]))
@@ -188,31 +215,67 @@ def fp8_fp4_mega_moe(y: torch.Tensor,
                      recipe: Tuple[int, int, int] = (1, 1, 32),
                      activation: str = 'swiglu',
                      activation_clamp: Optional[float] = None,
-                     fast_math: bool = True):
+                     fast_math: bool = True,
+                     use_x_scales: Optional[bool] = None,
+                     l1_alphas: Optional[torch.Tensor] = None,
+                     l2_alphas: Optional[torch.Tensor] = None,
+                     l2_act_scales: Optional[torch.Tensor] = None):
+    # NVFP4 activations always have a per-token FP32 outer scale.  Derive the
+    # only valid setting from the buffer type so a default call cannot silently
+    # discard that scale (or read an uninitialized scale buffer for other MMAs).
+    uses_nvfp4 = sym_buffer.mma_type == 'nvfp4xnvfp4'
+    if use_x_scales is None:
+        use_x_scales = uses_nvfp4
+    elif use_x_scales != uses_nvfp4:
+        raise ValueError(
+            '`use_x_scales` must be enabled exactly for `nvfp4xnvfp4`; '
+            f'got {use_x_scales=} with mma_type={sym_buffer.mma_type!r}'
+        )
+
     (l1_weights_data, l1_weights_sf) = l1_weights
     (l2_weights_data, l2_weights_sf) = l2_weights
-    assert (shared_l1_weights is None) == (shared_l2_weights is None)
-    if shared_l1_weights is None:
-        shared_l1_weights_data = shared_l1_weights_sf = None
-        shared_l2_weights_data = shared_l2_weights_sf = None
-    else:
-        (shared_l1_weights_data, shared_l1_weights_sf) = shared_l1_weights
-        (shared_l2_weights_data, shared_l2_weights_sf) = shared_l2_weights
+    (shared_l1_data, shared_l1_sf) = shared_l1_weights if shared_l1_weights is not None else (None, None)
+    (shared_l2_data, shared_l2_sf) = shared_l2_weights if shared_l2_weights is not None else (None, None)
     _C.fp8_fp4_mega_moe(
         y,
         l1_weights_data, l1_weights_sf,
         l2_weights_data, l2_weights_sf,
-        shared_l1_weights_data, shared_l1_weights_sf,
-        shared_l2_weights_data, shared_l2_weights_sf,
+        shared_l1_data, shared_l1_sf,
+        shared_l2_data, shared_l2_sf,
         cumulative_local_expert_recv_stats,
         sym_buffer.buffer,
         sym_buffer.handle.buffer_ptrs, sym_buffer.group.rank(),
         sym_buffer.num_max_tokens_per_rank,
         sym_buffer.num_experts, sym_buffer.num_topk,
-        recipe,
+        recipe, sym_buffer.mma_type,
         activation, activation_clamp,
-        fast_math
+        fast_math, use_x_scales, l1_alphas, l2_alphas, l2_act_scales
     )
+
+def nvfp4_mega_moe(y: torch.Tensor,
+                   l1_weights: Tuple[torch.Tensor, torch.Tensor],
+                   l2_weights: Tuple[torch.Tensor, torch.Tensor],
+                   sym_buffer: SymmBuffer,
+                   shared_l1_weights: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+                   shared_l2_weights: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+                   cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
+                   activation: str = 'swiglu',
+                   activation_clamp: Optional[float] = None,
+                   fast_math: bool = True,
+                   use_x_scales: Optional[bool] = None,
+                   l1_alphas: Optional[torch.Tensor] = None,
+                   l2_alphas: Optional[torch.Tensor] = None,
+                   l2_act_scales: Optional[torch.Tensor] = None):
+    fp8_fp4_mega_moe(
+        y, l1_weights, l2_weights, sym_buffer,
+        shared_l1_weights, shared_l2_weights,
+        cumulative_local_expert_recv_stats,
+        recipe=(1, 1, 16),
+        activation=activation, activation_clamp=activation_clamp,
+        fast_math=fast_math, use_x_scales=use_x_scales,
+        l1_alphas=l1_alphas, l2_alphas=l2_alphas, l2_act_scales=l2_act_scales
+    )
+
 
 def bf16_mega_moe(y: torch.Tensor,
                   l1_weights: torch.Tensor,
@@ -242,6 +305,14 @@ def bf16_mega_moe(y: torch.Tensor,
     )
 
 
+def get_block_m_for_mega_moe(num_ranks: int, num_experts: int,
+                             num_max_tokens_per_rank: int, num_tokens: int,
+                             num_topk: int, mma_type: str = 'fp8xfp4') -> int:
+    """`BLOCK_M` the kernel will pick — callers need it to lay out shared-expert SFs."""
+    return int(_C.get_block_m_for_mega_moe(
+        num_ranks, num_experts, num_max_tokens_per_rank, num_tokens, num_topk, mma_type))
+
+
 def mega_moe_pre_dispatch(x: torch.Tensor,
                           topk_idx: torch.Tensor,
                           topk_weights: torch.Tensor,
@@ -251,11 +322,14 @@ def mega_moe_pre_dispatch(x: torch.Tensor,
                           buf_topk_weights: torch.Tensor,
                           num_tokens: int,
                           group_size: int = 32,
-                          use_fp4_acts: bool = False) -> None:
+                          mma_type: str = 'fp8xfp4',
+                          buf_x_scales: Optional[torch.Tensor] = None,
+                          expert_scales: Optional[torch.Tensor] = None) -> None:
     _C.mega_moe_pre_dispatch(
         x, topk_idx, topk_weights,
         buf_x, buf_x_sf, buf_topk_idx, buf_topk_weights,
-        num_tokens, group_size, use_fp4_acts,
+        num_tokens, group_size, mma_type,
+        buf_x_scales, expert_scales,
     )
 
 

--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -122,6 +122,45 @@ def per_token_cast_to_fp4(x: torch.Tensor, use_ue8m0: bool, gran_k: int = 128,
     return packed[:, :n // 2].contiguous(), sf
 
 
+def cast_to_ue4m3(x: torch.Tensor) -> torch.Tensor:
+    return x.to(torch.float8_e4m3fn).float()
+
+
+def pack_ue4m3_to_int(x: torch.Tensor) -> torch.Tensor:
+    """Pack 4 UE4M3 scaling factor bytes into one int32, matching the kernel's SF word."""
+    assert x.size(-1) % 4 == 0
+    return x.to(torch.float8_e4m3fn).contiguous().view(torch.uint8).view(torch.int)
+
+
+def unpack_ue4m3_from_int(packed_sf: torch.Tensor) -> torch.Tensor:
+    return packed_sf.view(torch.uint8).view(torch.float8_e4m3fn).float()
+
+
+def per_token_cast_to_nvfp4(x: torch.Tensor, gran_k: int = 16,
+                            use_packed_ue4m3: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+    """NVFP4: E2M1 values with one UE4M3 (not pow2 UE8M0) scaling factor per `gran_k` elements."""
+    m, n = x.shape
+    assert n % gran_k == 0
+    x_view = x.view(m, -1, gran_k)
+    sf = cast_to_ue4m3(x_view.abs().float().amax(dim=2) / 6.0)
+    sf_inv = torch.where(sf > 0, 1.0 / sf, torch.zeros_like(sf))
+    codes = _quantize_to_fp4_e2m1(x_view.float() * sf_inv.unsqueeze(2)).view(m, n)
+    codes2 = codes.view(m, n // 2, 2)
+    packed = (codes2[:, :, 0] & 0x0F) | ((codes2[:, :, 1] & 0x0F) << 4)
+    return packed.contiguous(), pack_ue4m3_to_int(sf) if use_packed_ue4m3 else sf
+
+
+def transform_ue4m3_sf_into_required_layout(sf: torch.Tensor, mn: int) -> torch.Tensor:
+    """MN-major, TMA-aligned, int32-packed UE4M3 SFs — the weight-side layout the kernel reads.
+
+    `transform_sf_into_required_layout` only knows how to pack UE8M0, so NVFP4 weight SFs are
+    packed here and handed to its already-packed `(INT, 1, gran_k)` branch.
+    """
+    assert sf.dim() in (2, 3) and sf.size(-2) == mn
+    assert mn % 4 == 0, f'MN must be TMA-aligned for int32 SFs, got {mn}'
+    return pack_ue4m3_to_int(sf).transpose(-1, -2).contiguous().transpose(-1, -2)
+
+
 def transpose_packed_fp4(a: torch.Tensor) -> torch.Tensor:
     assert a.dtype == torch.int8
     assert a.dim() == 2

--- a/sgl_deep_gemm/__init__.py
+++ b/sgl_deep_gemm/__init__.py
@@ -269,9 +269,11 @@ from .mega import (
     SymmBuffer,
     transform_weights_for_mega_moe,
     fp8_fp4_mega_moe,
+    nvfp4_mega_moe,
     bf16_mega_moe,
     mega_moe_pre_dispatch,
     mega_moe_pre_dispatch_sm90,
+    get_block_m_for_mega_moe,
 )
 
 

--- a/sgl_deep_gemm/run_tests.sh
+++ b/sgl_deep_gemm/run_tests.sh
@@ -156,6 +156,7 @@ MEGA_MOE_BLACKWELL=(
   test_mega_moe_situ.py
   test_mega_moe_l1_fp4_accuracy.py
   test_mega_moe_l1_sentinel.py
+  test_mega_moe_nvfp4_alphas.py
   test_mega_moe_pre_dispatch.py
 )
 MEGA_MOE_HOPPER=(

--- a/sgl_deep_gemm/tests/test_mega_moe.py
+++ b/sgl_deep_gemm/tests/test_mega_moe.py
@@ -7,7 +7,8 @@ import torch.distributed as dist
 from typing import Tuple
 
 import deep_gemm
-from deep_gemm.utils import per_token_cast_to_fp4, per_token_cast_to_fp8
+from deep_gemm.utils import (per_token_cast_to_fp4, per_token_cast_to_fp8, per_token_cast_to_nvfp4,
+                             transform_ue4m3_sf_into_required_layout)
 from deep_gemm.utils.dist import dist_print, init_dist, uneven_all_gather
 from deep_gemm.testing import bench_kineto
 
@@ -18,6 +19,7 @@ def import_baseline():
     # noinspection PyBroadException
     try:
         import deep_ep
+        assert hasattr(deep_ep, 'ElasticBuffer'), 'deep_ep has no ElasticBuffer (DeepEP v2 required)'
         import importlib.util
         from tilelang.profiler.bench import do_bench
         spec = importlib.util.spec_from_file_location(
@@ -42,6 +44,8 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
     # Settings
     is_bf16xbf16 = args.mma_type == 'bf16xbf16'
+    use_nvfp4 = args.mma_type == 'nvfp4xnvfp4'
+    gran_k = 16 if use_nvfp4 else 32
     num_max_tokens_per_rank = args.num_max_tokens_per_rank
     num_tokens = max(0, args.num_max_tokens_per_rank - random.randint(0, args.num_max_removed_tokens)) \
         if args.num_tokens == 0 else args.num_tokens
@@ -55,17 +59,22 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         group, num_experts,
         num_max_tokens_per_rank, num_topk,
         hidden, intermediate_hidden,
-        mma_type=args.mma_type
+        mma_type=args.mma_type,
+        activation=args.activation
     )
 
     # Cast weights into FP4
     def _cast_weights_to_fp4(bf16_weights: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         num_groups, n, k = bf16_weights.shape
         w = torch.empty((num_groups, n, k // 2), device='cuda', dtype=torch.int8)
-        w_sf = torch.empty((num_groups, n, k // 32), device='cuda', dtype=torch.float)
+        w_sf = torch.empty((num_groups, n, k // gran_k), device='cuda', dtype=torch.float)
         for i in range(num_groups):
-            w[i], w_sf[i] = per_token_cast_to_fp4(bf16_weights[i], use_ue8m0=True, gran_k=32)
-        w_sf = deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, 32), num_groups)
+            if use_nvfp4:
+                w[i], w_sf[i] = per_token_cast_to_nvfp4(bf16_weights[i], gran_k=gran_k)
+            else:
+                w[i], w_sf[i] = per_token_cast_to_fp4(bf16_weights[i], use_ue8m0=True, gran_k=gran_k)
+        w_sf = transform_ue4m3_sf_into_required_layout(w_sf, n) if use_nvfp4 else \
+            deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, gran_k), num_groups)
         return w, w_sf
 
     # Create inputs
@@ -96,7 +105,9 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             # Stream A0.0b: when the flag is on, the symm buffer's `x` slot is sized
             # for packed E2M1 (`hidden/2` bytes/token), so we must quantize at the
             # source to match.
-            if os.environ.get('DG_USE_FP4_ACTS', '0') != '0':
+            if use_nvfp4:
+                x = per_token_cast_to_nvfp4(x, gran_k=gran_k, use_packed_ue4m3=True)
+            elif args.mma_type == 'mxf4xmxf4':
                 x = per_token_cast_to_fp4(x, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
             else:
                 x = per_token_cast_to_fp8(x, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
@@ -105,7 +116,7 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             l2_weights = _cast_weights_to_fp4(l2_weights)
 
         transformed_l1_weights, transformed_l2_weights = (
-            deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights))
+            deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights, args.activation, args.mma_type))
 
     # Run fused mega MoE
     # NOTES: copy x into buffer before each call because debug mode zeros the entire buffer
@@ -123,8 +134,11 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             y=y, l1_weights=transformed_l1_weights, l2_weights=transformed_l2_weights,
             sym_buffer=buffer,
             cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats_fused,
-            activation_clamp=args.activation_clamp,
+            activation=args.activation,
+            activation_clamp=args.activation_clamp if args.activation != 'situ' else None,
             fast_math=bool(args.fast_math))
+        if not is_bf16xbf16:
+            kernel_kwargs['recipe'] = (1, 1, gran_k)
         (deep_gemm.bf16_mega_moe if is_bf16xbf16 else deep_gemm.fp8_fp4_mega_moe)(**kernel_kwargs)
         return y, cumulative_local_expert_recv_stats_fused
 
@@ -209,10 +223,14 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             # Combine
             return ep_buffer.combine(l2_y, handle=handle)[0], cumulative_local_expert_recv_stats_baseline
 
-    # Check correctness (must be bitwise identical)
+    # Check correctness (must be bitwise identical).
     num_correctness_tests = 1 if args.num_correctness_tests is None else args.num_correctness_tests
+    can_compare_bitwise = is_bf16xbf16 or args.mma_type == 'fp8xfp4'
+    if is_legacy_loaded and num_correctness_tests > 0 and not can_compare_bitwise:
+        dist_print(f'Skipping bitwise correctness vs legacy baseline (FP8-acts only, '
+                   f'undefined for `{args.mma_type}`)', once_in_node=True)
     # noinspection PyBroadException
-    if is_legacy_loaded and num_correctness_tests > 0:
+    if is_legacy_loaded and num_correctness_tests > 0 and can_compare_bitwise:
         dist_print('Running correctness tests:', once_in_node=True)
         for i in range(num_correctness_tests):
             create_inputs()
@@ -299,7 +317,10 @@ if __name__ == '__main__':
     parser.add_argument('--num-topk', type=int, default=6, help='Number of expert selections')
     parser.add_argument('--masked-ratio', type=float, default=0.0, help='Mask some expert selections')
     parser.add_argument('--fast-math', type=int, default=1, help='Enable fast math (0 or 1, default: 1)')
-    parser.add_argument('--mma-type', type=str, default='fp8xfp4', help='MMA type: fp8xfp4 or bf16xbf16')
+    parser.add_argument('--mma-type', type=str, default='fp8xfp4',
+                        choices=('fp8xfp4', 'mxf4xmxf4', 'nvfp4xnvfp4', 'bf16xbf16'), help='MMA type')
+    parser.add_argument('--activation', type=str, default='swiglu', choices=('swiglu', 'situ', 'swigluoai'),
+                        help='Activation: swiglu, situ, or swigluoai')
 
     # Test settings
     parser.add_argument('--num-correctness-tests', type=int, default=None, help='Pressure test')

--- a/sgl_deep_gemm/tests/test_mega_moe_l1_fp4_accuracy.py
+++ b/sgl_deep_gemm/tests/test_mega_moe_l1_fp4_accuracy.py
@@ -29,7 +29,8 @@ import torch.distributed as dist
 from typing import Tuple
 
 import deep_gemm
-from deep_gemm.utils import per_token_cast_to_fp8, per_token_cast_to_fp4
+from deep_gemm.utils import (per_token_cast_to_fp8, per_token_cast_to_fp4,
+                             per_token_cast_to_nvfp4, transform_ue4m3_sf_into_required_layout)
 from deep_gemm.utils.dist import dist_print, init_dist
 
 
@@ -69,6 +70,11 @@ def _decode_fp4_packed(packed_bytes: torch.Tensor) -> torch.Tensor:
 def _decode_fp8_e4m3(fp8_bytes: torch.Tensor) -> torch.Tensor:
     """Decode (M, N) int8 buffer of FP8 E4M3 to float32."""
     return fp8_bytes.view(torch.float8_e4m3fn).to(torch.float)
+
+
+def _decode_ue4m3(sf_bytes: torch.Tensor) -> torch.Tensor:
+    """Decode UE4M3 SF bytes (NVFP4) — same bit layout as unsigned `float8_e4m3fn`."""
+    return sf_bytes.to(torch.uint8).view(torch.float8_e4m3fn).float()
 
 
 def _decode_ue8m0(sf_bytes: torch.Tensor) -> torch.Tensor:
@@ -156,7 +162,8 @@ def _dequant_l1_acts_fp4(l2_acts_bytes: torch.Tensor,
                          intermediate_hidden: int,
                          num_padded_sf_pool_tokens: int,
                          valid_slots: int,
-                         gran_k: int = 32) -> torch.Tensor:
+                         gran_k: int = 16,
+                         use_ue4m3: bool = True) -> torch.Tensor:
     """Decode the FP4 L1 output bytes from the same symm buffer slot.
 
     Per A0.1's TMA descriptor: only the first `intermediate_hidden / 2` bytes
@@ -169,7 +176,7 @@ def _dequant_l1_acts_fp4(l2_acts_bytes: torch.Tensor,
     decoded = _decode_fp4_packed(raw_bytes)  # (V, I)
     sf = _decode_sf_buffer_to_per_token(
         l2_acts_sf_bytes, num_padded_sf_pool_tokens,
-        intermediate_hidden, valid_slots, gran_k)
+        intermediate_hidden, valid_slots, gran_k, use_ue4m3=use_ue4m3)
     n_blocks = intermediate_hidden // gran_k
     decoded = decoded.view(valid_slots, n_blocks, gran_k)
     sf = sf.view(valid_slots, n_blocks, 1)
@@ -180,7 +187,8 @@ def _decode_sf_buffer_to_per_token(sf_bytes_int32: torch.Tensor,
                                    num_padded_sf_pool_tokens: int,
                                    intermediate_hidden: int,
                                    valid_slots: int,
-                                   gran_k: int) -> torch.Tensor:
+                                   gran_k: int,
+                                   use_ue4m3: bool = False) -> torch.Tensor:
     """Read out per-token-K-block UE8M0 SF bytes from the M-major SF buffer.
 
     The SF buffer in the kernel uses an M-major / per-32-elements layout with a
@@ -220,7 +228,7 @@ def _decode_sf_buffer_to_per_token(sf_bytes_int32: torch.Tensor,
         # word at that token's k_uint slot.
         word = sf_bytes_int32[sf_pool_token_idx, k_uint_idx]   # int32 (V,)
         out[:, kb] = ((word >> (byte_idx * 8)) & 0xFF).to(torch.uint8)
-    return _decode_ue8m0(out)
+    return _decode_ue4m3(out) if use_ue4m3 else _decode_ue8m0(out)
 
 
 def _gather_l2_buffers(buffer):
@@ -255,24 +263,39 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         (num_experts_per_rank,), dtype=torch.int, device='cuda')
 
     # FP8 / FP4 quantizations needed by the kernel
+    fp4_mma_type = args.fp4_mma_type
+    fp4_is_nvfp4 = fp4_mma_type == 'nvfp4xnvfp4'
+    fp4_gran_k = 16 if fp4_is_nvfp4 else 32
     x_fp8 = per_token_cast_to_fp8(x_bf16, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
-    x_fp4 = per_token_cast_to_fp4(x_bf16, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
+    x_fp4 = per_token_cast_to_nvfp4(x_bf16, gran_k=16, use_packed_ue4m3=True) if fp4_is_nvfp4 \
+        else per_token_cast_to_fp4(x_bf16, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
 
-    def cast_grouped_weights_to_fp4(bf16_weights):
+    def cast_grouped_weights_to_fp4(bf16_weights, use_nvfp4: bool):
+        gran_k = 16 if use_nvfp4 else 32
         num_groups, n, k = bf16_weights.shape
         w = torch.empty((num_groups, n, k // 2), device='cuda', dtype=torch.int8)
-        w_sf = torch.empty((num_groups, n, k // 32), device='cuda', dtype=torch.float)
+        w_sf = torch.empty((num_groups, n, k // gran_k), device='cuda', dtype=torch.float)
         for i in range(num_groups):
-            w[i], w_sf[i] = per_token_cast_to_fp4(bf16_weights[i], use_ue8m0=True, gran_k=32)
-        w_sf = deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, 32), num_groups)
+            if use_nvfp4:
+                w[i], w_sf[i] = per_token_cast_to_nvfp4(bf16_weights[i], gran_k=gran_k)
+            else:
+                w[i], w_sf[i] = per_token_cast_to_fp4(bf16_weights[i], use_ue8m0=True, gran_k=gran_k)
+        w_sf = transform_ue4m3_sf_into_required_layout(w_sf, n) if use_nvfp4 else \
+            deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, gran_k), num_groups)
         return w, w_sf
 
-    l1_weights_fp4 = cast_grouped_weights_to_fp4(l1_weights_bf16)
-    l2_weights_fp4 = cast_grouped_weights_to_fp4(l2_weights_bf16)
-    transformed_l1_weights, transformed_l2_weights = \
-        deep_gemm.transform_weights_for_mega_moe(l1_weights_fp4, l2_weights_fp4)
+    def transform_weights(mma_type: str):
+        use_nvfp4 = mma_type == 'nvfp4xnvfp4'
+        return deep_gemm.transform_weights_for_mega_moe(
+            cast_grouped_weights_to_fp4(l1_weights_bf16, use_nvfp4),
+            cast_grouped_weights_to_fp4(l2_weights_bf16, use_nvfp4),
+            'swiglu', mma_type)
 
-    def run_once(buffer, x_src):
+    weights_per_arm = {False: transform_weights('fp8xfp4'),
+                       True: transform_weights(fp4_mma_type)}
+
+    def run_once(buffer, x_src, use_fp4_acts: bool = False):
+        transformed_l1_weights, transformed_l2_weights = weights_per_arm[use_fp4_acts]
         buffer.x[:num_tokens].copy_(x_src[0])
         buffer.x_sf[:num_tokens].copy_(x_src[1])
         buffer.topk_idx[:num_tokens].copy_(topk_idx)
@@ -284,19 +307,19 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             transformed_l1_weights, transformed_l2_weights,
             buffer,
             cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
+            recipe=(1, 1, fp4_gran_k) if use_fp4_acts else (1, 1, 32),
             activation_clamp=activation_clamp,
             fast_math=bool(args.fast_math)
         )
         return y, cumulative_local_expert_recv_stats.clone()
 
-    # Buffer layout depends on DG_USE_FP4_ACTS; set the env before allocating.
     def make_buffer(use_fp4_acts):
-        os.environ['DG_USE_FP4_ACTS'] = '1' if use_fp4_acts else '0'
         os.environ['DG_COMM_KERNEL_DEBUG'] = '0'  # don't zero buffer between calls
         return deep_gemm.get_symm_buffer_for_mega_moe(
             group, num_experts,
             num_max_tokens_per_rank, num_topk,
-            hidden, intermediate_hidden
+            hidden, intermediate_hidden,
+            mma_type=fp4_mma_type if use_fp4_acts else 'fp8xfp4'
         )
 
     # ---- BF16 reference for L1 SwiGLU output (per token×topk) ----
@@ -323,9 +346,9 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
     # ---- Run FP4 path (separate buffer, laid out for packed E2M1) ----
     buffer = make_buffer(use_fp4_acts=True)
-    _ = run_once(buffer, x_fp4)
+    _ = run_once(buffer, x_fp4, use_fp4_acts=True)
     torch.cuda.synchronize()
-    y_fp4, recv_stats_fp4 = run_once(buffer, x_fp4)
+    y_fp4, recv_stats_fp4 = run_once(buffer, x_fp4, use_fp4_acts=True)
     torch.cuda.synchronize()
     l2_acts_fp4 = buffer.l2_acts.clone()
     l2_acts_sf_fp4 = buffer.l2_acts_sf.clone()
@@ -417,7 +440,7 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     fp4_dec = _dequant_l1_acts_fp4(
         l2_acts_fp4, l2_acts_sf_fp4,
         intermediate_hidden, num_padded_sf_pool_tokens,
-        total_local)
+        total_local, gran_k=fp4_gran_k, use_ue4m3=fp4_is_nvfp4)
 
     # Sanity: dump a few raw bytes from each path so we can compare visually
     # if the harness misaligns.
@@ -488,6 +511,9 @@ if __name__ == '__main__':
     parser.add_argument('--num-topk', type=int, default=2)
     parser.add_argument('--activation-clamp', type=float, default=10.0)
     parser.add_argument('--fast-math', type=int, default=1)
+    parser.add_argument('--fp4-mma-type', type=str, default='nvfp4xnvfp4',
+                        choices=('nvfp4xnvfp4', 'mxf4xmxf4'),
+                        help='MMA type for the FP4-acts arm')
     args = parser.parse_args()
 
     num_processes = args.num_processes

--- a/sgl_deep_gemm/tests/test_mega_moe_l1_sentinel.py
+++ b/sgl_deep_gemm/tests/test_mega_moe_l1_sentinel.py
@@ -38,7 +38,8 @@ import torch
 import torch.distributed as dist
 
 import deep_gemm
-from deep_gemm.utils import per_token_cast_to_fp8, per_token_cast_to_fp4
+from deep_gemm.utils import (per_token_cast_to_fp8, per_token_cast_to_fp4,
+                             per_token_cast_to_nvfp4, transform_ue4m3_sf_into_required_layout)
 from deep_gemm.utils.dist import dist_print, init_dist
 
 
@@ -88,36 +89,49 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     scores = torch.randn((num_tokens, num_experts), dtype=torch.float, device='cuda')
     topk_weights, topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)
     cumulative = torch.zeros((num_experts_per_rank,), dtype=torch.int, device='cuda')
-    x_fp8 = per_token_cast_to_fp8(x_bf16, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
-    x_fp4 = per_token_cast_to_fp4(x_bf16, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
+    x_src_by_type = {
+        'fp8xfp4': per_token_cast_to_fp8(x_bf16, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True),
+        'nvfp4xnvfp4': per_token_cast_to_nvfp4(x_bf16, gran_k=16, use_packed_ue4m3=True),
+        'mxf4xmxf4': per_token_cast_to_fp4(x_bf16, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True),
+    }
 
-    def cast_grouped_weights_to_fp4(bf16_weights):
+    def cast_grouped_weights_to_fp4(bf16_weights, mma_type: str):
+        use_nvfp4 = mma_type == 'nvfp4xnvfp4'
+        gran_k = 16 if use_nvfp4 else 32
         num_groups, n, k = bf16_weights.shape
         w = torch.empty((num_groups, n, k // 2), device='cuda', dtype=torch.int8)
-        w_sf = torch.empty((num_groups, n, k // 32), device='cuda', dtype=torch.float)
+        w_sf = torch.empty((num_groups, n, k // gran_k), device='cuda', dtype=torch.float)
         for i in range(num_groups):
-            w[i], w_sf[i] = per_token_cast_to_fp4(bf16_weights[i], use_ue8m0=True, gran_k=32)
-        w_sf = deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, 32), num_groups)
+            if use_nvfp4:
+                w[i], w_sf[i] = per_token_cast_to_nvfp4(bf16_weights[i], gran_k=gran_k)
+            else:
+                w[i], w_sf[i] = per_token_cast_to_fp4(bf16_weights[i], use_ue8m0=True, gran_k=gran_k)
+        w_sf = transform_ue4m3_sf_into_required_layout(w_sf, n) if use_nvfp4 else \
+            deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, gran_k), num_groups)
         return w, w_sf
 
-    l1_weights_fp4 = cast_grouped_weights_to_fp4(l1_weights_bf16)
-    l2_weights_fp4 = cast_grouped_weights_to_fp4(l2_weights_bf16)
-    transformed_l1_weights, transformed_l2_weights = \
-        deep_gemm.transform_weights_for_mega_moe(l1_weights_fp4, l2_weights_fp4)
+    # Each arm quantizes weights to its own SF granularity: per-32 UE8M0 for
+    # `fp8xfp4`/`mxf4xmxf4`, per-16 UE4M3 for `nvfp4xnvfp4`.
+    def transform_weights(mma_type: str):
+        return deep_gemm.transform_weights_for_mega_moe(
+            cast_grouped_weights_to_fp4(l1_weights_bf16, mma_type),
+            cast_grouped_weights_to_fp4(l2_weights_bf16, mma_type),
+            'swiglu', mma_type)
 
-    # Stream A0.0b: under `DG_USE_FP4_ACTS=1`, the symm buffer's `x` slot is
-    # sized for packed E2M1 (`hidden/2` bytes/token) — different from FP8.
-    # Allocate the buffer separately for each path and feed it the matching
-    # source tensor.
-    def make_buffer_and_run(use_fp4_acts: bool):
-        os.environ['DG_USE_FP4_ACTS'] = '1' if use_fp4_acts else '0'
+    # FP4-acts kinds make the symm buffer's `x` slot packed E2M1 (`hidden/2`
+    # bytes/token), while `fp8xfp4` retains FP8 activations.
+    # Allocate the buffer separately for each path and feed it the matching source tensor.
+    def make_buffer_and_run(mma_type: str):
         os.environ['DG_COMM_KERNEL_DEBUG'] = '0'
         buf = deep_gemm.get_symm_buffer_for_mega_moe(
             group, num_experts,
             num_max_tokens_per_rank, num_topk,
-            hidden, intermediate_hidden
+            hidden, intermediate_hidden,
+            mma_type=mma_type
         )
-        x_src = x_fp4 if use_fp4_acts else x_fp8
+        x_src = x_src_by_type[mma_type]
+        transformed_l1_weights, transformed_l2_weights = transform_weights(mma_type)
+        recipe = (1, 1, 16) if mma_type == 'nvfp4xnvfp4' else (1, 1, 32)
 
         def run_once():
             buf.x[:num_tokens].copy_(x_src[0])
@@ -129,6 +143,7 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             deep_gemm.fp8_fp4_mega_moe(
                 y, transformed_l1_weights, transformed_l2_weights, buf,
                 cumulative_local_expert_recv_stats=cumulative,
+                recipe=recipe,
                 activation_clamp=activation_clamp,
                 fast_math=bool(args.fast_math)
             )
@@ -141,47 +156,48 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         buf.destroy()
         return y_out
 
-    # Run FP8-acts first (warmup + measurement).
-    y_fp8 = make_buffer_and_run(use_fp4_acts=False)
-    # Run FP4-acts (separate buffer because the `x` slot footprint changes).
-    y_fp4 = make_buffer_and_run(use_fp4_acts=True)
-
-    # End-to-end y comparison: this is the source of truth (no slot
-    # permutation ambiguity since y is indexed by global (token, hidden)).
-    y_diff = (y_fp4.float() - y_fp8.float()).abs()
-    y_rmse = y_diff.pow(2).mean().sqrt().item()
+    # Run FP8-acts first (warmup + measurement), then each FP4-acts kind
+    # (separate buffers because the `x` slot footprint changes).
+    y_fp8 = make_buffer_and_run('fp8xfp4')
     y_fp8_rms = y_fp8.float().pow(2).mean().sqrt().item()
-    rel_rmse = y_rmse / max(y_fp8_rms, 1e-12)
-
-    dist_print(f'=== A0.2.1 sentinel — y rel-RMSE (FP4 vs FP8 acts) ===',
-               once_in_node=True)
-    dist_print(f'  y_fp8 RMS:        {y_fp8_rms:.4f}', once_in_node=True)
-    dist_print(f'  y_rmse:           {y_rmse:.4f}', once_in_node=True)
-    dist_print(f'  rel-RMSE:         {rel_rmse:.4f}', once_in_node=True)
-    max_rel_rmse = args.max_rel_rmse
     y_fp8_mag = y_fp8.float().abs().mean().item()
-    y_fp4_mag = y_fp4.float().abs().mean().item()
+    max_rel_rmse = args.max_rel_rmse
 
-    dist_print(f'  y_fp8 mean|.|:    {y_fp8_mag:.4f}', once_in_node=True)
-    dist_print(f'  y_fp4 mean|.|:    {y_fp4_mag:.4f}', once_in_node=True)
-    dist_print(f'  target:           <= {max_rel_rmse:.2f} (layout sentinel)',
-               once_in_node=True)
-    dist_print(f'  verdict:          {"PASS" if rel_rmse <= max_rel_rmse else "FAIL"}',
-               once_in_node=True)
+    for mma_type in ('nvfp4xnvfp4', 'mxf4xmxf4'):
+        y_fp4 = make_buffer_and_run(mma_type)
 
-    # Spot-check first row to make the failure mode legible if it ever
-    # comes back: matched values at low N indices = layout correct;
-    # garbage = layout broken.
-    dist_print(f'\n  y_fp8 [0, :8]:  {y_fp8[0, :8].cpu().tolist()}',
-               once_in_node=True)
-    dist_print(f'  y_fp4 [0, :8]:  {y_fp4[0, :8].cpu().tolist()}',
-               once_in_node=True)
+        # End-to-end y comparison: this is the source of truth (no slot
+        # permutation ambiguity since y is indexed by global (token, hidden)).
+        y_diff = (y_fp4.float() - y_fp8.float()).abs()
+        y_rmse = y_diff.pow(2).mean().sqrt().item()
+        rel_rmse = y_rmse / max(y_fp8_rms, 1e-12)
+        y_fp4_mag = y_fp4.float().abs().mean().item()
 
-    assert torch.isfinite(y_fp4).all(), 'FP4 output contains NaN/Inf'
-    assert y_fp8_mag * 0.5 < y_fp4_mag < y_fp8_mag * 2.0, \
-        f'FP4 magnitude miscalibrated: |y_fp4|={y_fp4_mag} vs |y_fp8|={y_fp8_mag}'
-    assert rel_rmse <= max_rel_rmse, \
-        f'A0.2.1 layout regression: y rel-RMSE {rel_rmse:.4f} > {max_rel_rmse:.2f}'
+        dist_print(f'=== A0.2.1 sentinel — y rel-RMSE ({mma_type} vs FP8 acts) ===',
+                   once_in_node=True)
+        dist_print(f'  y_fp8 RMS:        {y_fp8_rms:.4f}', once_in_node=True)
+        dist_print(f'  y_rmse:           {y_rmse:.4f}', once_in_node=True)
+        dist_print(f'  rel-RMSE:         {rel_rmse:.4f}', once_in_node=True)
+        dist_print(f'  y_fp8 mean|.|:    {y_fp8_mag:.4f}', once_in_node=True)
+        dist_print(f'  y_fp4 mean|.|:    {y_fp4_mag:.4f}', once_in_node=True)
+        dist_print(f'  target:           <= {max_rel_rmse:.2f} (layout sentinel)',
+                   once_in_node=True)
+        dist_print(f'  verdict:          {"PASS" if rel_rmse <= max_rel_rmse else "FAIL"}',
+                   once_in_node=True)
+
+        # Spot-check first row to make the failure mode legible if it ever
+        # comes back: matched values at low N indices = layout correct;
+        # garbage = layout broken.
+        dist_print(f'\n  y_fp8 [0, :8]:  {y_fp8[0, :8].cpu().tolist()}',
+                   once_in_node=True)
+        dist_print(f'  y_fp4 [0, :8]:  {y_fp4[0, :8].cpu().tolist()}',
+                   once_in_node=True)
+
+        assert torch.isfinite(y_fp4).all(), f'{mma_type} output contains NaN/Inf'
+        assert y_fp8_mag * 0.5 < y_fp4_mag < y_fp8_mag * 2.0, \
+            f'{mma_type} magnitude miscalibrated: |y_fp4|={y_fp4_mag} vs |y_fp8|={y_fp8_mag}'
+        assert rel_rmse <= max_rel_rmse, \
+            f'A0.2.1 layout regression ({mma_type}): y rel-RMSE {rel_rmse:.4f} > {max_rel_rmse:.2f}'
 
     dist.barrier()
     dist.destroy_process_group()

--- a/sgl_deep_gemm/tests/test_mega_moe_nvfp4_alphas.py
+++ b/sgl_deep_gemm/tests/test_mega_moe_nvfp4_alphas.py
@@ -1,0 +1,248 @@
+# NVFP4 outer-scale (global scale) plumbing for the mega-MoE kernel.
+#
+# Four tables carry the NVFP4 dequant alphas:
+#
+#   x_scales      per token, written by `mega_moe_pre_dispatch` (1 / gs_x1)
+#   l1_alphas     [num_LOCAL_experts, 2] = 1 / (gs_w1, gs_w3), on the L1 accum
+#   l2_alphas     [num_LOCAL_experts]    = 1 / gs_w2,          on the L2 accum
+#   expert_scales [num_GLOBAL_experts]   folded into the topk weight, O(1) only
+#
+# The fc2 alpha is deliberately NOT routed through `expert_scales`: that lands on
+# the L1 output, which is then re-quantized to NVFP4 with a bare per-block E4M3
+# SF, and a realistic `1 / gs_w2` (~1e-4) sinks that SF under E4M3's subnormal
+# floor — `y` comes back all zeros (measured). `expert_scales` is exercised
+# separately below with an O(1) ratio, which is all it can carry.
+#
+# Method: quantize the same BF16 weights twice — once with gs = 1 and no alphas,
+# once with per-expert gs and the alphas that undo it — and compare `y`.
+#   - Power-of-two gs: every scaling is exact in FP32/E4M3, so the two runs must
+#     be BITWISE equal.
+#   - Realistic gs (= 448*6/amax, not powers of two): the two encodings round
+#     differently, so this arm is only a sanity band — measured 0.18 rel-L2 on
+#     `y`, which is what two independent NVFP4 encodings cost (7.7% apart on the
+#     weights alone, over two GEMMs). Its job is to show realistic gs magnitudes
+#     neither saturate the E4M3 SF nor zero it, not to catch subtle bugs; the
+#     pow2 arm and the roll controls are the sharp instruments here.
+#   - Control: rolling either alpha table by one expert must change `y`,
+#     otherwise the test would pass on a kernel that ignores the table.
+#
+# Run with >= 2 ranks: local- vs global-expert index confusion only shows up on
+# a rank whose `expert_lo` is nonzero.
+#
+# Usage:
+#   PYTHONPATH=/workspace/chunan/DeepGEMM CUDA_VISIBLE_DEVICES=4,5 MASTER_PORT=29511 \
+#       python3 sgl_deep_gemm/tests/test_mega_moe_nvfp4_alphas.py --num-processes 2
+
+import argparse
+import sys
+import torch
+import torch.distributed as dist
+
+import deep_gemm
+from deep_gemm.utils import cast_to_ue4m3, transform_ue4m3_sf_into_required_layout
+from deep_gemm.utils.math import _quantize_to_fp4_e2m1
+from deep_gemm.utils.dist import dist_print, init_dist
+
+GRAN_K = 16
+E4M3_MAX = 448.0
+FP4_MAX = 6.0
+
+
+def cast_to_nvfp4_with_gs(w: torch.Tensor, gs) -> tuple:
+    """NVFP4 with an outer scale. Dequant contract: `w ~= fp4 * sf / gs`.
+
+    `gs` is a scalar or a per-row (m,) tensor — the L1 weight carries gs_w1 on
+    its gate rows and gs_w3 on its up rows. `gs = 1` reproduces
+    `per_token_cast_to_nvfp4` exactly.
+    """
+    m, n = w.shape
+    v = w.view(m, -1, GRAN_K).float()
+    gs = torch.as_tensor(gs, dtype=torch.float, device=w.device).reshape(-1, 1).expand(m, 1)
+    sf = cast_to_ue4m3(v.abs().amax(dim=2) * (gs / FP4_MAX))
+    scale = torch.where(sf > 0, gs / sf, torch.zeros_like(sf))
+    codes = _quantize_to_fp4_e2m1(v * scale.unsqueeze(2)).view(m, n)
+    codes2 = codes.view(m, n // 2, 2)
+    packed = (codes2[:, :, 0] & 0x0F) | ((codes2[:, :, 1] & 0x0F) << 4)
+    return packed.contiguous(), sf
+
+
+def cast_grouped(w: torch.Tensor, gs_rows) -> tuple:
+    """`w` is (E, N, K) BF16; `gs_rows` is one per-row gs tensor per expert."""
+    num_experts, n, k = w.shape
+    packed = torch.empty((num_experts, n, k // 2), dtype=torch.int8, device=w.device)
+    sf = torch.empty((num_experts, n, k // GRAN_K), dtype=torch.float, device=w.device)
+    for e in range(num_experts):
+        packed[e], sf[e] = cast_to_nvfp4_with_gs(w[e], gs_rows[e])
+    return packed, transform_ue4m3_sf_into_required_layout(sf, n)
+
+
+def make_gs(amax_per_expert: torch.Tensor, pow2: bool) -> torch.Tensor:
+    """Realistic NVFP4 global scale, `448 * 6 / amax`, optionally snapped to a
+    power of two so the two runs stay bitwise comparable.
+
+    Same-shaped random weights have near-identical amax, so the pow2 arm would
+    otherwise hand every expert the same scale and the roll-by-one control would
+    be vacuous. Spread it downwards per expert — never up, `gs > 448*6/amax`
+    saturates the E4M3 SF.
+    """
+    gs = (E4M3_MAX * FP4_MAX) / amax_per_expert.clamp_min(1e-4)
+    if not pow2:
+        return gs
+    spread = torch.pow(2.0, -(torch.arange(gs.numel(), device=gs.device) % 4).float())
+    return torch.pow(2.0, torch.floor(torch.log2(gs))) * spread
+
+
+# noinspection PyUnboundLocalVariable
+def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank_idx, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    torch.manual_seed(1000 + rank_idx)
+
+    num_tokens = args.num_tokens
+    hidden, inter = args.hidden, args.intermediate_hidden
+    num_experts, num_topk = args.num_experts, args.num_topk
+    num_local_experts = num_experts // num_ranks
+    expert_lo = rank_idx * num_local_experts
+
+    buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+        group, num_experts, args.num_max_tokens_per_rank, num_topk,
+        hidden, inter, mma_type='nvfp4xnvfp4')
+
+    # `x` is damped so the L1 output amax stays under the L2 activation SF's
+    # 448*6 ceiling; weights stay unit-variance so their own block SFs stay in
+    # E4M3's normal range in BOTH runs (a gs=1 encoding of small weights lands on
+    # E4M3 subnormals, where power-of-two rescaling is no longer exact).
+    x = (torch.randn((num_tokens, hidden), device='cuda') * args.x_scale).bfloat16()
+    scores = torch.randn((num_tokens, num_experts), dtype=torch.float, device='cuda')
+    topk_weights, topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)
+    topk_idx = topk_idx.int()
+
+    # Weights are local, but a GLOBAL table (`expert_scales`) has to know every
+    # rank's values. Draw all experts from a shared seed and keep the local
+    # slice, so the global tables agree across ranks.
+    torch.manual_seed(7)
+    l1_all = torch.randn((num_experts, inter * 2, hidden), dtype=torch.bfloat16, device='cuda')
+    l2_all = torch.randn((num_experts, hidden, inter), dtype=torch.bfloat16, device='cuda')
+    gate_amax = l1_all[:, :inter].abs().float().amax(dim=(1, 2))
+    up_amax = l1_all[:, inter:].abs().float().amax(dim=(1, 2))
+    l2_amax = l2_all.abs().float().amax(dim=(1, 2))
+    l1_local = l1_all[expert_lo:expert_lo + num_local_experts].contiguous()
+    l2_local = l2_all[expert_lo:expert_lo + num_local_experts].contiguous()
+    del l1_all, l2_all
+
+    base_w = deep_gemm.transform_weights_for_mega_moe(
+        cast_grouped(l1_local, [torch.ones(inter * 2, device='cuda')] * num_local_experts),
+        cast_grouped(l2_local, [torch.ones(hidden, device='cuda')] * num_local_experts),
+        'swiglu', 'nvfp4xnvfp4')
+
+    def run(weights, l1_alphas=None, l2_alphas=None, expert_scales=None, tw=None,
+            l2_act_scales=None):
+        deep_gemm.mega_moe_pre_dispatch(
+            x, topk_idx, topk_weights if tw is None else tw,
+            buffer.x, buffer.x_sf, buffer.topk_idx, buffer.topk_weights,
+            num_tokens=num_tokens, group_size=GRAN_K, mma_type='nvfp4xnvfp4',
+            buf_x_scales=buffer.x_scales, expert_scales=expert_scales)
+        y = torch.empty((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
+        deep_gemm.fp8_fp4_mega_moe(
+            y=y, l1_weights=weights[0], l2_weights=weights[1], sym_buffer=buffer,
+            recipe=(1, 1, GRAN_K), activation='swiglu', fast_math=bool(args.fast_math),
+            # The NVFP4 wrapper must select per-token x scales by default.
+            l1_alphas=l1_alphas, l2_alphas=l2_alphas,
+            l2_act_scales=l2_act_scales)
+        dist.barrier()
+        torch.cuda.synchronize()
+        return y
+
+    y_base = run(base_w)
+    dist_print(f'Config: {num_ranks} ranks x {num_local_experts} local experts, '
+               f'{num_tokens} tokens, hidden={hidden}, inter={inter}, '
+               f'|y_base| mean {y_base.float().abs().mean().item():.4g}', once_in_node=True)
+
+    for pow2 in (True, False):
+        gs_w1, gs_w3, gs_w2 = (make_gs(a, pow2) for a in (gate_amax, up_amax, l2_amax))
+        scaled = deep_gemm.transform_weights_for_mega_moe(
+            cast_grouped(l1_local, [torch.cat([gs_w1[expert_lo + e].expand(inter),
+                                               gs_w3[expert_lo + e].expand(inter)])
+                                    for e in range(num_local_experts)]),
+            cast_grouped(l2_local, [gs_w2[expert_lo + e].expand(hidden)
+                                    for e in range(num_local_experts)]),
+            'swiglu', 'nvfp4xnvfp4')
+
+        # Both LOCAL index space; `l1_alphas` columns are (gate, up).
+        local = slice(expert_lo, expert_lo + num_local_experts)
+        l1_alphas = torch.stack([1.0 / gs_w1[local], 1.0 / gs_w3[local]], dim=1).contiguous()
+        l2_alphas = (1.0 / gs_w2[local]).contiguous()
+
+        y_scaled = run(scaled, l1_alphas, l2_alphas)
+        tag = 'pow2' if pow2 else 'realistic'
+        if pow2:
+            assert torch.equal(y_base, y_scaled), \
+                f'[{tag}] power-of-two global scales must cancel bitwise, max |delta| = ' \
+                f'{(y_base.float() - y_scaled.float()).abs().max().item():.3e}'
+            dist_print(f' > [{tag}] gs_w2 = {gs_w2.tolist()} — bitwise equal', once_in_node=True)
+        else:
+            rel = ((y_scaled.float() - y_base.float()).norm() / y_base.float().norm()).item()
+            assert rel < args.rel_tol, f'[{tag}] rel-L2 {rel:.4f} >= {args.rel_tol}'
+            dist_print(f' > [{tag}] rel-L2 = {rel:.5f} (< {args.rel_tol})', once_in_node=True)
+
+        for name, wrong in (('l1_alphas', (l1_alphas.roll(1, dims=0).contiguous(), l2_alphas)),
+                            ('l2_alphas', (l1_alphas, l2_alphas.roll(1).contiguous()))):
+            assert not torch.equal(y_scaled, run(scaled, *wrong)), \
+                f'[{tag}] rolling `{name}` changed nothing — the kernel ignores it'
+        dist_print(f' > [{tag}] roll-by-one control: both tables have teeth', once_in_node=True)
+
+    # `l2_act_scales` (LOCAL index): pow2 fc2 input gs is cancelled by `1/gs`
+    # in `l2_alphas`. Damp x so the scaled block SFs stay under E4M3's 448
+    # satfinite ceiling. Exact pow2 invariance still breaks for blocks whose SF
+    # lands in E4M3's SUBNORMAL range (absolute 2**-9 grid, not scale
+    # invariant): a re-rounded SF moves single FP4 codes, perturbing outputs by
+    # at most ~1 BF16 ulp of the tensor scale. Bound accordingly, not bitwise.
+    x = (x.float() * 0.25).bfloat16()
+    y_damped = run(base_w)
+    gs_in = torch.pow(2.0, (torch.arange(num_local_experts, device='cuda',
+                                         dtype=torch.float) % 3))
+    y_gs = run(base_w, l2_alphas=(1.0 / gs_in).contiguous(),
+               l2_act_scales=gs_in.contiguous())
+    d = (y_gs.float() - y_damped.float()).abs()
+    tol = torch.finfo(torch.bfloat16).eps * y_damped.float().abs().max()
+    rel = (d.norm() / y_damped.float().norm()).item()
+    assert d.max() <= tol and rel < 1e-3, \
+        f'l2_act_scales cancellation off: max |d| {d.max().item():.3e} ' \
+        f'(tol {tol.item():.3e}), rel-L2 {rel:.3e}'
+    assert not torch.equal(y_damped, run(base_w, l2_act_scales=gs_in.contiguous())), \
+        'l2_act_scales alone changed nothing -- the kernel ignores it'
+    dist_print(f' > l2_act_scales: pow2 gs cancels to 1 tensor-scale ulp '
+               f'(max |d| {d.max().item():.2e}, rel {rel:.1e}), teeth ok',
+               once_in_node=True)
+
+    # `expert_scales`, GLOBAL index space: folding an O(1) per-expert ratio in the
+    # kernel must equal folding it into `topk_weights` on the host. Bitwise —
+    # both are the same FP32 multiply, so this pins the index space exactly.
+    ratios = (1.0 + 0.25 * torch.arange(num_experts, device='cuda', dtype=torch.float)
+              / num_experts).contiguous()
+    host_tw = topk_weights * torch.where(topk_idx >= 0, ratios[topk_idx.long().clamp_min(0)], 1.0)
+    assert torch.equal(run(base_w, expert_scales=ratios), run(base_w, tw=host_tw)), \
+        '`expert_scales` does not match a host-side fold — check the global expert index'
+    dist_print(' > expert_scales: matches a host-side topk_weights fold', once_in_node=True)
+
+    dist_print('OK', once_in_node=True)
+    dist.barrier()
+    buffer.destroy()
+    dist.destroy_process_group()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--num-processes', type=int, default=2)
+    parser.add_argument('--num-max-tokens-per-rank', type=int, default=1024)
+    parser.add_argument('--num-tokens', type=int, default=1024)
+    parser.add_argument('--hidden', type=int, default=1024)
+    parser.add_argument('--intermediate-hidden', type=int, default=512)
+    parser.add_argument('--num-experts', type=int, default=8)
+    parser.add_argument('--num-topk', type=int, default=2)
+    parser.add_argument('--x-scale', type=float, default=0.1)
+    parser.add_argument('--fast-math', type=int, default=1)
+    parser.add_argument('--rel-tol', type=float, default=0.30)
+    args = parser.parse_args()
+    assert args.num_experts % args.num_processes == 0
+    torch.multiprocessing.spawn(test, args=(args.num_processes, args), nprocs=args.num_processes)
+    sys.exit(0)

--- a/sgl_deep_gemm/tests/test_mega_moe_pre_dispatch.py
+++ b/sgl_deep_gemm/tests/test_mega_moe_pre_dispatch.py
@@ -57,7 +57,8 @@ def _run_one(use_fp4_acts: bool, args: argparse.Namespace) -> None:
     deep_gemm.mega_moe_pre_dispatch(
         x, topk_idx, topk_weights,
         buf_x, buf_x_sf, buf_topk_idx, buf_topk_weights,
-        num_tokens=M, group_size=G, use_fp4_acts=use_fp4_acts,
+        num_tokens=M, group_size=G,
+        mma_type='mxf4xmxf4' if use_fp4_acts else 'fp8xfp4',
     )
     torch.cuda.synchronize()
 

--- a/sgl_deep_gemm/tests/test_mega_moe_situ.py
+++ b/sgl_deep_gemm/tests/test_mega_moe_situ.py
@@ -135,13 +135,13 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     assert len(kernel_sources) == 2
     assert any(
         re.search(
-            r"cute::numeric_limits<float>::infinity\(\),\s+true,\s+true,",
+            r"cute::numeric_limits<float>::infinity\(\),\s+0x0p[+-]\d+f,\s+true,\s+true",
             source,
         )
         for source in kernel_sources
     ), "explicit SiTU did not instantiate kUseSitu=true"
     assert any(
-        re.search(r"0x1p-5f,\s+false,\s+true,", source) for source in kernel_sources
+        re.search(r"0x1p-5f,\s+0x0p[+-]\d+f,\s+false,\s+true", source) for source in kernel_sources
     ), "activation_clamp=0.03125 still instantiated kUseSitu=true"
 
     try:

--- a/tests/test_mega_moe.py
+++ b/tests/test_mega_moe.py
@@ -145,7 +145,10 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             # Cast inputs to FP8/FP4 with per-32 UE8M0 SF. FP4 activations
             # remain routed-expert-only; shared experts retain upstream FP8.
             assert hidden % 128 == 0 and intermediate_hidden % 128 == 0 and shared_intermediate_hidden % 128 == 0
-            use_fp4_acts = (os.environ.get('DG_USE_FP4_ACTS', '0') != '0'
+            # FP4 activations are selected by the buffer's `mma_type`
+            # (`mxf4xmxf4` / `nvfp4xnvfp4`), not by an env var, and remain a
+            # routed-expert-only path.
+            use_fp4_acts = (args.mma_type in ('mxf4xmxf4', 'nvfp4xnvfp4')
                             and num_shared_experts == 0)
             if use_fp4_acts:
                 x = per_token_cast_to_fp4(x, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
@@ -165,8 +168,12 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                 shared_l1_weights = _cast_fp8_for_mega_moe(shared_l1_weights)[0::2]
                 shared_l2_weights = _cast_fp8_for_mega_moe(shared_l2_weights)[0::2]
 
+        # NOTES: the routed weights must be interleaved for the buffer's own MMA kind
+        # (the FP4 kinds need the packed gate/up interleave); the shared-expert weights
+        # stay FP8 and therefore keep the default `fp8xfp4` interleave.
         transformed_l1_weights, transformed_l2_weights = (
-            deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights))
+            deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights,
+                                                     mma_type=args.mma_type))
         if num_shared_experts > 0:
             transformed_shared_l1_weights, transformed_shared_l2_weights = (
                 deep_gemm.transform_weights_for_mega_moe(shared_l1_weights, shared_l2_weights))


### PR DESCRIPTION
## Added

**`nvfp4xnvfp4` MMA kind.** A third kind alongside `fp8xfp4` and `mxf4xmxf4`. Reuses the dense FP4 operand layout and changes only the block-scale grid — UE4M3 per 16 elements instead of UE8M0 per 32.

**NVFP4 outer scales.** The dynamic range needs scales the other kinds don't carry:
- per-token FP32 input scales applied to the L1 (fc13) accumulator
- per-expert `l1_alphas` (gate, up) and `l2_alphas` weight global scales
- per-expert `l2_act_scales` for the fc2 input

**NVFP4 mode in `mega_moe_pre_dispatch`.** Takes `mma_type` plus optional `buf_x_scales` / `expert_scales`, replacing the `use_fp4_acts` boolean.

**`get_block_m_for_mega_moe`** exported to Python. Callers laying out shared-expert activation SFs need the kernel's chosen `BLOCK_M`; only the raw tvm-ffi symbol existed, so `deep_gemm.get_block_m_for_mega_moe` raised `AttributeError`.

## Refactored

**MMA kind now comes from the symmetric buffer's `mma_type`, not the recipe's K granularity.** The buffer's activation slots are sized for the kind it was allocated with, so deriving the kind anywhere else lets the two disagree; the recipe is cross-checked against it instead. Unimplemented and mismatched combinations fail by name rather than tripping an opaque byte-count assertion.

This replaces the `DG_USE_FP4_ACTS` / `DG_USE_MXF4_KIND` environment switches, which selected the same behaviour without the buffer agreeing. One combination they could express is no longer selectable: FP4 activations on the `mxf8f6f4` kind — same numerics, different instruction path, covered by `mxf4xmxf4`.

**Buffer and block sizing are byte-denominated.** `MegaMoEBuffer` sizes activation slots from `get_element_bits(mma_kind)` instead of a per-kind flag, and the block heuristic scales `BLOCK_K` so `BLOCK_K_BYTES` is kind-independent. `kSwizzleAMode` is a fixed 128 B atom and `tma::copy` tiles `BLOCK_K_BYTES / 128` atoms per row, which removes the `min(block_k, 128)` clamp and the `use_mxf4_kind` block-config special case.

**SM100 FP8/FP4 kernel rebased onto the upstream SharedStorage implementation.** `kUseFullPoolFP8FP4Path` / `kRingCoversFullPool` and `DG_USE_FP8_COMBINE` are reimplemented on top of it; both are verified below. `DG_USE_FP8_COMBINE` remains off by default.

## Tests

All on 8×B300, 2 ranks, `sgl_deep_gemm/tests` unless noted.

| test | result |
|---|---|
| `test_mega_moe_nvfp4_alphas.py` | pow2 global scales cancel bitwise; realistic rel-L2 **0.18253** (tol 0.30); `l1_alphas`/`l2_alphas`/`l2_act_scales` roll-by-one controls all have teeth |
| same, `DG_USE_FP8_COMBINE=1` | rel-L2 **0.18627** |
| `mxf4xmxf4` vs `fp8xfp4` control, identical inputs | rel-L2 **0.211** |
| `nvfp4xnvfp4` vs `fp8xfp4` control, identical inputs | rel-L2 **0.467** |
| activations `swiglu` / `swigluoai` / `situ` | all finite and non-zero, each differs from `swiglu` |
| same, with 1 shared expert | all pass; `\|y\|` 1859 → 2175 |
| `test_mega_moe_pre_dispatch.py --dtype both` | FP8 and FP4 bytewise equal vs host helper, pad-fill correct |
| `test_attention.py` (`DG_MQA_NUM_CASES=24`) | pass, both prefill and paged MQA sections |
| block regimes | normal (`BLOCK_M=192`) and small (`BLOCK_M=16`, `BLOCK_K_BYTES=256`) pass for all three kinds |

**Full-pool path equivalence.** `kUseFullPoolFP8FP4Path` is a synchronization change, so output must be unchanged. Dumped `y` for `fp8xfp4` under both implementations at the shape where the gate arms (`BLOCK_K == BLOCK_N == 128`, ring == pool == 138240 tokens, no shared experts, `L2_SHAPE_K/BLOCK_K = 24 ≤ 32`):

```
rank0: bitwise_equal=True  maxdiff=0
rank1: bitwise_equal=True  maxdiff=0
```

Same at 1024 tokens/rank, where the ring wraps and the path is off.

## Bench

`fp8xfp4` prefill, 8192 tokens/rank, hidden 7168, intermediate 3072, 384 experts, top-6, 2 ranks. Both builds measured in the same session:

| | EP 0 | EP 1 |
|---|---|---|
| before | 2569 TFLOPS | 2541 TFLOPS |
| after | 2570 TFLOPS | 2547 TFLOPS |

Unchanged, as intended — the full-pool fast path was confirmed armed in the benched kernel, and showed no measurable gain at 2 ranks.

## Not covered

`tests/test_mega_moe.py` follows the upstream version and does not carry shared-expert arms; that coverage lives in the probes above. SM90 and SM120 paths are untouched by this change and were not re-run — every `sm90`, `sm120`, `mqa_logits`, `attention` and `w4a4` file is byte-identical to `dev`.
