### PR TITLE
fix and add cache hint

### DIFF
--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -221,7 +221,7 @@ static void fp8_fp4_mega_moe(
         DG_HOST_UNREACHABLE("recipe K granularity " + std::to_string(rk) + " does not match `" +
                             mma_type + "` (expected " +
                             std::to_string(get_sf_gran_k(mma_kind)) + ")");
-    DG_HOST_ASSERT(use_x_scales == (mma_kind == MmaKind::NVFP4));
+    DG_HOST_ASSERT(not use_x_scales or mma_kind == MmaKind::NVFP4);
     DG_HOST_ASSERT(activation == "swiglu" or activation == "swigluoai" or
                    (mma_kind == MmaKind::MXFP8FP4 and activation == "situ"));
     DG_HOST_ASSERT(activation != "situ" or not activation_clamp_opt.has_value());

--- a/deep_gemm/include/deep_gemm/common/tma_copy.cuh
+++ b/deep_gemm/include/deep_gemm/common/tma_copy.cuh
@@ -19,7 +19,8 @@ template <uint32_t BLOCK_INNER, uint32_t BLOCK_OUTER,
 CUTLASS_DEVICE void
 copy(void const* desc_ptr, cutlass::arch::ClusterTransactionBarrier* barrier_ptr,
      dtype_t* smem_ptr, const uint32_t& inner_idx, const uint32_t& outer_idx,
-     const uint32_t& num_tma_multicast = 1, const uint32_t& batch_idx = 0) {
+     const uint32_t& num_tma_multicast = 1, const uint32_t& batch_idx = 0,
+     const uint64_t& cache_hint = static_cast<uint64_t>(cute::TMA::CacheHintSm100::EVICT_NORMAL)) {
     DG_STATIC_ASSERT(static_cast<uint64_t>(cute::TMA::CacheHintSm90::EVICT_NORMAL) ==
                      static_cast<uint64_t>(cute::TMA::CacheHintSm100::EVICT_NORMAL), "Invalid cache hint");
     constexpr uint32_t BLOCK_INNER_ATOM = get_inner_block_atom_size<BLOCK_INNER, kSwizzleMode, dtype_t>();
@@ -29,7 +30,7 @@ copy(void const* desc_ptr, cutlass::arch::ClusterTransactionBarrier* barrier_ptr
             #pragma unroll
             for (uint32_t i = 0; i < BLOCK_INNER / BLOCK_INNER_ATOM; ++ i) {
                 cute::SM90_TMA_LOAD_2D::copy(desc_ptr, reinterpret_cast<uint64_t*>(barrier_ptr),
-                                             static_cast<uint64_t>(cute::TMA::CacheHintSm100::EVICT_NORMAL),
+                                             cache_hint,
                                              smem_ptr + i * BLOCK_OUTER * BLOCK_INNER_ATOM,
                                              inner_idx + i * BLOCK_INNER_ATOM, outer_idx);
             }
@@ -39,7 +40,7 @@ copy(void const* desc_ptr, cutlass::arch::ClusterTransactionBarrier* barrier_ptr
                 #pragma unroll
                 for (uint32_t i = 0; i < BLOCK_INNER / BLOCK_INNER_ATOM; ++ i) {
                     cute::SM100_TMA_2SM_LOAD_2D::copy(desc_ptr, reinterpret_cast<uint64_t*>(barrier_ptr),
-                                                      static_cast<uint64_t>(cute::TMA::CacheHintSm100::EVICT_NORMAL),
+                                                      cache_hint,
                                                       smem_ptr + i * BLOCK_OUTER * BLOCK_INNER_ATOM,
                                                       inner_idx + i * BLOCK_INNER_ATOM, outer_idx);
                 }

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -227,6 +227,9 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t kSwizzleCDMode = 128;
     DG_STATIC_ASSERT(BLOCK_N % kSwizzleCDMode == 0, "Invalid block N");
 
+    constexpr uint64_t kActsCacheHint = static_cast<uint64_t>(BLOCK_M <= 128 ?
+        cute::TMA::CacheHintSm100::EVICT_LAST : cute::TMA::CacheHintSm100::EVICT_NORMAL);
+
     // Epilogue configs
     constexpr uint32_t kNumEpilogueStages = 2;
     constexpr uint32_t kNumTMAStoreStages = 2;
@@ -836,7 +839,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 // TMA copy tokens and SFA, then arrive at full barrier
                 if (cute::elect_one_sync()) {
                     tma::copy<BLOCK_K_BYTES, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(
-                        tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_a[stage_idx], k_idx, m_idx, 2);
+                        tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_a[stage_idx], k_idx, m_idx, 2, 0, kActsCacheHint);
                     tma::copy<SF_BLOCK_M, 1, 0>(
                         tensor_map_sfa_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
                     if (is_leader_cta) {

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -216,20 +216,14 @@ def fp8_fp4_mega_moe(y: torch.Tensor,
                      activation: str = 'swiglu',
                      activation_clamp: Optional[float] = None,
                      fast_math: bool = True,
-                     use_x_scales: Optional[bool] = None,
+                     use_x_scales: bool = False,
                      l1_alphas: Optional[torch.Tensor] = None,
                      l2_alphas: Optional[torch.Tensor] = None,
                      l2_act_scales: Optional[torch.Tensor] = None):
-    # NVFP4 activations always have a per-token FP32 outer scale.  Derive the
-    # only valid setting from the buffer type so a default call cannot silently
-    # discard that scale (or read an uninitialized scale buffer for other MMAs).
-    uses_nvfp4 = sym_buffer.mma_type == 'nvfp4xnvfp4'
-    if use_x_scales is None:
-        use_x_scales = uses_nvfp4
-    elif use_x_scales != uses_nvfp4:
+    if use_x_scales and sym_buffer.mma_type != 'nvfp4xnvfp4':
         raise ValueError(
-            '`use_x_scales` must be enabled exactly for `nvfp4xnvfp4`; '
-            f'got {use_x_scales=} with mma_type={sym_buffer.mma_type!r}'
+            '`use_x_scales` is only supported for `nvfp4xnvfp4`; '
+            f'got mma_type={sym_buffer.mma_type!r}'
         )
 
     (l1_weights_data, l1_weights_sf) = l1_weights
@@ -262,7 +256,7 @@ def nvfp4_mega_moe(y: torch.Tensor,
                    activation: str = 'swiglu',
                    activation_clamp: Optional[float] = None,
                    fast_math: bool = True,
-                   use_x_scales: Optional[bool] = None,
+                   use_x_scales: bool = False,
                    l1_alphas: Optional[torch.Tensor] = None,
                    l2_alphas: Optional[torch.Tensor] = None,
                    l2_act_scales: Optional[torch.Tensor] = None):

--- a/sgl_deep_gemm/tests/test_mega_moe_nvfp4_alphas.py
+++ b/sgl_deep_gemm/tests/test_mega_moe_nvfp4_alphas.py
@@ -145,8 +145,7 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         deep_gemm.fp8_fp4_mega_moe(
             y=y, l1_weights=weights[0], l2_weights=weights[1], sym_buffer=buffer,
             recipe=(1, 1, GRAN_K), activation='swiglu', fast_math=bool(args.fast_math),
-            # The NVFP4 wrapper must select per-token x scales by default.
-            l1_alphas=l1_alphas, l2_alphas=l2_alphas,
+            use_x_scales=True, l1_alphas=l1_alphas, l2_alphas=l2_alphas,
             l2_act_scales=l2_act_scales)
         dist.barrier()
         torch.cuda.synchronize()


### PR DESCRIPTION
Two independent changes to the SM100 mega-MoE path.

## 1. `use_x_scales` becomes opt-in

`fp8_fp4_mega_moe` previously asserted `use_x_scales == (mma_kind == NVFP4)`, i.e. every
NVFP4 call was *forced* to supply per-token FP32 outer scales, and the Python wrapper
derived the flag from the buffer type. That makes the common NVFP4 case impossible to
express — the one where the outer scale is already folded into the weight SFs — and it
forces every default NVFP4 call onto a path that reads the `x_scales` region whether or
not the caller ever wrote it.

Now the flag defaults to `False` and is only *permitted* for `nvfp4xnvfp4`:

- `csrc/apis/mega.hpp`: `DG_HOST_ASSERT(not use_x_scales or mma_kind == MmaKind::NVFP4)`
- `deep_gemm/mega/__init__.py`: `use_x_scales: bool = False`, raises only when the flag is
  set on a non-NVFP4 buffer
- `test_mega_moe_nvfp4_alphas.py` passes `use_x_scales=True` explicitly, so the
  per-token-scale path stays covered

That silent-uninitialized-read is not hypothetical. `moe_ep_benchmark`'s NVFP4 mega
backend fills `x`, `x_sf`, `topk_idx` and `topk_weights` and never touches `x_scales`, so
under the old default it multiplied every activation by a zero scale: the L1 intermediate
came out all-zero and fc2 ran on zero-valued FP4. That is measurably *faster* on a
power-limited part (~937 vs ~985 us at 4096 tok/rank), so the old default was quietly
inflating prefill numbers. Filling `x_scales` with 1.0 reproduces the ~985 us of the
`False` path, confirming the gap is the degenerate data and not this change.

## 2. L2 cache hint on the activation TMA loads

`tma::copy` grows an optional `cache_hint` argument (default `EVICT_NORMAL`, so every
other caller is byte-identical). The mainloop activation load passes:

```cpp
constexpr uint64_t kActsCacheHint = static_cast<uint64_t>(BLOCK_M <= 128 ?
    cute::TMA::CacheHintSm100::EVICT_LAST : cute::TMA::CacheHintSm100::EVICT_NORMAL);
```

Rationale: one activation tile is re-read by every N block of the same token block
(80 N blocks at the shape below), while the weight stream is read once per
(expert, N block). Marking the activations `EVICT_LAST` keeps the reused operand resident
against the weight stream. The `BLOCK_M <= 128` gate restricts this to decode block sizes
— see the rejected variants for why prefill is excluded.

### Benchmark

`bench_moe_ep_mega.py --mega-backend deep_gemm_nvfp4_mega`, `MEGA_TIMING=e2e_pipelined`
(GPU time, back-to-back enqueued — excludes host launch overhead), 8x B300, EP8,
h7168 / i5120 / 384 experts / top-4, 50 iters after 20 warmup, p50 in us.

A/B is interleaved off/on/off/on in a single session between two copies of this branch
that differ only in the hint, both with their own freshly built `_C.so`. Null A/B on two
identical trees measured 512.8 vs 512.8 us, i.e. a sub-1% noise floor.

| tok/rank | BLOCK_M | hint off | hint on | delta |
|---:|---:|---:|---:|---:|
| 1 | 16 | 107.6 / 107.6 | 107.6 / 107.7 | — |
| 8 | 16 | 310.4 / 310.4 | 310.2 / 310.3 | — |
| 32 | 16 | 476.2 / 476.2 | 476.1 / 476.2 | — |
| 128 | 32 | 492.3 / 492.3 | 491.5 / 491.8 | +0.13% |
| 512 | 96 | 510.9 / 510.9 | 508.8 / 508.1 | **+0.47%** |
| 1024 | 128 | 530.4 / 530.3 | 527.2 / 528.5 | **+0.47%** |
| 4096 | 192 | 985.8 | unchanged (hint gated off) | — |

The win is confined to the larger decode block sizes (BLOCK_M 96/128), where the
activation tile is big enough and re-read often enough for L2 residency to matter. At
BLOCK_M 16/32 it is flat: the working set is small and the fixed dispatch/combine/barrier
cost dominates. An earlier sweep over 1/2/4/8/16/32/64/128 tok/rank was flat at every
point, which is why only a subset is listed here.

### Variants measured and rejected

All at the same shape, same protocol.

| variant | 512 tok | 2048 tok | 4096 tok |
|---|---:|---:|---:|
| activations `EVICT_LAST` + weights `EVICT_FIRST` | -0.7% | — | **-13%** |
| activations `EVICT_LAST`, ungated | +0.5% | — | **-1.5%** |
| weights `EVICT_FIRST`, prefill only (`BLOCK_M > 128`) | — | **-2.2%** | **-11.2%** |
| final `y` TMA store `EVICT_FIRST` | -0.2% | — | 0% |
| activations `EVICT_LAST`, gated `BLOCK_M <= 128` (this PR) | +0.47% | unchanged | unchanged |

Demoting the weight stream is clearly wrong, and gating it to prefill does not rescue it:
at prefill many m-blocks of one expert are in flight across SMs at once and all re-fetch
the same `(n_block, k)` weight tiles, so `EVICT_FIRST` throws away exactly those hits.
The activation hint alone still costs 1.5% at prefill, hence the block-size gate.

Demoting the final `y` store — the write-once output, which is the object the analogous
GEMM-kernel optimization targets — does nothing here, because that store happens in the
post-NVLink-barrier combine phase after all GEMM work is done, so there is no live
operand left in L2 for it to protect.

### Correctness

`test_mega_moe_nvfp4_alphas.py --num-processes 2` passes, rel-L2 0.18253 — bit-for-bit
the same value as before the change, as expected for a pure cache-policy hint.
