### PR TITLE
fix: size MegaMoE full-pool MXFP8FP4 pull buffer

### DIFF
--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -219,6 +219,7 @@ static MegaMoEConfig get_mega_moe_config(
     const int& hidden, const int& intermediate_hidden,
     const int& num_ring_tokens,
     const int& num_sf_ring_tokens,
+    const int& num_shared_experts,
     const MmaKind& mma_kind) {
 
     // Block config
@@ -239,10 +240,21 @@ static MegaMoEConfig get_mega_moe_config(
     const int num_dispatch_threads = 128;
     const int num_non_epilogue_threads = 128;
 
-    // Pull: divide token bytes by 2 until <= kPullThreshold
+    // The MXFP8FP4 full-pool path issues one-shot TMA transfers for an entire
+    // token. Its per-warp scratch slice must therefore hold the complete token.
+    const int num_max_pool_tokens = layout::get_num_max_pool_tokens(
+        num_ranks, num_max_tokens_per_rank, num_topk, num_experts_per_rank);
+    const bool use_full_pool_fp8_fp4_path =
+        mma_kind == MmaKind::MXFP8FP4 and
+        num_ring_tokens >= num_max_pool_tokens and
+        num_shared_experts == 0 and
+        block_k == block_n and
+        intermediate_hidden / block_k <= 32;
+
+    // Reusable-ring paths can split a token into smaller pull chunks.
     constexpr int kPullThreshold = 4096;
     int num_bytes_per_pull = hidden * get_element_bits(mma_kind) / 8;
-    while (num_bytes_per_pull > kPullThreshold) {
+    while (not use_full_pool_fp8_fp4_path and num_bytes_per_pull > kPullThreshold) {
         DG_HOST_ASSERT(num_bytes_per_pull % 2 == 0);
         num_bytes_per_pull /= 2;
     }

--- a/csrc/jit_kernels/impls/sm100_bf16_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_bf16_mega_moe.hpp
@@ -133,7 +133,7 @@ static void sm100_bf16_mega_moe(
     const auto config = get_mega_moe_config(
         num_ranks, num_experts, num_experts_per_rank,
         num_max_tokens_per_rank, num_tokens, num_topk, hidden, intermediate_hidden,
-        num_ring_tokens, 0, MmaKind::BF16);
+        num_ring_tokens, 0, num_shared_experts, MmaKind::BF16);
 
     // Make tensormap
     const auto tensor_map_l1_acts = make_tma_2d_desc(l1_acts,

--- a/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
@@ -191,6 +191,7 @@ static void sm100_fp8_fp4_mega_moe(
         num_ranks, num_experts, num_experts_per_rank,
         num_max_tokens_per_rank, num_tokens, num_topk, hidden, intermediate_hidden,
         num_ring_tokens, num_sf_ring_tokens,
+        num_shared_experts,
         mma_kind);
 
     // Make tensormap

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -582,6 +582,9 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
             // Hidden bytes are divided into chunks
             constexpr uint32_t kNumHiddenTokenBytes = kHidden * kNumElemBits / 8;
+            DG_STATIC_ASSERT(
+                not kUseFullPoolFP8FP4Path or kNumBytesPerPull == kNumHiddenTokenBytes,
+                "The full-pool MXFP8FP4 path requires a complete-token pull buffer");
             constexpr uint32_t kNumChunks = kNumHiddenTokenBytes / kNumBytesPerPull;
             DG_STATIC_ASSERT(kNumChunks * kNumBytesPerPull == kNumHiddenTokenBytes, "kNumBytesPerPull must divide the token bytes");
             const uint32_t pool_token_idx = expert_pool_block_offset * BLOCK_M + token_idx_in_expert;


### PR DESCRIPTION
## Summary

- Keep a complete-token pull scratch slice when the SM100 MegaMoE MXFP8FP4
  kernel selects its one-shot full-pool path.
- Preserve the existing 4 KiB chunking heuristic for reusable-ring and other
  non-full-pool paths.
- Mirror the device full-pool predicate in the host configuration and add a
  compile-time assertion at the transfer site to prevent future host/device
  drift.

Related issue: https://github.com/sgl-project/sglang/issues/37559

## Root cause

The v0.1.7 host heuristic repeatedly halves `num_bytes_per_pull` until it is at
most 4 KiB. For DeepSeek-V4's 7,168-byte FP8 activation token, this produces a
3,584-byte per-warp scratch slice.

The retained MXFP8FP4 full-pool fast path does not consume that token in chunks:
it issues a one-shot TMA transfer for all 7,168 bytes. The transfer therefore
writes beyond the 3,584-byte slice and corrupts adjacent shared memory,
eventually surfacing as a CUDA illegal-memory-access failure under sustained
high-concurrency serving.

## Validation

All GPU testing used Blackwell B300/GB300 systems.

### Correctness and memory safety

- Reproduced the native v0.1.7 MXFP8FP4/W4A8 illegal memory access on eight
  B300 GPUs.
- The original W4A8 issue workload passed at concurrency 2,048, and an
  additional concurrency-4,096 stress run also passed.
- The applicable installed-wheel `sgl_deep_gemm/run_tests.sh` attention and
  MegaMoE tests passed; documented architecture/upstream exclusions remained
  skips.
- W4A8 full-pool and reusable-ring GSM8K-200 controls both scored 0.98 exact
  match.
- Native and fixed W4A4 GSM8K-200 controls both scored 0.98, with identical
  normalized per-sample results.

No functional or accuracy regression was detected in the validation above.
