### PR TITLE
Match the MegaMoE dispatch pull to the kernel's full-pool predicate

### DIFF
--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -239,10 +239,17 @@ static MegaMoEConfig get_mega_moe_config(
     const int num_dispatch_threads = 128;
     const int num_non_epilogue_threads = 128;
 
+    // A ring that already spans the whole pool pulls each MXFP8FP4 token whole;
+    // splitting it desynchronises the full-pool dispatch and yields NaN activations.
+    const int num_max_pool_tokens = layout::get_num_max_pool_tokens(
+        num_ranks, num_max_tokens_per_rank, num_topk, num_experts_per_rank);
+    const bool use_full_pool_fp8_fp4_path =
+        mma_kind == MmaKind::MXFP8FP4 and num_ring_tokens >= num_max_pool_tokens;
+
     // Pull: divide token bytes by 2 until <= kPullThreshold
     constexpr int kPullThreshold = 4096;
     int num_bytes_per_pull = hidden * get_element_bits(mma_kind) / 8;
-    while (num_bytes_per_pull > kPullThreshold) {
+    while (not use_full_pool_fp8_fp4_path and num_bytes_per_pull > kPullThreshold) {
         DG_HOST_ASSERT(num_bytes_per_pull % 2 == 0);
         num_bytes_per_pull /= 2;
     }

--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -104,6 +104,21 @@ static bool is_nvfp4_mma_kind(const MmaKind& mma_kind) {
     return mma_kind == MmaKind::NVFP4;
 }
 
+// Mirror of `kUseFullPoolFP8FP4Path` in `sm100_fp8_fp4_mega_moe.cuh`. On that
+// branch the kernel pulls a whole token with a single TMA, so the pull buffer
+// has to be sized for the whole token; every other case keeps chunked pulls,
+// which also keeps the dispatch buffers small enough to hold the pipeline
+// depth. BF16 runs `sm100_bf16_mega_moe.cuh`, which always chunks.
+// Keep this predicate in step with the kernel's.
+static bool uses_full_pool_fp8_fp4_path(
+    const MmaKind& mma_kind, const int& num_shared_experts,
+    const int& num_ring_tokens, const int& num_max_pool_tokens,
+    const int& block_n, const int& block_k, const int& intermediate_hidden) {
+    return mma_kind != MmaKind::BF16 and num_shared_experts == 0 and
+           num_ring_tokens >= num_max_pool_tokens and block_k == block_n and
+           intermediate_hidden / block_k <= 32;
+}
+
 static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
     const int& num_ranks, const int& num_experts,
     const int& num_max_tokens_per_rank, const int& num_topk,
@@ -215,6 +230,7 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
 
 static MegaMoEConfig get_mega_moe_config(
     const int& num_ranks, const int& num_experts, const int& num_experts_per_rank,
+    const int& num_shared_experts,
     const int& num_max_tokens_per_rank, const int& num_tokens, const int& num_topk,
     const int& hidden, const int& intermediate_hidden,
     const int& num_ring_tokens,
@@ -239,12 +255,14 @@ static MegaMoEConfig get_mega_moe_config(
     const int num_dispatch_threads = 128;
     const int num_non_epilogue_threads = 128;
 
-    // A ring that already spans the whole pool pulls each MXFP8FP4 token whole;
-    // splitting it desynchronises the full-pool dispatch and yields NaN activations.
+    // The kernel's full-pool branch pulls a whole token in one TMA into a buffer
+    // this size, so it must cover the token; splitting it overruns that buffer
+    // and leaves NaN activations behind.
     const int num_max_pool_tokens = layout::get_num_max_pool_tokens(
         num_ranks, num_max_tokens_per_rank, num_topk, num_experts_per_rank);
-    const bool use_full_pool_fp8_fp4_path =
-        mma_kind == MmaKind::MXFP8FP4 and num_ring_tokens >= num_max_pool_tokens;
+    const bool use_full_pool_fp8_fp4_path = uses_full_pool_fp8_fp4_path(
+        mma_kind, num_shared_experts, num_ring_tokens, num_max_pool_tokens,
+        block_n, block_k, intermediate_hidden);
 
     // Pull: divide token bytes by 2 until <= kPullThreshold
     constexpr int kPullThreshold = 4096;

--- a/csrc/jit_kernels/impls/sm100_bf16_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_bf16_mega_moe.hpp
@@ -131,7 +131,7 @@ static void sm100_bf16_mega_moe(
 
     // Heuristics
     const auto config = get_mega_moe_config(
-        num_ranks, num_experts, num_experts_per_rank,
+        num_ranks, num_experts, num_experts_per_rank, num_shared_experts,
         num_max_tokens_per_rank, num_tokens, num_topk, hidden, intermediate_hidden,
         num_ring_tokens, 0, MmaKind::BF16);
 

--- a/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
@@ -188,7 +188,7 @@ static void sm100_fp8_fp4_mega_moe(
 
     // Heuristics
     const auto config = get_mega_moe_config(
-        num_ranks, num_experts, num_experts_per_rank,
+        num_ranks, num_experts, num_experts_per_rank, num_shared_experts,
         num_max_tokens_per_rank, num_tokens, num_topk, hidden, intermediate_hidden,
         num_ring_tokens, num_sf_ring_tokens,
         mma_kind);


### PR DESCRIPTION
## Summary

Fixes a regression from #80, shipped in v0.1.7.

`num_bytes_per_pull` sizes the dispatch pull buffer on the host, and the kernel either TMAs a whole token into that buffer or walks it in chunks. The two have to agree. v0.1.6 kept them in sync with a host-side escape that skipped chunking whenever the kernel took its full-pool path; #80 deleted the escape and left the halving loop unconditional.

What follows is an overrun. DeepSeek-V4-Pro FP4 (`hidden=7168`, EP4) takes the fast path, the host hands it a 3584-byte buffer, the kernel writes 7168 bytes into it, and the activations come back NaN. That is what killed sglang's GB300 nightly. Moving only the wheel pins it down:

| sglang commit | sgl-deep-gemm | result |
|---|---|---|
| `20a491d1d3` | 0.1.5.post3 / 0.1.6 | pass |
| `20a491d1d3` | **0.1.7** | **NaN** |
| `dc2843801d` | 0.1.6 | pass |
| `dc2843801d` | **0.1.7** | **NaN** |

Restoring v0.1.6's escape verbatim would not be enough, because it keyed on the ring alone while the kernel also demands no shared experts, `BLOCK_K == BLOCK_N`, and `L2_SHAPE_K / BLOCK_K <= 32`. Exempt more than the kernel does and the dispatch buffers grow, the pipeline drops a stage, and a shared-expert shape stops compiling outright with `"Hidden is too large"`. So this mirrors the kernel's predicate term for term and threads `num_shared_experts` into `get_mega_moe_config()`.

BF16 stays chunked — different kernel, no unchunked branch. MXFP4 and NVFP4 are covered, since #80 routes them through this same kernel and its predicate ignores the MMA kind.

Verified on 4x GB300: gsm8k **0.96499** against a 0.935 floor, zero NaN, ~1012 tok/s against 1013 on v0.1.6. Pull size now tracks the kernel per config — `block_k=128` gets the whole 7168-byte token, `block_k=256` stays chunked at 3584. The MegaMoE test family passes, including #80's own `test_mega_moe_nvfp4_alphas`.